### PR TITLE
check obs pointer before accessing it

### DIFF
--- a/libobs/obs-module.c
+++ b/libobs/obs-module.c
@@ -211,6 +211,9 @@ char *obs_find_module_file(obs_module_t *module, const char *file)
 char *obs_module_get_config_path(obs_module_t *module, const char *file)
 {
 	struct dstr output = {0};
+	
+	if(!obs)
+		return NULL;
 
 	dstr_copy(&output, obs->module_config_path);
 	if (!dstr_is_empty(&output) && dstr_end(&output) != '/')

--- a/plugins/rtmp-services/twitch.c
+++ b/plugins/rtmp-services/twitch.c
@@ -93,8 +93,13 @@ static bool load_ingests(const char *json, bool write_file)
 	cache_old = obs_module_config_path("twitch_ingests.json");
 	cache_new = obs_module_config_path("twitch_ingests.new.json");
 
-	os_quick_write_utf8_file(cache_new, json, strlen(json), false);
-	os_safe_replace(cache_old, cache_new, NULL);
+	if(cache_old && cache_new)
+	{
+		os_quick_write_utf8_file(cache_new, json, strlen(json), false);
+		os_safe_replace(cache_old, cache_new, NULL);
+	} else {
+		success = false;
+	}
 
 	bfree(cache_old);
 	bfree(cache_new);


### PR DESCRIPTION
If some other thread already in _obs_shutdown_ then call to obs_module_get_config_path can crash as it tried to access obs object. 

We have number of crashes here when autoconfig thread access config when shutdown is in progress. 