### PR TITLE
fix crash on using an empty qsv context

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -232,11 +232,14 @@ static bool nvenc_reconfigure(void *data, obs_data_t *settings)
 {
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(58, 19, 101)
 	struct nvenc_encoder *enc = data;
+	if (!enc->context) 
+		return false;
 
 	int bitrate = (int)obs_data_get_int(settings, "bitrate");
 	const char *rc = obs_data_get_string(settings, "rate_control");
 	bool cbr = astrcmpi(rc, "CBR") == 0;
 	bool vbr = astrcmpi(rc, "VBR") == 0;
+
 	if (cbr || vbr) {
 		enc->context->bit_rate = bitrate * 1000;
 		enc->context->rc_max_rate = bitrate * 1000;

--- a/plugins/obs-qsv11/obs-qsv11.c
+++ b/plugins/obs-qsv11/obs-qsv11.c
@@ -475,15 +475,21 @@ static bool obs_qsv_update(void *data, obs_data_t *settings)
 {
 	struct obs_qsv *obsqsv = data;
 	bool success = update_settings(obsqsv, settings);
-	int ret;
+	int ret = 0;
 
 	if (success) {
 		EnterCriticalSection(&g_QsvCs);
 
-		ret = qsv_encoder_reconfig(obsqsv->context, &obsqsv->params);
-		if (ret != 0)
-			warn("Failed to reconfigure: %d", ret);
+		if (obsqsv->context) {
 
+			ret = qsv_encoder_reconfig(obsqsv->context,
+						   &obsqsv->params);
+
+			if (ret != 0)
+				warn("Failed to reconfigure: %d", ret);
+		} else {
+			warn("Cannot update encoder. QSV ecoder context is epmpty.");
+		}
 		LeaveCriticalSection(&g_QsvCs);
 
 		return ret == 0;

--- a/plugins/obs-x264/obs-x264.c
+++ b/plugins/obs-x264/obs-x264.c
@@ -589,12 +589,16 @@ static bool obs_x264_update(void *data, obs_data_t *settings)
 {
 	struct obs_x264 *obsx264 = data;
 	bool success = update_settings(obsx264, settings, true);
-	int ret;
+	int ret = 0;
 
 	if (success) {
-		ret = x264_encoder_reconfig(obsx264->context, &obsx264->params);
-		if (ret != 0)
-			warn("Failed to reconfigure: %d", ret);
+		if (obsx264->context) {
+			ret = x264_encoder_reconfig(obsx264->context, &obsx264->params);
+			if (ret != 0)
+				warn("Failed to reconfigure: %d", ret);
+		} else {
+			warn("Cannot update encoder. x264 ecoder context is epmpty.");
+		}
 		return ret == 0;
 	}
 


### PR DESCRIPTION
In some situation there can be a request to update encoder params while encoder context is empty(while stream reconnecting for example). So call for qsv_encoder_reconfig should be skipped. 