### PR TITLE
Remove the breakpoint call and let bcrash be called directly

### DIFF
--- a/libobs/util/bmem.c
+++ b/libobs/util/bmem.c
@@ -101,7 +101,6 @@ void *bmalloc(size_t size)
 	if (!ptr && !size)
 		ptr = alloc.malloc(1);
 	if (!ptr) {
-		os_breakpoint();
 		bcrash("Out of memory while trying to allocate %lu bytes",
 				(unsigned long)size);
 	}
@@ -119,7 +118,6 @@ void *brealloc(void *ptr, size_t size)
 	if (!ptr && !size)
 		ptr = alloc.realloc(ptr, 1);
 	if (!ptr) {
-		os_breakpoint();
 		bcrash("Out of memory while trying to allocate %lu bytes",
 				(unsigned long)size);
 	}


### PR DESCRIPTION
This will make `bcrash` be called instead stopping the application by a breakpoint. This won't solve directly any problems but will let us know the allocation size requested, helping identifying invalid allocations.

We handle `bcrash` on our crashmanager, its error message will be attached to the report.