### PR TITLE
fix: double audio init on reconnect/capture race condition

### DIFF
--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -451,7 +451,7 @@ bool WASAPISource::ProcessCaptureData()
 	UINT64  pos, ts;
 	UINT    captureSize = 0;
 
-	while (true) {
+	while (active) {
 		res = capture->GetNextPacketSize(&captureSize);
 
 		if (FAILED(res)) {
@@ -523,6 +523,7 @@ DWORD WINAPI WASAPISource::CaptureThread(LPVOID param)
 
 	while (WaitForCaptureSignal(2, sigs, dur)) {
 		if (source->hadDefaultChangeEvent || !source->ProcessCaptureData()) {
+			ResetEvent(source->receiveSignal);
 			source->hadDefaultChangeEvent = false;
 			reconnect = true;
 			break;


### PR DESCRIPTION
CaptureThread should not fail if device not activated yet. So I add check into while loop in WASAPISource::ProcessCaptureData()
