### PR TITLE
Add device rebuild callback to graphics.h

### DIFF
--- a/libobs-d3d11/d3d11-rebuild.cpp
+++ b/libobs-d3d11/d3d11-rebuild.cpp
@@ -437,6 +437,9 @@ try {
 	for (auto &state : blendStates)
 		state.Rebuild(dev);
 
+	if (rebuildCallback)
+		rebuildCallback();
+
 } catch (const char *error) {
 	bcrash("Failed to recreate D3D11: %s", error);
 

--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -2651,3 +2651,10 @@ device_stagesurface_create_nv12(gs_device_t *device, uint32_t width,
 
 	return surf;
 }
+
+extern "C" EXPORT void
+device_set_rebuild_callback(gs_device_t *device,
+			    gs_rebuild_device_callback_t callback)
+{
+	device->rebuildCallback = std::move(callback);
+}

--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -902,6 +902,8 @@ struct gs_device {
 
 	gs_obj *first_obj = nullptr;
 
+	gs_rebuild_device_callback_t rebuildCallback = nullptr;
+
 	void InitCompiler();
 	void InitFactory(uint32_t adapterIdx);
 	void InitDevice(uint32_t adapterIdx);

--- a/libobs-opengl/gl-vertexbuffer.c
+++ b/libobs-opengl/gl-vertexbuffer.c
@@ -275,3 +275,11 @@ void device_load_vertexbuffer(gs_device_t *device, gs_vertbuffer_t *vb)
 {
 	device->cur_vertex_buffer = vb;
 }
+
+void device_set_rebuild_callback(gs_device_t *device,
+				 gs_rebuild_device_callback_t callback)
+{
+	/* Do nothing - OpenGL */
+	UNUSED_PARAMETER(device);
+	UNUSED_PARAMETER(callback);
+}

--- a/libobs/graphics/graphics-imports.c
+++ b/libobs/graphics/graphics-imports.c
@@ -215,5 +215,8 @@ bool load_graphics_imports(struct gs_exports *exports, void *module,
 	GRAPHICS_IMPORT_OPTIONAL(device_stagesurface_create_nv12);
 #endif
 
+	/* SLOBS custom functions */
+	GRAPHICS_IMPORT_OPTIONAL(device_set_rebuild_callback);
+
 	return success;
 }

--- a/libobs/graphics/graphics-internal.h
+++ b/libobs/graphics/graphics-internal.h
@@ -311,6 +311,10 @@ struct gs_exports {
 							   uint32_t width,
 							   uint32_t height);
 #endif
+
+	/* SLOBS custom functions */
+	void (*device_set_rebuild_callback)(
+		gs_device_t *device, gs_rebuild_device_callback_t callback);
 };
 
 struct blend_state {

--- a/libobs/graphics/graphics.c
+++ b/libobs/graphics/graphics.c
@@ -2953,3 +2953,14 @@ gs_stagesurf_t *gs_stagesurface_create_nv12(uint32_t width, uint32_t height)
 }
 
 #endif
+
+void gs_set_rebuild_device_callback(gs_rebuild_device_callback_t callback)
+{
+	graphics_t *graphics = thread_graphics;
+
+	if (!gs_valid("gs_set_rebuild_device_callback"))
+		return;
+
+	graphics->exports.device_set_rebuild_callback(graphics->device,
+						      callback);
+}

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -884,6 +884,12 @@ EXPORT gs_stagesurf_t *gs_stagesurface_create_nv12(uint32_t width,
 
 #endif
 
+/* SLOBS custom functions */
+typedef void (*gs_rebuild_device_callback_t)();
+
+EXPORT void
+gs_set_rebuild_device_callback(gs_rebuild_device_callback_t callback);
+
 /* inline functions used by modules */
 
 static inline uint32_t gs_get_format_bpp(enum gs_color_format format)


### PR DESCRIPTION
Add a callback to graphics.h that notifies about device rebuilt events. Basically, it is required to fix a problem with OBS display being incorrectly resized in obs-studio-node after switch devices.