### PR TITLE
correctly check written amount

### DIFF
--- a/libobs/util/config-file.c
+++ b/libobs/util/config-file.c
@@ -404,10 +404,10 @@ int config_save(config_t *config)
 	}
 
 #ifdef _WIN32
-	if (fwrite("\xEF\xBB\xBF", 3, 1, f) != 1)
+	if (fwrite("\xEF\xBB\xBF", 1, 3, f) != 3)
 		goto cleanup;
 #endif
-	if (fwrite(str.array, str.len, 1, f) != 1)
+	if (fwrite(str.array, 1, str.len, f) != str.len)
 		goto cleanup;
 
 	ret = CONFIG_SUCCESS;


### PR DESCRIPTION
fwrite expect third param be amount of data need to be written. 
In code call each fwrite with 1 and expect 1 in return. 
But this logic not works when there is 0 in str.len. it still expect 1 to be returned. 