### PR TITLE
switch to a starting state when reconnecting

### DIFF
--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -2408,10 +2408,6 @@ static void output_reconnect(struct obs_output *output)
 
 static inline bool can_reconnect(const obs_output_t *output, int code)
 {
-	blog(LOG_DEBUG, "FREEZLOG: can_reconnect %d %d", output->reconnect_retries, output->reconnect_retry_max);
-	if (output->reconnect_retry_max != 0 && output->reconnect_retries >= output->reconnect_retry_max) 
-		return false;
-
 	bool reconnect_active = output->reconnect_retry_max != 0;
 
 	return (reconnecting(output) && code != OBS_OUTPUT_SUCCESS) ||


### PR DESCRIPTION
Fix for missing a "starting" state after reconnect timeout:
**stream error -> reconnecting state waiting for a timeout -> begin a starting sequence (but not switching state)**
It is allowed for a user to press disconnect on this third step as it still Reconnect state. And that caused some undefined behavior.