### PR TITLE
Check if the replay buffer was saved sucessfully

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -720,11 +720,17 @@ static void *replay_buffer_mux_thread(void *data)
 
 	for (size_t i = 0; i < stream->mux_packets.num; i++) {
 		struct encoder_packet *pkt = &stream->mux_packets.array[i];
-		write_packet(stream, pkt);
+
+		if (!hasFailed) {
+			hasFailed = !write_packet(stream, pkt);
+		}
+
 		obs_encoder_packet_release(pkt);
 	}
 
-	info("Wrote replay buffer to '%s'", stream->path.array);
+	if (!hasFailed) {
+		info("Wrote replay buffer to '%s'", stream->path.array);
+	}
 	
 error:
 	os_process_pipe_destroy(stream->pipe);


### PR DESCRIPTION
Fix the issue where if the save path is invalid the user was prompted with 90+ warning messages, now it will stop sending error codes after the first write attempt has failed.