### PR TITLE
Add more thresholds and timeouts to lower bitrate

### DIFF
--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -31,9 +31,15 @@
 
 /* dynamic bitrate coefficients */
 #define DBR_INC_TIMER (30ULL * SEC_TO_NSEC)
-#define DBR_TRIGGER_USEC (200ULL * MSEC_TO_USEC)
+//#define DBR_TRIGGER_USEC (200ULL * MSEC_TO_USEC)
 #define MIN_ESTIMATE_DURATION_MS 1000
 #define MAX_ESTIMATE_DURATION_MS 2000
+
+typedef enum {
+	LOW,
+	NORMAL,
+	HIGH
+} Severity;
 
 static const char *rtmp_stream_getname(void *unused)
 {
@@ -1023,6 +1029,13 @@ static bool init_connect(struct rtmp_stream *stream)
 	int64_t drop_p;
 	int64_t drop_b;
 	uint32_t caps;
+	uint8_t rates[3][2] = {{LOW, 50}, {NORMAL, 20}, {HIGH, 10}};
+	uint64_t timers[3][2] = {{LOW, 400ULL * MSEC_TO_NSEC},
+				 {NORMAL, 600ULL * MSEC_TO_NSEC},
+				 {HIGH, 1000ULL * MSEC_TO_NSEC}};
+	uint64_t triggers[3][2] = {{LOW, 200ULL * MSEC_TO_USEC},
+				   {NORMAL, 400ULL * MSEC_TO_USEC},
+				   {HIGH, 700ULL * MSEC_TO_USEC}};
 
 	if (stopping(stream)) {
 		pthread_join(stream->send_thread, NULL);
@@ -1064,9 +1077,15 @@ static bool init_connect(struct rtmp_stream *stream)
 	stream->dbr_orig_bitrate = (long)obs_data_get_int(vsettings, "bitrate");
 	stream->dbr_cur_bitrate = stream->dbr_orig_bitrate;
 	stream->dbr_est_bitrate = 0;
-	stream->dbr_inc_bitrate = stream->dbr_orig_bitrate / 10;
+	stream->dbr_inc_bitrate = stream->dbr_orig_bitrate / 5;
 	stream->dbr_inc_timeout = 0;
+	stream->dbr_low_timeout = 0;
+	stream->dbr_normal_timeout = 0;
+	stream->dbr_high_timeout = 0;
 	stream->dbr_enabled = obs_data_get_bool(settings, OPT_DYN_BITRATE);
+	stream->dbr_rates = rates;
+	stream->dbr_timers = timers;
+	stream->dbr_triggers = triggers;
 
 	caps = obs_encoder_get_caps(venc);
 	if ((caps & OBS_ENCODER_CAP_DYN_BITRATE) == 0) {
@@ -1218,7 +1237,7 @@ static bool find_first_video_packet(struct rtmp_stream *stream,
 	return false;
 }
 
-static bool dbr_bitrate_lowered(struct rtmp_stream *stream)
+static bool dbr_bitrate_lowered(struct rtmp_stream *stream, Severity severity)
 {
 	long prev_bitrate = stream->dbr_prev_bitrate;
 	long est_bitrate = 0;
@@ -1259,8 +1278,12 @@ static bool dbr_bitrate_lowered(struct rtmp_stream *stream)
 	}
 #else
 	if (est_bitrate) {
-		new_bitrate = est_bitrate;
+		uint8_t lower_rate = stream->dbr_rates[severity][1];
+		new_bitrate = stream->dbr_cur_bitrate - (stream->dbr_orig_bitrate / lower_rate);
 
+		if (new_bitrate < est_bitrate) {
+			new_bitrate = est_bitrate;
+		}
 	} else if (prev_bitrate) {
 		new_bitrate = prev_bitrate;
 		info("going back to prev bitrate");
@@ -1277,6 +1300,17 @@ static bool dbr_bitrate_lowered(struct rtmp_stream *stream)
 	stream->dbr_prev_bitrate = 0;
 	stream->dbr_cur_bitrate = new_bitrate;
 	stream->dbr_inc_timeout = os_gettime_ns() + DBR_INC_TIMER;
+
+	uint64_t lower_time = stream->dbr_timers[severity][1];
+
+	if (severity == HIGH) {
+		stream->dbr_high_timeout = os_gettime_ns() + lower_time;
+	} else if (severity == NORMAL) {
+		stream->dbr_normal_timeout = os_gettime_ns() + lower_time;
+	} else if (severity == LOW) {
+		stream->dbr_low_timeout = os_gettime_ns() + lower_time;
+	}
+
 	info("bitrate decreased to: %ld", stream->dbr_cur_bitrate);
 	return true;
 }
@@ -1360,9 +1394,19 @@ static void check_to_drop_frames(struct rtmp_stream *stream, bool pframes)
 			return;
 		}
 
-		if ((uint64_t)buffer_duration_usec >= DBR_TRIGGER_USEC) {
+		uint64_t t = os_gettime_ns();
+
+		if (buffer_duration_usec >= stream->dbr_triggers[HIGH][1] && t >= stream->dbr_high_timeout) {
 			pthread_mutex_lock(&stream->dbr_mutex);
-			bitrate_changed = dbr_bitrate_lowered(stream);
+			bitrate_changed = dbr_bitrate_lowered(stream, HIGH);
+			pthread_mutex_unlock(&stream->dbr_mutex);
+		} else if (buffer_duration_usec >= stream->dbr_triggers[NORMAL][1] && t >= stream->dbr_normal_timeout) {
+			pthread_mutex_lock(&stream->dbr_mutex);
+			bitrate_changed = dbr_bitrate_lowered(stream, NORMAL);
+			pthread_mutex_unlock(&stream->dbr_mutex);
+		} else if (buffer_duration_usec >= stream->dbr_triggers[LOW][1] && t >= stream->dbr_low_timeout) {
+			pthread_mutex_lock(&stream->dbr_mutex);
+			bitrate_changed = dbr_bitrate_lowered(stream, LOW);
 			pthread_mutex_unlock(&stream->dbr_mutex);
 		}
 

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -31,7 +31,6 @@
 
 /* dynamic bitrate coefficients */
 #define DBR_INC_TIMER (30ULL * SEC_TO_NSEC)
-//#define DBR_TRIGGER_USEC (200ULL * MSEC_TO_USEC)
 #define MIN_ESTIMATE_DURATION_MS 1000
 #define MAX_ESTIMATE_DURATION_MS 2000
 

--- a/plugins/obs-outputs/rtmp-stream.h
+++ b/plugins/obs-outputs/rtmp-stream.h
@@ -114,9 +114,6 @@ struct rtmp_stream {
 	long dbr_cur_bitrate;
 	long dbr_inc_bitrate;
 	bool dbr_enabled;
-	uint8_t (*dbr_rates)[3][2];
-	uint64_t (*dbr_timers)[3][2];
-	uint64_t (*dbr_triggers)[3][2];
 
 	RTMP rtmp;
 

--- a/plugins/obs-outputs/rtmp-stream.h
+++ b/plugins/obs-outputs/rtmp-stream.h
@@ -104,6 +104,9 @@ struct rtmp_stream {
 	struct circlebuf dbr_frames;
 	size_t dbr_data_size;
 	uint64_t dbr_inc_timeout;
+	uint64_t dbr_low_timeout;
+	uint64_t dbr_normal_timeout;
+	uint64_t dbr_high_timeout;
 	long audio_bitrate;
 	long dbr_est_bitrate;
 	long dbr_orig_bitrate;
@@ -111,6 +114,9 @@ struct rtmp_stream {
 	long dbr_cur_bitrate;
 	long dbr_inc_bitrate;
 	bool dbr_enabled;
+	uint8_t (*dbr_rates)[3][2];
+	uint64_t (*dbr_timers)[3][2];
+	uint64_t (*dbr_triggers)[3][2];
 
 	RTMP rtmp;
 


### PR DESCRIPTION
Rebase of streamlabs-25.0.8 on previous PR was removing code from rtmp-stream.c that it was not supposed to.

Original discussion: https://github.com/stream-labs/obs-studio/pull/175