### PR TITLE
Move to individual appveyor script

### DIFF
--- a/CI/win-build.cmd
+++ b/CI/win-build.cmd
@@ -1,0 +1,44 @@
+if not exist "dependencies2017.zip" appveyor DownloadFile "%DependenciesUrl%"
+if not exist "%CefZip%" appveyor DownloadFile "%CefUrl%" -FileName "%CefZip%"
+7z x "%CefZip%"
+7z x dependencies2017.zip -odependencies2017
+
+cmake ^
+	-G"%CMakeGenerator%" ^
+	-A x64 ^
+	-H"%CefPath%" ^
+	-B"%CefBuildPath%" ^
+	-DCEF_RUNTIME_LIBRARY_FLAG="/MD"
+
+cmake ^
+	--build "%CefBuildPath%" ^
+	--config Release ^
+	--target libcef_dll_wrapper ^
+	-- /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
+cmake ^
+	-H. ^
+	-B"%BuildPath64%" ^
+	-G"%CmakeGenerator%" ^
+	-A x64 ^
+	-DCMAKE_INSTALL_PREFIX="%InstallPath%" ^
+	-DDepsPath="%DepsPath64%" ^
+	-DCEF_ROOT_DIR="%CefPath%" ^
+	-DCEF_WRAPPER_DIR="%CefBuildPath%\libcef_dll_wrapper\Release" ^
+	-DENABLE_UI=false ^
+	-DCOPIED_DEPENDENCIES=false ^
+	-DCOPY_DEPENDDENCIES=true ^
+	-DENABLE_SCRIPTING=false ^
+	-DBUILD_CAPTIONS=false ^
+	-DCOMPILE_D3D12_HOOK=true ^
+	-DBUILD_BROWSER=true ^
+	-DBROWSER_FRONTEND_API_SUPPORT=false ^
+	-DBROWSER_PANEL_SUPPORT=false ^
+	-DBROWSER_USE_STATIC_CRT=false ^
+	-DEXPERIMENTAL_SHARED_TEXTURE_SUPPORT=false
+
+cmake ^
+	--build "%BuildPath64%" ^
+	--target install ^
+	--config %BuildConfig% ^
+	-- /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"

--- a/slobs-appveyor.yml
+++ b/slobs-appveyor.yml
@@ -1,0 +1,48 @@
+version: 22.0.3-sl.{build}
+
+image:
+- Visual Studio 2017
+
+clone_depth: 1
+
+environment:
+  matrix:
+    - BuildConfig: RelWithDebInfo
+
+  CURL_VERSION: 7.56.1
+  CmakeGenerator: Visual Studio 15 2017
+  DepsPath32: $(APPVEYOR_BUILD_FOLDER)\dependencies2017\win32
+  DepsPath64: $(APPVEYOR_BUILD_FOLDER)\dependencies2017\win64
+  BuildPath32: $(APPVEYOR_BUILD_FOLDER)\build32
+  BuildPath64: $(APPVEYOR_BUILD_FOLDER)\build64
+  InstallPath: $(APPVEYOR_BUILD_FOLDER)\packed_build
+  CefVersion: 3.3396.1779.g36f9eab
+  CefDirName: cef_binary_$(CefVersion)_windows64
+  CefPath: $(APPVEYOR_BUILD_FOLDER)\$(CefDirName)
+  CefBuildPath: $(CefPath)\build
+  CefZip: $(CefDirName).zip
+  CefUrl: https://s3-us-west-2.amazonaws.com/streamlabs-cef-dist/$(CefZip)
+  ReleaseArtifact: windows-x86_64-$(BuildConfig)-$(APPVEYOR_BUILD_VERSION).7z
+  DependenciesUrl: https://obsproject.com/downloads/dependencies2017.zip
+
+install:
+  - git submodule update --init --recursive --jobs 2
+
+  - mkdir "%BuildPath32%"
+  - mkdir "%BuildPath64%"
+
+build_script:
+  - cmd: CI\win-build.cmd
+
+after_build:
+  - 7z a "%ReleaseArtifact%" "%InstallPath%\*"
+
+artifacts:
+  - path: $(ReleaseArtifact)
+    name: Release Artifact
+
+test: off
+
+cache:
+  - $(AMFZip)
+  - $(CefZip)


### PR DESCRIPTION
Using an appveyor script gives easier to manage files and let's us change the appveyor script per branch. This changes our versioning system a bit to use the version specified in the appveyor script + the build number. Trying to manage tags here hasn't worked out too well and has been a bit of a management nightmare. 