### PR TITLE
reset source video ts when file switched to audio only

### DIFF
--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -834,6 +834,8 @@ static inline bool mp_media_thread(mp_media_t *m)
 	if (!mp_media_reset(m)) {
 		return false;
 	}
+	if (m->ready_cb)
+		m->ready_cb(m->opaque);
 
 	for (;;) {
 		bool reset, kill, is_active, seek, pause, reset_time;
@@ -1026,6 +1028,7 @@ bool mp_media_init(mp_media_t *media, const struct mp_media_info *info)
 	media->v_cb = info->v_cb;
 	media->a_cb = info->a_cb;
 	media->stop_cb = info->stop_cb;
+	media->ready_cb = info->ready_cb;
 	media->v_seek_cb = info->v_seek_cb;
 	media->v_preload_cb = info->v_preload_cb;
 	media->force_range = info->force_range;

--- a/deps/media-playback/media-playback/media.h
+++ b/deps/media-playback/media-playback/media.h
@@ -42,6 +42,7 @@ extern "C" {
 typedef void (*mp_video_cb)(void *opaque, struct obs_source_frame *frame);
 typedef void (*mp_audio_cb)(void *opaque, struct obs_source_audio *audio);
 typedef void (*mp_stop_cb)(void *opaque);
+typedef void (*mp_ready_cb)(void *opaque);
 
 struct cached_data {
 	int index;
@@ -57,6 +58,7 @@ struct mp_media {
 	mp_video_cb v_preload_cb;
 	mp_video_cb v_seek_cb;
 	mp_stop_cb stop_cb;
+	mp_ready_cb ready_cb;
 	mp_video_cb v_cb;
 	mp_audio_cb a_cb;
 	void *opaque;
@@ -129,6 +131,7 @@ struct mp_media_info {
 	mp_video_cb v_seek_cb;
 	mp_audio_cb a_cb;
 	mp_stop_cb stop_cb;
+	mp_ready_cb ready_cb;
 
 	const char *path;
 	const char *format;

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -2888,6 +2888,16 @@ void obs_source_output_video2(obs_source_t *source,
 	obs_source_output_video_internal(source, &new_frame);
 }
 
+void obs_source_reset_video(obs_source_t *source)
+{
+	obs_source_output_video(source, NULL);
+	pthread_mutex_lock(&source->async_mutex);
+	free_async_cache(source);
+	clean_cache(source);
+	source->last_frame_ts = 0;
+	pthread_mutex_unlock(&source->async_mutex);
+}
+
 void obs_source_set_async_rotation(obs_source_t *source, long rotation)
 {
 	if (source)

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1310,6 +1310,9 @@ EXPORT struct obs_source_frame *obs_source_get_frame(obs_source_t *source);
 EXPORT void obs_source_release_frame(obs_source_t *source,
 				     struct obs_source_frame *frame);
 
+/** Reset varables for video played before */
+EXPORT void obs_source_reset_video(obs_source_t *source);
+
 /**
  * Default RGB filter handler for generic effect filters.  Processes the
  * filter chain and renders them to texture if needed, then the filter is

--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -311,6 +311,15 @@ static void media_stopped(void *opaque)
 	obs_source_media_ended(s->source);
 }
 
+static void media_ready(void *opaque)
+{
+	struct ffmpeg_source *s = opaque;
+	blog(LOG_DEBUG, "[MP4MP3]: media_ready %d %d", s->media.has_video?1:0, s->media.has_audio?1:0);
+	if (!s->media.has_video) {
+		obs_source_reset_video(s->source);
+	}
+}
+
 static void ffmpeg_source_open(struct ffmpeg_source *s)
 {
 	if (s->input && *s->input) {
@@ -321,6 +330,7 @@ static void ffmpeg_source_open(struct ffmpeg_source *s)
 			.v_seek_cb = seek_frame,
 			.a_cb = get_audio,
 			.stop_cb = media_stopped,
+			.ready_cb = media_ready,
 			.path = s->input,
 			.format = s->input_format,
 			.buffering = s->buffering_mb * 1024 * 1024,


### PR DESCRIPTION
fix for issue when switching from video file to audio only file. 
when it happens a ffmpeg source does not notify a source what there is no more video frames. 
it can lead to last frame remaining on a screen. 
and to no audio played through monitoring as code expect timestamp from a video frame to match audio frame timestamp. 