### PR TITLE
Validate the filter parent and target before using them

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -3069,6 +3069,10 @@ void obs_source_process_filter_end(obs_source_t *filter, gs_effect_t *effect,
 
 	target       = obs_filter_get_target(filter);
 	parent       = obs_filter_get_parent(filter);
+
+	if (target == NULL || parent == NULL)
+		return;
+
 	parent_flags = parent->info.output_flags;
 
 	if (can_bypass(target, parent, parent_flags, filter->allow_direct)) {


### PR DESCRIPTION
Fix this issue https://app.asana.com/0/734357654754972/1113363015553646/f

Crash reason: Invalid access of `parent_flags = parent->info.output_flags;` if the filter was being deleted and the parent was set to NULL.

The correct way to fix this would be using a mutex but I think it's best to rely on verifying the pointers directly (even with race access) because of these conditions:

1 - Would be really hard to insert a new mutex into the source structure, it would require more work then simple adding a new variable, the source struct by itself is a really complex object.
2 - Locking an existing mutex could cause a dead-lock, it's complicated to make sure 100% no deadlock would appear by doing this.
3 - About the concurrent access, there is no problem if we get valid or non-valid values for the `parent` and `target`, if both are valid we can proceed with the rendering method for the last time, if at least one of them is invalid we will just not render the current frame and when it finish the filter will be deleted.