### PR TITLE
Add extra checks for null url

### DIFF
--- a/plugins/obs-outputs/librtmp/parseurl.c
+++ b/plugins/obs-outputs/librtmp/parseurl.c
@@ -39,6 +39,10 @@ int RTMP_ParseURL(const char *url, int *protocol, AVal *host, unsigned int *port
     /* Old School Parsing */
 
     /* look for usual :// pattern */
+    if (!url) {
+        RTMP_Log(RTMP_LOGERROR, "RTMP URL: Url is null!");
+        return FALSE;
+    }
     p = strstr(url, "://");
     if(!p)
     {

--- a/plugins/obs-outputs/librtmp/rtmp.c
+++ b/plugins/obs-outputs/librtmp/rtmp.c
@@ -658,6 +658,9 @@ int RTMP_SetupURL(RTMP *r, char *url)
 {
     int ret, len;
     unsigned int port = 0;
+    if (!url) {
+        return FALSE;
+    }
 
     len = (int)strlen(url);
     ret = RTMP_ParseURL(url, &r->Link.protocol, &r->Link.hostname,


### PR DESCRIPTION
This is also handled by dstr.h `dstr_is_empty` but it's good to have these checks as well.