### PR TITLE
Mark excluded DLLs

### DIFF
--- a/libobs/obs-module.c
+++ b/libobs/obs-module.c
@@ -100,6 +100,21 @@ extern void reset_win32_symbol_paths(void);
 int obs_open_module(obs_module_t **module, const char *path,
 		    const char *data_path)
 {
+     static char* excluded_patterns[] = {
+        "libEGL",
+        "libGLES",   
+        "obs-browser-page",
+        "chrome_elf",
+        "facemask",
+        "libcef"
+    };
+    for (size_t idx=0; idx < sizeof(excluded_patterns) / sizeof(char*); idx++) {
+        if (strstr(path, excluded_patterns[idx])) {
+            blog(LOG_INFO, "Excluding %s from openmodule ", path);
+            return MODULE_SUCCESS;
+        }
+    }
+
 	struct obs_module mod = {0};
 	int errorcode;
 
@@ -275,7 +290,6 @@ void obs_add_module_path(const char *bin, const char *data)
 static void load_all_callback(void *param, const struct obs_module_info *info)
 {
 	obs_module_t *module;
-
 	int code = obs_open_module(&module, info->bin_path, info->data_path);
 	if (code != MODULE_SUCCESS) {
 		blog(LOG_DEBUG, "Failed to load module file '%s': %d",
@@ -374,6 +388,7 @@ static void process_found_module(struct obs_module_path *omp, const char *path,
 				 obs_find_module_callback_t callback,
 				 void *param)
 {
+   
 	struct obs_module_info info;
 	struct dstr name = {0};
 	struct dstr parsed_bin_path = {0};

--- a/libobs/obs-module.c
+++ b/libobs/obs-module.c
@@ -100,20 +100,20 @@ extern void reset_win32_symbol_paths(void);
 int obs_open_module(obs_module_t **module, const char *path,
 		    const char *data_path)
 {
-     static char* excluded_patterns[] = {
-        "libEGL",
-        "libGLES",   
-        "obs-browser-page",
-        "chrome_elf",
-        "facemask",
-        "libcef"
-    };
-    for (size_t idx=0; idx < sizeof(excluded_patterns) / sizeof(char*); idx++) {
-        if (strstr(path, excluded_patterns[idx])) {
-            blog(LOG_INFO, "Excluding %s from openmodule ", path);
-            return MODULE_SUCCESS;
-        }
-    }
+	static char* excluded_patterns[] = {
+	"libEGL",
+	"libGLES",   
+	"obs-browser-page",
+	"chrome_elf",
+	"facemask",
+	"libcef"
+	};
+	for (size_t idx=0; idx < sizeof(excluded_patterns) / sizeof(char*); idx++) {
+		if (strstr(path, excluded_patterns[idx])) {
+			blog(LOG_INFO, "Excluding %s from openmodule ", path);
+			return MODULE_SUCCESS;
+		}
+	}
 
 	struct obs_module mod = {0};
 	int errorcode;


### PR DESCRIPTION
do not attempt to load some DLLs which do not contain OBS related functions