### PR TITLE
Fix vst asynchronous delete

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 2.8.12)
 
-
 if (UNIX AND POLICY CMP0072)
 	# In case of both legacy and glvnd OpenGL libraries found. Prefer GLVND
 	cmake_policy(SET CMP0072 NEW)


### PR DESCRIPTION
This PR fixes 2 crashes:

- Does not crashes if the user opens an invalid plugin from an older version (still crashes if the plugin is for version 3.x, nothing we can do).
- Does not crashes if the user switch plugins with its config window open, there was a race condition and the component destruction order was wrong.

The changes are on our `vst` fork