### PR TITLE
libobs: Allow exporting a json file with default values

### DIFF
--- a/libobs/obs-data.h
+++ b/libobs/obs-data.h
@@ -70,6 +70,7 @@ EXPORT void obs_data_addref(obs_data_t *data);
 EXPORT void obs_data_release(obs_data_t *data);
 
 EXPORT const char *obs_data_get_json(obs_data_t *data);
+EXPORT const char *obs_data_get_full_json(obs_data_t *data);
 EXPORT bool obs_data_save_json(obs_data_t *data, const char *file);
 EXPORT bool obs_data_save_json_safe(obs_data_t *data, const char *file,
 		const char *temp_ext, const char *backup_ext);


### PR DESCRIPTION
This version of obs_data_to_json allows exporting default values in addition to user values.