### PR TITLE
Log if out of memory

### DIFF
--- a/libobs/util/bmem.c
+++ b/libobs/util/bmem.c
@@ -101,6 +101,7 @@ void *bmalloc(size_t size)
 	if (!ptr && !size)
 		ptr = alloc.malloc(1);
 	if (!ptr) {
+		blog(LOG_ERROR, "Out of memory while trying to allocate %lu bytes", (unsigned long)size);
 		os_breakpoint();
 		bcrash("Out of memory while trying to allocate %lu bytes",
 				(unsigned long)size);
@@ -119,6 +120,7 @@ void *brealloc(void *ptr, size_t size)
 	if (!ptr && !size)
 		ptr = alloc.realloc(ptr, 1);
 	if (!ptr) {
+		blog(LOG_ERROR, "Out of memory while trying to allocate %lu bytes", (unsigned long)size);
 		os_breakpoint();
 		bcrash("Out of memory while trying to allocate %lu bytes",
 				(unsigned long)size);


### PR DESCRIPTION
Log out of memory allocation attempts, this would help determine when invalid allocations are being made (like this https://sentry.io/organizations/streamlabs-obs/issues/1045356068/?project=1406061&query=is%3Aunresolved) while the user still have enough memory available.