### PR TITLE
obs-transitions: Fix potential stinger divide by 0

### DIFF
--- a/plugins/obs-transitions/transition-stinger.c
+++ b/plugins/obs-transitions/transition-stinger.c
@@ -237,8 +237,8 @@ static void stinger_transition_start(void *data)
 				(long double)s->transition_point_ns /
 				(long double)s->duration_ns);
 
-		if (s->transition_point > 1.0f)
-			s->transition_point = 1.0f;
+		if (s->transition_point > 0.999f)
+			s->transition_point = 0.999f;
 		else if (s->transition_point < 0.001f)
 			s->transition_point = 0.001f;
 


### PR DESCRIPTION
If the transition point was above or equal to 1.0, it would cause a
divide by 0 error a few lines down.  This could cause audio data to
become corrupted with NAN audio data when mixing, which can cause
certain audio encoders (namely the FFmpeg AAC encoder) to fail.

It was possible for the transition point to be above or equal to 1.0 if
the stinger media file was no longer loadable for whatever reason.