### PR TITLE
Find different device id for device name

### DIFF
--- a/plugins/win-wasapi/enum-wasapi.cpp
+++ b/plugins/win-wasapi/enum-wasapi.cpp
@@ -90,7 +90,7 @@ void GetWASAPIAudioDevices_(vector<AudioDeviceInfo> &devices, bool input,
 }
 
 void GetWASAPIAudioDevices(vector<AudioDeviceInfo> &devices, bool input,
-			   const string &searchbyName="")
+			   const string &searchbyName)
 {
 	devices.clear();
 

--- a/plugins/win-wasapi/enum-wasapi.cpp
+++ b/plugins/win-wasapi/enum-wasapi.cpp
@@ -90,7 +90,7 @@ void GetWASAPIAudioDevices_(vector<AudioDeviceInfo> &devices, bool input,
 }
 
 void GetWASAPIAudioDevices(vector<AudioDeviceInfo> &devices, bool input,
-			   const string &searchbyName)
+			   const string &searchbyName="")
 {
 	devices.clear();
 

--- a/plugins/win-wasapi/enum-wasapi.hpp
+++ b/plugins/win-wasapi/enum-wasapi.hpp
@@ -41,5 +41,6 @@ struct AudioDeviceInfo {
 };
 
 std::string GetDeviceName(IMMDevice *device);
+
 void GetWASAPIAudioDevices(std::vector<AudioDeviceInfo> &devices, bool input,
 			   const std::string &searchByName = "");

--- a/plugins/win-wasapi/enum-wasapi.hpp
+++ b/plugins/win-wasapi/enum-wasapi.hpp
@@ -6,6 +6,8 @@
 #include <mmdeviceapi.h>
 #include <audioclient.h>
 #include <propsys.h>
+#include <util/platform.h>
+#include <util/windows/ComPtr.hpp>
 
 #ifdef __MINGW32__
 
@@ -35,7 +37,9 @@ DEFINE_PROPERTYKEY(PKEY_Device_FriendlyName, \
 struct AudioDeviceInfo {
 	std::string name;
 	std::string id;
+	ComPtr<IMMDevice> device;
 };
 
 std::string GetDeviceName(IMMDevice *device);
-void GetWASAPIAudioDevices(std::vector<AudioDeviceInfo> &devices, bool input);
+void GetWASAPIAudioDevices(std::vector<AudioDeviceInfo> &devices, bool input,
+			   const std::string &searchByName = "");

--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -80,40 +80,28 @@ public:
 
 	void Update(obs_data_t *settings);
 	//callbacks for IMMNotificationClient
-	HRESULT STDMETHODCALLTYPE OnDefaultDeviceChanged(
-		EDataFlow flow, ERole role, LPCWSTR pwstrDefaultDeviceId);
+	HRESULT STDMETHODCALLTYPE OnDefaultDeviceChanged(EDataFlow flow, ERole role, LPCWSTR 
+pwstrDefaultDeviceId);
 
-	HRESULT STDMETHODCALLTYPE OnDeviceStateChanged(
-		LPCWSTR /*pwstrDeviceId*/, DWORD /*dwNewState*/)
-	{
-		return S_OK;
-	}
-	HRESULT STDMETHODCALLTYPE OnDeviceAdded(LPCWSTR /*pwstrDeviceId*/)
-	{
-		return S_OK;
-	}
-	HRESULT STDMETHODCALLTYPE OnDeviceRemoved(LPCWSTR /*pwstrDeviceId*/)
-	{
-		return S_OK;
-	}
-	HRESULT STDMETHODCALLTYPE OnPropertyValueChanged(
-		LPCWSTR /*pwstrDeviceId*/, const PROPERTYKEY /*key*/)
-	{
-		return S_OK;
-	}
+	HRESULT STDMETHODCALLTYPE OnDeviceStateChanged(LPCWSTR /*pwstrDeviceId*/, DWORD 
+/*dwNewState*/) { return S_OK; }
+	HRESULT STDMETHODCALLTYPE OnDeviceAdded(LPCWSTR /*pwstrDeviceId*/) { return S_OK; }
+	HRESULT STDMETHODCALLTYPE OnDeviceRemoved(LPCWSTR /*pwstrDeviceId*/) { return S_OK; }
+	HRESULT STDMETHODCALLTYPE OnPropertyValueChanged(LPCWSTR /*pwstrDeviceId*/, const PROPERTYKEY 
+/*key*/) { return S_OK; }
 	HRESULT STDMETHODCALLTYPE OnDeviceQueryRemove() { return S_OK; }
 	HRESULT STDMETHODCALLTYPE OnDeviceQueryRemoveFailed() { return S_OK; }
 	HRESULT STDMETHODCALLTYPE OnDeviceRemovePending() { return S_OK; }
 
-	HRESULT STDMETHODCALLTYPE QueryInterface(const IID &iid, void **ppUnk);
-	IFACEMETHODIMP_(ULONG) AddRef();
+	HRESULT STDMETHODCALLTYPE QueryInterface(const IID& iid, void** ppUnk);
+	IFACEMETHODIMP_(ULONG) AddRef(); 
 	IFACEMETHODIMP_(ULONG) Release();
 
 	long m_cRef;
 };
 
 WASAPISource::WASAPISource(obs_data_t *settings, obs_source_t *source_,
-			   bool input)
+				bool input)
 	: source(source_),
 	  isInputDevice(input),
 	  m_cRef(1)
@@ -167,25 +155,21 @@ inline WASAPISource::~WASAPISource()
 void WASAPISource::RegisterNotificationCallback()
 {
 	if (isDefaultDevice && !isInputDevice) {
-		blog(LOG_INFO,
-		     "WASAPI: will register for notification callbacks on default audio device change");
+		blog(LOG_INFO, "WASAPI: will register for notification callbacks on default audio device change");
 
 		ComPtr<IMMDeviceEnumerator> enumerator;
 		HRESULT res;
 
-		res = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr,
-				       CLSCTX_ALL,
+		res = CoCreateInstance(__uuidof(MMDeviceEnumerator), 
+						nullptr, CLSCTX_ALL,
 				       __uuidof(IMMDeviceEnumerator),
-				       (void **)enumerator.Assign());
+				       (void** )enumerator.Assign());
 		if (FAILED(res)) {
-			blog(LOG_INFO,
-			     "WASAPI: failed to get enumerator to set callbacks");
+			blog(LOG_INFO, "WASAPI: failed to get enumerator to set callbacks");
 		} else {
-			res = enumerator->RegisterEndpointNotificationCallback(
-				this);
+			res = enumerator->RegisterEndpointNotificationCallback(this);
 			if (FAILED(res)) {
-				blog(LOG_INFO,
-				     "WASAPI: failed to set callbacks");
+				blog(LOG_INFO, "WASAPI: failed to set callbacks");
 			}
 		}
 	}
@@ -197,14 +181,13 @@ void WASAPISource::UnRegisterNotificationCallback()
 		ComPtr<IMMDeviceEnumerator> enumerator;
 		HRESULT res;
 
-		res = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr,
-				       CLSCTX_ALL,
+		res = CoCreateInstance(__uuidof(MMDeviceEnumerator), 
+						nullptr, CLSCTX_ALL,
 				       __uuidof(IMMDeviceEnumerator),
-				       (void **)enumerator.Assign());
+				       (void** )enumerator.Assign());
 
 		if (!FAILED(res)) {
-			res = enumerator->UnregisterEndpointNotificationCallback(
-				this);
+			res = enumerator->UnregisterEndpointNotificationCallback(this);
 		}
 	}
 }
@@ -320,7 +303,7 @@ void WASAPISource::InitClient()
 	DWORD flags = AUDCLNT_STREAMFLAGS_EVENTCALLBACK;
 
 	res = device->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr,
-			       (void **)client.Assign());
+			       (void** )client.Assign());
 	if (FAILED(res))
 		throw HRError(
 			"[WASAPISource::InitClient] Failed to activate client context",
@@ -350,11 +333,9 @@ void WASAPISource::InitRender()
 	ComPtr<IAudioClient> client;
 
 	res = device->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr,
-			       (void **)client.Assign());
+			       (void** )client.Assign());
 	if (FAILED(res))
-		throw HRError(
-			"[WASAPISource::InitRender] Failed to activate client context",
-			res);
+		throw HRError("[WASAPISource::InitRender] Failed to activate client context", res);
 
 	res = client->GetMixFormat(&wfex);
 	if (FAILED(res))
@@ -374,7 +355,7 @@ void WASAPISource::InitRender()
 		throw HRError("Failed to get buffer size", res);
 
 	res = client->GetService(__uuidof(IAudioRenderClient),
-					(void **)render.Assign());
+			(void** )render.Assign());
 	if (FAILED(res))
 		throw HRError("Failed to get render client", res);
 
@@ -423,7 +404,7 @@ void WASAPISource::InitFormat(WAVEFORMATEX *wfex)
 void WASAPISource::InitCapture()
 {
 	HRESULT res = client->GetService(__uuidof(IAudioCaptureClient),
-					 (void **)capture.Assign());
+					 (void** )capture.Assign());
 	if (FAILED(res))
 		throw HRError("Failed to create capture context", res);
 
@@ -450,7 +431,7 @@ void WASAPISource::Initialize()
 
 	res = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr,
 			       CLSCTX_ALL, __uuidof(IMMDeviceEnumerator),
-			       (void **)enumerator.Assign());
+			       (void** )enumerator.Assign());
 	if (FAILED(res))
 		throw HRError("Failed to create enumerator", res);
 
@@ -496,30 +477,26 @@ bool WASAPISource::TryInitialize()
 		if (previouslyFailed) {
 			blog(LOG_WARNING,
 			     "[WASAPISource::TryInitialize]:[%s] Device id %s previously failed, aborting with active = %d",
-			     device_name.empty() ? device_id.c_str()
-						 : device_name.c_str(),
+			     device_name.empty() ? device_id.c_str(): device_name.c_str(),
 			     device_id.c_str(), active);
 			return active;
 		}
 
 		blog(LOG_WARNING, "[WASAPISource::TryInitialize]:[%s] %s: %lX",
-		     device_name.empty() ? device_id.c_str()
-					 : device_name.c_str(),
+				device_name.empty() ? device_id.c_str(): device_name.c_str(),
 		     error.str, error.hr);
 
 	} catch (const char *error) {
 		if (previouslyFailed) {
 			blog(LOG_WARNING,
 			     "[WASAPISource::TryInitialize]:[%s] Device id %s previously failed, aborting with active = %d",
-			     device_name.empty() ? device_id.c_str()
-						 : device_name.c_str(),
+			     device_name.empty() ? device_id.c_str(): device_name.c_str(),
 			     device_id.c_str(), active);
 			return active;
 		}
 
 		blog(LOG_WARNING, "[WASAPISource::TryInitialize]:[%s] %s",
-		     device_name.empty() ? device_id.c_str()
-					 : device_name.c_str(),
+		     device_name.empty() ? device_id.c_str(): device_name.c_str(),
 		     error);
 	}
 
@@ -691,8 +668,7 @@ HRESULT STDMETHODCALLTYPE WASAPISource::OnDefaultDeviceChanged(EDataFlow Flow,
 {
 	if (Flow == eRender && Role == eConsole) {
 		if (isDefaultDevice) {
-			blog(LOG_INFO,
-			     "Got notification about Default audio output device switch");
+			blog(LOG_INFO, "Got notification about Default audio output device switch");
 			hadDefaultChangeEvent = true;
 			SetEvent(receiveSignal);
 		}
@@ -701,10 +677,10 @@ HRESULT STDMETHODCALLTYPE WASAPISource::OnDefaultDeviceChanged(EDataFlow Flow,
 	return S_OK;
 }
 
-HRESULT WASAPISource::QueryInterface(const IID &iid, void **ppUnk)
+HRESULT WASAPISource::QueryInterface(const IID& iid, void** ppUnk)
 {
 	if ((iid == __uuidof(IUnknown)) ||
-	    (iid == __uuidof(IMMNotificationClient))) {
+		(iid == __uuidof(IMMNotificationClient))) {
 		*ppUnk = static_cast<IMMNotificationClient *>(this);
 	} else {
 		*ppUnk = NULL;

--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -79,21 +79,19 @@ public:
 	inline ~WASAPISource();
 
 	void Update(obs_data_t *settings);
-	//callbacks for IMMNotificationClient
-	HRESULT STDMETHODCALLTYPE OnDefaultDeviceChanged(EDataFlow flow, ERole role, LPCWSTR 
-pwstrDefaultDeviceId);
 
-	HRESULT STDMETHODCALLTYPE OnDeviceStateChanged(LPCWSTR /*pwstrDeviceId*/, DWORD 
-/*dwNewState*/) { return S_OK; }
+//callbacks for IMMNotificationClient	
+	HRESULT STDMETHODCALLTYPE OnDefaultDeviceChanged(EDataFlow flow, ERole role, LPCWSTR pwstrDefaultDeviceId);
+
+	HRESULT STDMETHODCALLTYPE OnDeviceStateChanged(LPCWSTR /*pwstrDeviceId*/, DWORD /*dwNewState*/) { return S_OK; }
 	HRESULT STDMETHODCALLTYPE OnDeviceAdded(LPCWSTR /*pwstrDeviceId*/) { return S_OK; }
 	HRESULT STDMETHODCALLTYPE OnDeviceRemoved(LPCWSTR /*pwstrDeviceId*/) { return S_OK; }
-	HRESULT STDMETHODCALLTYPE OnPropertyValueChanged(LPCWSTR /*pwstrDeviceId*/, const PROPERTYKEY 
-/*key*/) { return S_OK; }
+	HRESULT STDMETHODCALLTYPE OnPropertyValueChanged(LPCWSTR /*pwstrDeviceId*/, const PROPERTYKEY /*key*/) { return S_OK; }
 	HRESULT STDMETHODCALLTYPE OnDeviceQueryRemove() { return S_OK; }
 	HRESULT STDMETHODCALLTYPE OnDeviceQueryRemoveFailed() { return S_OK; }
 	HRESULT STDMETHODCALLTYPE OnDeviceRemovePending() { return S_OK; }
 
-	HRESULT STDMETHODCALLTYPE QueryInterface(const IID& iid, void ** ppUnk);
+	HRESULT STDMETHODCALLTYPE QueryInterface(const IID& iid, void** ppUnk);
 	IFACEMETHODIMP_(ULONG) AddRef(); 
 	IFACEMETHODIMP_(ULONG) Release();
 
@@ -101,10 +99,10 @@ pwstrDefaultDeviceId);
 };
 
 WASAPISource::WASAPISource(obs_data_t *settings, obs_source_t *source_,
-				bool input)
-	: source(source_),
-	  isInputDevice(input),
-	  m_cRef(1)
+		bool input)
+	: source          (source_),
+	  isInputDevice   (input),
+	  m_cRef          (1)
 {
 	UpdateSettings(settings);
 
@@ -124,7 +122,7 @@ inline void WASAPISource::Start()
 	if (!TryInitialize()) {
 		blog(LOG_INFO,
 		     "[WASAPISource::WASAPISource] "
-		     "Device '%s' not found. <=> Waiting for device <=>",
+		     "Device '%s' not found.  Waiting for device",
 		     device_id.c_str());
 		Reconnect();
 	}
@@ -154,21 +152,21 @@ inline WASAPISource::~WASAPISource()
 
 void WASAPISource::RegisterNotificationCallback()
 {
-	if (isDefaultDevice && !isInputDevice) {
+	if(isDefaultDevice && !isInputDevice) {
 		blog(LOG_INFO, "WASAPI: will register for notification callbacks on default audio device change");
 
 		ComPtr<IMMDeviceEnumerator> enumerator;
 		HRESULT res;
 
-		res = CoCreateInstance(__uuidof(MMDeviceEnumerator), 
-						nullptr, CLSCTX_ALL,
-				       __uuidof(IMMDeviceEnumerator),
-				       (void **)enumerator.Assign());
-		if (FAILED(res)) {
+		res = CoCreateInstance(__uuidof(MMDeviceEnumerator),
+				nullptr, CLSCTX_ALL,
+				__uuidof(IMMDeviceEnumerator),
+				(void**)enumerator.Assign());
+		if(FAILED(res) ) {
 			blog(LOG_INFO, "WASAPI: failed to get enumerator to set callbacks");
 		} else {
 			res = enumerator->RegisterEndpointNotificationCallback(this);
-			if (FAILED(res)) {
+			if(FAILED(res) ) {
 				blog(LOG_INFO, "WASAPI: failed to set callbacks");
 			}
 		}
@@ -177,19 +175,19 @@ void WASAPISource::RegisterNotificationCallback()
 
 void WASAPISource::UnRegisterNotificationCallback()
 {
-	if (isDefaultDevice && !isInputDevice) {
+	if(isDefaultDevice && !isInputDevice) {
 		ComPtr<IMMDeviceEnumerator> enumerator;
 		HRESULT res;
 
-		res = CoCreateInstance(__uuidof(MMDeviceEnumerator), 
-					nullptr, CLSCTX_ALL,
-				    __uuidof(IMMDeviceEnumerator),
-				    (void **)enumerator.Assign());
-
+		res = CoCreateInstance(__uuidof(MMDeviceEnumerator),
+				nullptr, CLSCTX_ALL,
+				__uuidof(IMMDeviceEnumerator),
+				(void**)enumerator.Assign());
+		
 		if(!FAILED(res) ) {
 			res = enumerator->UnregisterEndpointNotificationCallback(this);
 		}
-	}
+	}	
 }
 
 void WASAPISource::UpdateSettings(obs_data_t *settings)
@@ -341,8 +339,8 @@ void WASAPISource::InitRender()
 	if (FAILED(res))
 		throw HRError("Failed to get mix format", res);
 
-	res = client->Initialize(AUDCLNT_SHAREMODE_SHARED, 0, BUFFER_TIME_100NS, 
-                             0, wfex, nullptr);
+	res = client->Initialize(AUDCLNT_SHAREMODE_SHARED, 0, BUFFER_TIME_100NS,
+				 0, wfex, nullptr);
 	if (FAILED(res))
 		throw HRError("Failed to get initialize audio client", res);
 
@@ -355,7 +353,7 @@ void WASAPISource::InitRender()
 		throw HRError("Failed to get buffer size", res);
 
 	res = client->GetService(__uuidof(IAudioRenderClient),
-			(void **)render.Assign());
+				 (void **)render.Assign());
 	if (FAILED(res))
 		throw HRError("Failed to get render client", res);
 
@@ -597,14 +595,15 @@ bool WASAPISource::ProcessCaptureData()
 			return false;
 		}
 
-		obs_source_audio data = {0};			
-		data.data[0]          = (const uint8_t*)buffer;			
-		data.frames           = (uint32_t)frames;			
-		data.speakers         = speakers;			
-		data.samples_per_sec  = sampleRate;			
-		data.format           = format;			
-		data.timestamp        = useDeviceTiming ?			
+		obs_source_audio data = {0};
+		data.data[0]          = (const uint8_t*)buffer;
+		data.frames           = (uint32_t)frames;
+		data.speakers         = speakers;
+		data.samples_per_sec  = sampleRate;
+		data.format           = format;
+		data.timestamp        = useDeviceTiming ?
 			ts*100 : os_gettime_ns();
+
 
 		if (!useDeviceTiming)
 			data.timestamp -= util_mul_div64(frames, 1000000000ULL,
@@ -671,26 +670,26 @@ HRESULT STDMETHODCALLTYPE WASAPISource::OnDefaultDeviceChanged(EDataFlow Flow, E
 			hadDefaultChangeEvent = true;
 			SetEvent(receiveSignal);
 		}
-	}
+	}		
 
 	return S_OK;
 }
 
 HRESULT WASAPISource::QueryInterface(const IID& iid, void** ppUnk)
-{	
-    if ((iid == __uuidof(IUnknown)) ||		
-        (iid == __uuidof(IMMNotificationClient))) {			
+{
+    if ((iid == __uuidof(IUnknown)) ||
+        (iid == __uuidof(IMMNotificationClient))) {
         *ppUnk = static_cast<IMMNotificationClient*>(this);
     } else {
         *ppUnk = NULL;
         return E_NOINTERFACE;
     }
 
-    AddRef();		
-    return S_OK;		
+    AddRef();
+    return S_OK;
 }
 
-ULONG WASAPISource::AddRef()	
+ULONG WASAPISource::AddRef()
 {
     return InterlockedIncrement(&m_cRef);
 }

--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -494,8 +494,8 @@ bool WASAPISource::TryInitialize()
 		}
 
 		blog(LOG_WARNING, "[WASAPISource::TryInitialize]:[%s] %s",
-                device_name.empty() ? device_id.c_str()
-                : device_name.c_str(),
+		     device_name.empty() ? device_id.c_str()
+					 : device_name.c_str(),
 		     error);
 	}
 
@@ -646,7 +646,6 @@ DWORD WINAPI WASAPISource::CaptureThread(LPVOID param)
 			break;
 		}
 	}
-
 
 	source->client->Stop();
 

--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -93,7 +93,7 @@ pwstrDefaultDeviceId);
 	HRESULT STDMETHODCALLTYPE OnDeviceQueryRemoveFailed() { return S_OK; }
 	HRESULT STDMETHODCALLTYPE OnDeviceRemovePending() { return S_OK; }
 
-	HRESULT STDMETHODCALLTYPE QueryInterface(const IID& iid, void** ppUnk);
+	HRESULT STDMETHODCALLTYPE QueryInterface(const IID& iid, void ** ppUnk);
 	IFACEMETHODIMP_(ULONG) AddRef(); 
 	IFACEMETHODIMP_(ULONG) Release();
 
@@ -163,7 +163,7 @@ void WASAPISource::RegisterNotificationCallback()
 		res = CoCreateInstance(__uuidof(MMDeviceEnumerator), 
 						nullptr, CLSCTX_ALL,
 				       __uuidof(IMMDeviceEnumerator),
-				       (void** )enumerator.Assign());
+				       (void **)enumerator.Assign());
 		if (FAILED(res)) {
 			blog(LOG_INFO, "WASAPI: failed to get enumerator to set callbacks");
 		} else {
@@ -182,11 +182,11 @@ void WASAPISource::UnRegisterNotificationCallback()
 		HRESULT res;
 
 		res = CoCreateInstance(__uuidof(MMDeviceEnumerator), 
-						nullptr, CLSCTX_ALL,
-				       __uuidof(IMMDeviceEnumerator),
-				       (void** )enumerator.Assign());
+					nullptr, CLSCTX_ALL,
+				    __uuidof(IMMDeviceEnumerator),
+				    (void **)enumerator.Assign());
 
-		if (!FAILED(res)) {
+		if(!FAILED(res) ) {
 			res = enumerator->UnregisterEndpointNotificationCallback(this);
 		}
 	}
@@ -303,7 +303,7 @@ void WASAPISource::InitClient()
 	DWORD flags = AUDCLNT_STREAMFLAGS_EVENTCALLBACK;
 
 	res = device->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr,
-			       (void** )client.Assign());
+			       (void **)client.Assign());
 	if (FAILED(res))
 		throw HRError(
 			"[WASAPISource::InitClient] Failed to activate client context",
@@ -333,7 +333,7 @@ void WASAPISource::InitRender()
 	ComPtr<IAudioClient> client;
 
 	res = device->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr,
-			       (void** )client.Assign());
+			       (void **)client.Assign());
 	if (FAILED(res))
 		throw HRError("[WASAPISource::InitRender] Failed to activate client context", res);
 
@@ -341,8 +341,8 @@ void WASAPISource::InitRender()
 	if (FAILED(res))
 		throw HRError("Failed to get mix format", res);
 
-	res = client->Initialize(AUDCLNT_SHAREMODE_SHARED, 0,
-					BUFFER_TIME_100NS, 0, wfex, nullptr);
+	res = client->Initialize(AUDCLNT_SHAREMODE_SHARED, 0, BUFFER_TIME_100NS, 
+                             0, wfex, nullptr);
 	if (FAILED(res))
 		throw HRError("Failed to get initialize audio client", res);
 
@@ -355,7 +355,7 @@ void WASAPISource::InitRender()
 		throw HRError("Failed to get buffer size", res);
 
 	res = client->GetService(__uuidof(IAudioRenderClient),
-			(void** )render.Assign());
+			(void **)render.Assign());
 	if (FAILED(res))
 		throw HRError("Failed to get render client", res);
 
@@ -404,7 +404,7 @@ void WASAPISource::InitFormat(WAVEFORMATEX *wfex)
 void WASAPISource::InitCapture()
 {
 	HRESULT res = client->GetService(__uuidof(IAudioCaptureClient),
-					 (void** )capture.Assign());
+					 (void **)capture.Assign());
 	if (FAILED(res))
 		throw HRError("Failed to create capture context", res);
 
@@ -431,7 +431,7 @@ void WASAPISource::Initialize()
 
 	res = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr,
 			       CLSCTX_ALL, __uuidof(IMMDeviceEnumerator),
-			       (void** )enumerator.Assign());
+			       (void **)enumerator.Assign());
 	if (FAILED(res))
 		throw HRError("Failed to create enumerator", res);
 
@@ -496,7 +496,8 @@ bool WASAPISource::TryInitialize()
 		}
 
 		blog(LOG_WARNING, "[WASAPISource::TryInitialize]:[%s] %s",
-		     device_name.empty() ? device_id.c_str(): device_name.c_str(),
+                device_name.empty() ? device_id.c_str()
+                : device_name.c_str(),
 		     error);
 	}
 
@@ -596,14 +597,14 @@ bool WASAPISource::ProcessCaptureData()
 			return false;
 		}
 
-		obs_source_audio data = {};
-		data.data[0] = (const uint8_t *)buffer;
-		data.frames = (uint32_t)frames;
-		data.speakers = speakers;
-		data.samples_per_sec = sampleRate;
-		data.format = format;
-		data.timestamp = useDeviceTiming ?
-			ts * 100 : os_gettime_ns();
+		obs_source_audio data = {0};			
+		data.data[0]          = (const uint8_t*)buffer;			
+		data.frames           = (uint32_t)frames;			
+		data.speakers         = speakers;			
+		data.samples_per_sec  = sampleRate;			
+		data.format           = format;			
+		data.timestamp        = useDeviceTiming ?			
+			ts*100 : os_gettime_ns();
 
 		if (!useDeviceTiming)
 			data.timestamp -= util_mul_div64(frames, 1000000000ULL,
@@ -662,12 +663,10 @@ DWORD WINAPI WASAPISource::CaptureThread(LPVOID param)
 	return 0;
 }
 
-HRESULT STDMETHODCALLTYPE WASAPISource::OnDefaultDeviceChanged(EDataFlow Flow,
-							       ERole Role,
-							       LPCWSTR)
+HRESULT STDMETHODCALLTYPE WASAPISource::OnDefaultDeviceChanged(EDataFlow Flow, ERole Role, LPCWSTR )
 {
 	if (Flow == eRender && Role == eConsole) {
-		if (isDefaultDevice) {
+		if (isDefaultDevice ) {
 			blog(LOG_INFO, "Got notification about Default audio output device switch");
 			hadDefaultChangeEvent = true;
 			SetEvent(receiveSignal);
@@ -678,31 +677,31 @@ HRESULT STDMETHODCALLTYPE WASAPISource::OnDefaultDeviceChanged(EDataFlow Flow,
 }
 
 HRESULT WASAPISource::QueryInterface(const IID& iid, void** ppUnk)
-{
-	if ((iid == __uuidof(IUnknown)) ||
-		(iid == __uuidof(IMMNotificationClient))) {
-		*ppUnk = static_cast<IMMNotificationClient *>(this);
-	} else {
-		*ppUnk = NULL;
-		return E_NOINTERFACE;
-	}
+{	
+    if ((iid == __uuidof(IUnknown)) ||		
+        (iid == __uuidof(IMMNotificationClient))) {			
+        *ppUnk = static_cast<IMMNotificationClient*>(this);
+    } else {
+        *ppUnk = NULL;
+        return E_NOINTERFACE;
+    }
 
-	AddRef();
-	return S_OK;
+    AddRef();		
+    return S_OK;		
 }
 
-ULONG WASAPISource::AddRef()
+ULONG WASAPISource::AddRef()	
 {
-	return InterlockedIncrement(&m_cRef);
+    return InterlockedIncrement(&m_cRef);
 }
 
 ULONG WASAPISource::Release()
 {
-	long lRef = InterlockedDecrement(&m_cRef);
-	if (lRef == 0) {
-		delete this;
-	}
-	return lRef;
+    long lRef = InterlockedDecrement(&m_cRef);
+    if (lRef == 0) {
+        delete this;
+    }
+    return lRef;
 }
 
 /* ------------------------------------------------------------------------- */

--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -265,6 +265,7 @@ HRESULT WASAPISource::InitDeviceLoop(IMMDeviceEnumerator *enumerator,
 		res = InitDevice(enumerator, !retryInitDeviceCounter
 						     ? isDefaultDevice
 						     : false);
+	
 		if (device_name.empty())
 			device_name = GetDeviceName(device);
 		if (SUCCEEDED(res)) {
@@ -295,10 +296,6 @@ HRESULT WASAPISource::InitDeviceLoop(IMMDeviceEnumerator *enumerator,
 				break;
 			}
 
-		} else {
-			blog(LOG_INFO,
-			     "[WASAPISource::InitDeviceLoop][count %d]: Could not get device name ",
-			     retryInitDeviceCounter);
 		}
 		retryInitDeviceCounter++;
 		Sleep(sleepMs);
@@ -452,8 +449,8 @@ void WASAPISource::Initialize()
 	res = InitDeviceLoop(enumerator, MAX_RETRY_INIT_DEVICE_COUNTER, 500);
 
 	if (FAILED(res)) {
-		return;
-		//throw HRError("Failed to init device", res);
+		// fail early
+		throw HRError("Failed to init device", res);
 	}
 
 	HRESULT resSample;


### PR DESCRIPTION
This addresses https://logitech.slack.com/archives/CQA8J45PX/p1606107330352500 in the following way:

For a given device ID `device_1`, it has to successfully get the name for the first time, call it `device_name_1`
Next, somewhere during the initialization or during capture packet phase, the communication with `device_1` is lost, so recapture thread kicks in
Recapture thread runs `InitLoop` which already has the `device_name_1`  name. it then searches the list of audio endpoints for a new device ID which has device name `device_name_1` (The assumption is that somehow the device ID has changed for `device_name_1`), then refreshes the ID into `device_2` for example
