### PR TITLE
prevent switching multiple rendering state while mixing audio

### DIFF
--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -480,6 +480,8 @@ extern bool audio_callback(void *param, uint64_t start_ts_in,
 			   struct audio_output_data *main_mixes,
 			   struct audio_output_data *streaming_mixes,
 			   struct audio_output_data *recording_mixes);
+extern void cache_multiple_rendering(void);
+extern bool get_cached_multiple_rendering(void);
 
 extern void
 start_raw_video(video_t *video, const struct video_scale_info *conversion,


### PR DESCRIPTION
Array for audio data **audio_output_data** allocated on stack in **input_and_output()**
It cleaned and initialized with data based on in which **rendering mode** we are right now. Only needed part of data cleaned. Parts of array what was not cleaned still contain data from previous calls of other functions as this array allocated on a stack. 

And then this array used in calls like **mix_audio().** 
If at this moment rendering mode was changed then **mix_audio()** will use part of **audio_output_data** what was not initialized. 

As a solution state of multiple rendering be cached at the start of each run in audio_thread. So all function called from here will work with same rendering mode. 

also **enum obs_video_rendering_mode** replaced with **enum obs_audio_rendering_mode** to make code more clear. it was not produce any functional issues but light confusion for who read code. 