### PR TITLE
Fix crash when rebuilding device

### DIFF
--- a/libobs-d3d11/d3d11-rebuild.cpp
+++ b/libobs-d3d11/d3d11-rebuild.cpp
@@ -178,10 +178,14 @@ void gs_vertex_shader::Rebuild(ID3D11Device *dev)
 	if (FAILED(hr))
 		throw HRError("Failed to create vertex shader", hr);
 
-	hr = dev->CreateInputLayout(layoutData.data(), (UINT)layoutData.size(),
-				    data.data(), data.size(), &layout);
-	if (FAILED(hr))
-		throw HRError("Failed to create input layout", hr);
+	if (!layoutData.empty()) {
+		hr = dev->CreateInputLayout(layoutData.data(),
+					    (UINT)layoutData.size(),
+					    data.data(), data.size(), &layout);
+
+		if (FAILED(hr))
+			throw HRError("Failed to create input layout", hr);
+	}
 
 	if (constantSize) {
 		hr = dev->CreateBuffer(&bd, NULL, &constants);

--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -2240,6 +2240,10 @@ void gs_vertexbuffer_destroy(gs_vertbuffer_t *vertbuffer)
 {
 	if (vertbuffer && vertbuffer->device->lastVertexBuffer == vertbuffer)
 		vertbuffer->device->lastVertexBuffer = nullptr;
+
+	if (vertbuffer && vertbuffer->device->curVertexBuffer == vertbuffer)
+		vertbuffer->device->curVertexBuffer = nullptr;
+
 	delete vertbuffer;
 }
 


### PR DESCRIPTION
- fix crash when rebuilding device;
- alternative way to fix the vertex buffer corruption error (see PR in osn - https://github.com/stream-labs/obs-studio-node/pull/500 );