### PR TITLE
restore text plugin flag

### DIFF
--- a/plugins/obs-text/gdiplus/obs-text.cpp
+++ b/plugins/obs-text/gdiplus/obs-text.cpp
@@ -1116,7 +1116,7 @@ bool obs_module_load(void)
 	obs_source_info si = { 0 };
 	si.id = "text_gdiplus";
 	si.type = OBS_SOURCE_TYPE_INPUT;
-	si.output_flags = OBS_SOURCE_VIDEO;
+	si.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW;
 	si.create = text_create;
 	si.destroy = text_destroy;
 	si.get_name = text_get_name;


### PR DESCRIPTION
Flag needed for filters to work on input. 
https://github.com/obsproject/obs-studio/commit/33e4de5be62c4518cd47598ef8ef5f431f0d19f6

Flag was overwritten with other changes when merging from OBS done. 
https://github.com/stream-labs/obs-studio/commit/248bfec16b52741f317fd1880bd33ced6b190271#diff-b5fdeb512c8f88a867de9261f1ad5ee1
