### PR TITLE
Fix data race when stop stream during connection

### DIFF
--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -207,6 +207,13 @@ void obs_output_destroy(obs_output_t *output)
 		if (output->context.data) {
 			output->info.destroy(output->context.data);
 			output->context.data = NULL;
+
+			// In case when output has started connecting, but haven't started capturing data (i.e. not active),
+			// the info `destroy` call can switch output to active state - in this case it is needed to wait till
+			// the `end_data_capture_thread` will finish. Otherwise we might run into a data race
+			if (data_capture_ending(output))
+				pthread_join(output->end_data_capture_thread,
+					     NULL);
 		}
 
 		free_packets(output);


### PR DESCRIPTION
Fix a data race when the user manually stopped stream during connecting to an RTMP server. 

This is caused by a data race in the `obs_output_destroy` method, which calls the `rtmp_stream_destroy` method before output became active. In such case, the `rtmp_stream_destroy` method will detach `end_data_capture` thread, thus it will result in a potential crash. 

In order to avoid this, the thread which destroys output should wait till `end_data_capture` will be finished.