### PR TITLE
Revert PR#187 - add device rebuild callback

### DIFF
--- a/libobs-d3d11/d3d11-rebuild.cpp
+++ b/libobs-d3d11/d3d11-rebuild.cpp
@@ -510,9 +510,6 @@ try {
 	for (auto &state : blendStates)
 		state.Rebuild(dev);
 
-	if (rebuildCallback)
-		rebuildCallback();
-
 	for (gs_device_loss &callback : loss_callbacks)
 		callback.device_loss_rebuild(device.Get(), callback.data);
 

--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -2782,13 +2782,6 @@ device_stagesurface_create_nv12(gs_device_t *device, uint32_t width,
 }
 
 extern "C" EXPORT void
-device_set_rebuild_callback(gs_device_t *device,
-			    gs_rebuild_device_callback_t callback)
-{
-	device->rebuildCallback = std::move(callback);
-}
-
-extern "C" EXPORT void
 device_register_loss_callbacks(gs_device_t *device,
 			       const gs_device_loss *callbacks)
 {

--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -949,8 +949,6 @@ struct gs_device {
 	vector<gs_device_loss> loss_callbacks;
 	gs_obj *first_obj = nullptr;
 
-	gs_rebuild_device_callback_t rebuildCallback = nullptr;
-
 	void InitCompiler();
 	void InitFactory(uint32_t adapterIdx);
 	void InitDevice(uint32_t adapterIdx);

--- a/libobs-opengl/gl-vertexbuffer.c
+++ b/libobs-opengl/gl-vertexbuffer.c
@@ -275,11 +275,3 @@ void device_load_vertexbuffer(gs_device_t *device, gs_vertbuffer_t *vb)
 {
 	device->cur_vertex_buffer = vb;
 }
-
-void device_set_rebuild_callback(gs_device_t *device,
-				 gs_rebuild_device_callback_t callback)
-{
-	/* Do nothing - OpenGL */
-	UNUSED_PARAMETER(device);
-	UNUSED_PARAMETER(callback);
-}

--- a/libobs/graphics/graphics-imports.c
+++ b/libobs/graphics/graphics-imports.c
@@ -218,8 +218,5 @@ bool load_graphics_imports(struct gs_exports *exports, void *module,
 	GRAPHICS_IMPORT_OPTIONAL(device_unregister_loss_callbacks);
 #endif
 
-	/* SLOBS custom functions */
-	GRAPHICS_IMPORT_OPTIONAL(device_set_rebuild_callback);
-
 	return success;
 }

--- a/libobs/graphics/graphics-internal.h
+++ b/libobs/graphics/graphics-internal.h
@@ -316,10 +316,6 @@ struct gs_exports {
 	void (*device_unregister_loss_callbacks)(gs_device_t *device,
 						 void *data);
 #endif
-
-	/* SLOBS custom functions */
-	void (*device_set_rebuild_callback)(
-		gs_device_t *device, gs_rebuild_device_callback_t callback);
 };
 
 struct blend_state {

--- a/libobs/graphics/graphics.c
+++ b/libobs/graphics/graphics.c
@@ -2987,14 +2987,3 @@ void gs_unregister_loss_callbacks(void *data)
 }
 
 #endif
-
-void gs_set_rebuild_device_callback(gs_rebuild_device_callback_t callback)
-{
-	graphics_t *graphics = thread_graphics;
-
-	if (!gs_valid("gs_set_rebuild_device_callback"))
-		return;
-
-	graphics->exports.device_set_rebuild_callback(graphics->device,
-						      callback);
-}

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -894,12 +894,6 @@ EXPORT void gs_unregister_loss_callbacks(void *data);
 
 #endif
 
-/* SLOBS custom functions */
-typedef void (*gs_rebuild_device_callback_t)();
-
-EXPORT void
-gs_set_rebuild_device_callback(gs_rebuild_device_callback_t callback);
-
 /* inline functions used by modules */
 
 static inline uint32_t gs_get_format_bpp(enum gs_color_format format)


### PR DESCRIPTION
Revert PR#187 about adding device rebuild callback, because similar callbacks (`gs_register_loss_callbacks `and `gs_unregister_loss_callbacks`) were introduced in OBS 25.