### PR TITLE
check encoder status in gpu thread

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -289,7 +289,7 @@ void obs_encoder_destroy(obs_encoder_t *encoder)
 {
 	if (encoder) {
 		bool destroy;
-
+		set_encoder_active(encoder , false);
 		obs_context_data_remove(&encoder->context);
 
 		pthread_mutex_lock(&encoder->init_mutex);

--- a/libobs/obs-video-gpu-encode.c
+++ b/libobs/obs-video-gpu-encode.c
@@ -61,8 +61,13 @@ static void *gpu_encode_thread(void *unused)
 
 		for (size_t i = 0; i < video->gpu_encoders.num; i++) {
 			obs_encoder_t *encoder = video->gpu_encoders.array[i];
-			da_push_back(encoders, &encoder);
-			obs_encoder_addref(encoder);
+			if (obs_encoder_active(encoder)) {
+				obs_weak_encoder_t *control = encoder->control;
+				if (control->ref.refs != -1) {
+					da_push_back(encoders, &encoder);
+					obs_encoder_addref(encoder);
+				}
+			}
 		}
 
 		pthread_mutex_unlock(&video->gpu_encoder_mutex);


### PR DESCRIPTION
Two changes:
Deactivate encoder when destroying it. 
Do not use encoder in gpu thread if this encoder not active and has no references(in process of being destroyed). 
