### PR TITLE
Fix D3D11 Cubemap texture creation and mipmaps levels

### DIFF
--- a/libobs-d3d11/d3d11-texture2d.cpp
+++ b/libobs-d3d11/d3d11-texture2d.cpp
@@ -127,10 +127,10 @@ void gs_texture_2d::InitResourceView()
 
 	if (type == GS_TEXTURE_CUBE) {
 		resourceDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURECUBE;
-		resourceDesc.TextureCube.MipLevels = genMipmaps ? -1 : levels;
+		resourceDesc.TextureCube.MipLevels = (genMipmaps || !levels) ? -1 : levels;
 	} else {
 		resourceDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
-		resourceDesc.Texture2D.MipLevels = genMipmaps ? -1 : levels;
+		resourceDesc.Texture2D.MipLevels = (genMipmaps || !levels) ? -1 : levels;
 	}
 
 	hr = device->device->CreateShaderResourceView(texture, &resourceDesc,

--- a/libobs-d3d11/d3d11-texture2d.cpp
+++ b/libobs-d3d11/d3d11-texture2d.cpp
@@ -50,24 +50,28 @@ void gs_texture_2d::InitSRD(vector<D3D11_SUBRESOURCE_DATA> &srd)
 
 void gs_texture_2d::BackupTexture(const uint8_t **data)
 {
-	this->data.resize(levels);
+	size_t textures = (type == GS_TEXTURE_2D ? 1 : 6);
+	this->data.resize(levels * textures);
 
-	uint32_t w = width;
-	uint32_t h = height;
 	uint32_t bbp = gs_get_format_bpp(format);
 
-	for (uint32_t i = 0; i < levels; i++) {
-		if (!data[i])
-			break;
+	for (size_t i = 0; i < textures; i++) {
+		uint32_t w = width;
+		uint32_t h = height;
 
-		uint32_t texSize = bbp * w * h / 8;
-		this->data[i].resize(texSize);
+		for (uint32_t j = 0; j < levels; j++) {
+			if (!data[i * levels + j])
+				break;
 
-		vector<uint8_t> &subData = this->data[i];
-		memcpy(&subData[0], data[i], texSize);
+			uint32_t texSize = bbp * w * h / 8;
+			this->data[i * levels + j].resize(texSize);
 
-		w /= 2;
-		h /= 2;
+			vector<uint8_t> &subData = this->data[i * levels + j];
+			memcpy(&subData[0], data[i * levels + j], texSize);
+
+			w /= 2;
+			h /= 2;
+		}
 	}
 }
 

--- a/libobs-d3d11/d3d11-texture2d.cpp
+++ b/libobs-d3d11/d3d11-texture2d.cpp
@@ -127,10 +127,10 @@ void gs_texture_2d::InitResourceView()
 
 	if (type == GS_TEXTURE_CUBE) {
 		resourceDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURECUBE;
-		resourceDesc.TextureCube.MipLevels = genMipmaps ? -1 : 1;
+		resourceDesc.TextureCube.MipLevels = genMipmaps ? -1 : levels;
 	} else {
 		resourceDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
-		resourceDesc.Texture2D.MipLevels = genMipmaps ? -1 : 1;
+		resourceDesc.Texture2D.MipLevels = genMipmaps ? -1 : levels;
 	}
 
 	hr = device->device->CreateShaderResourceView(texture, &resourceDesc,


### PR DESCRIPTION
## Overview
This PR will fix memory allocation for texture cubes. Before, the memory was allocated for only one 2D texture with its mipmaps (downsized versions). With this fix, if the texture is cube, it will allocate and upload all the 6 sides of the texture as well. This PR will also fix a problem that even though mipmaps were uploaded to GPU, the shader resource view was set to only see one level of mipmaps, for both texture cubes and 2D textures.

## Results
After the fix, using Nsight, I confirmed the texture cubes are uploaded correctly, and also all mipmap levels are available for use.

Here is the screenshot for a texture cube resource in Nsight:
![full-texture-cube](https://user-images.githubusercontent.com/3115894/51765680-4ca6fb00-208d-11e9-9347-f6c23d0d2a1b.png)

This is for a regular 2D texture:
![full-texture-2d](https://user-images.githubusercontent.com/3115894/51765715-65afac00-208d-11e9-8e96-aedb15d97229.png)

