### PR TITLE
Wincapture: do not use display_stream_update

### DIFF
--- a/plugins/mac-capture/mac-display-capture.m
+++ b/plugins/mac-capture/mac-display-capture.m
@@ -14,7 +14,7 @@ static inline bool crop_mode_valid(enum crop_mode mode)
 	return CROP_NONE <= mode && mode < CROP_INVALID;
 }
 
-static void destroy_display_stream(struct screen_capture *dc)
+void destroy_display_stream(struct screen_capture *dc)
 {
 	if (dc->disp) {
 		CGDisplayStreamStop(dc->disp);

--- a/plugins/mac-capture/mac-display-capture.m
+++ b/plugins/mac-capture/mac-display-capture.m
@@ -14,7 +14,7 @@ static inline bool crop_mode_valid(enum crop_mode mode)
 	return CROP_NONE <= mode && mode < CROP_INVALID;
 }
 
-void destroy_display_stream(struct screen_capture *dc)
+static void destroy_display_stream(struct screen_capture *dc)
 {
 	if (dc->disp) {
 		CGDisplayStreamStop(dc->disp);

--- a/plugins/mac-capture/mac-display-capture.m
+++ b/plugins/mac-capture/mac-display-capture.m
@@ -51,7 +51,7 @@ static void destroy_display_stream(struct screen_capture *dc)
 	os_event_destroy(dc->disp_finished);
 }
 
-static void display_capture_destroy(void *data)
+void display_capture_destroy(void *data)
 {
 	struct screen_capture *dc = data;
 
@@ -137,7 +137,7 @@ static void *display_capture_create(obs_data_t *settings, obs_source_t *source)
 	dc->display = obs_data_get_int(settings, "display");
 	pthread_mutex_init(&dc->mutex, NULL);
 
-	if (!init_screen_stream(dc))
+	if (!init_screen_stream(dc, true))
 		goto fail;
 
 	return dc;
@@ -390,7 +390,7 @@ static void display_capture_update(void *data, obs_data_t *settings)
 	destroy_display_stream(dc);
 	dc->display = display;
 	dc->hide_cursor = !show_cursor;
-	init_screen_stream(dc);
+	init_screen_stream(dc, true);
 
 	obs_leave_graphics();
 }

--- a/plugins/mac-capture/mac-window-capture.m
+++ b/plugins/mac-capture/mac-window-capture.m
@@ -112,12 +112,11 @@ static void _window_capture_destroy(void *data)
 	os_event_destroy(cap->stop_event);
 
 	pthread_mutex_destroy(&cap->dc->mutex);
-    if (cap->dc->disp) {
-        CGDisplayStreamStop(cap->dc->disp);
-        CFRelease(cap->dc->disp);
+	if (cap->dc->disp) {
+		CFRelease(cap->dc->disp);
 		cap->dc->disp = NULL;
-    }
-    if (cap->dc->screen) {
+	}
+	if (cap->dc->screen) {
 		[cap->dc->screen release];
 		cap->dc->screen = nil;
 	}

--- a/plugins/mac-capture/mac-window-capture.m
+++ b/plugins/mac-capture/mac-window-capture.m
@@ -5,8 +5,6 @@
 
 #include "screen-utils.h"
 
-extern void destroy_display_stream(struct screen_capture *dc);
-
 struct window_capture {
 	obs_source_t *source;
 	struct screen_capture* dc;
@@ -111,7 +109,7 @@ static inline void *window_capture_create_internal(obs_data_t *settings,
 		return NULL;
 	}
 	wc->dc->display = obs_data_get_int(settings, "display");
-	pthread_mutex_init(&wc->dc->mutex, NULL); 
+	pthread_mutex_init(&wc->dc->mutex, NULL); //?
 
 	if (!init_screen_stream(wc->dc)) {
 		blog(LOG_INFO, "[window-capture] - Display Capture Init Fail");
@@ -155,17 +153,6 @@ static void window_capture_destroy(void *data)
 
 	os_event_destroy(cap->capture_event);
 	os_event_destroy(cap->stop_event);
-
-    obs_enter_graphics();
-
-	destroy_display_stream(cap->dc);
-
-	if (cap->dc->sampler)
-		gs_samplerstate_destroy(cap->dc->sampler);
-	if (cap->dc->vertbuf)
-		gs_vertexbuffer_destroy(cap->dc->vertbuf);
-
-	obs_leave_graphics();
 
 	destroy_window(&cap->window);
 	pthread_mutex_destroy(&cap->dc->mutex);

--- a/plugins/mac-capture/mac-window-capture.m
+++ b/plugins/mac-capture/mac-window-capture.m
@@ -7,8 +7,10 @@
 
 struct window_capture {
 	obs_source_t *source;
+    struct screen_capture* dc;
 
 	struct cocoa_window window;
+
 
 	//CGRect              bounds;
 	//CGWindowListOption  window_option;
@@ -101,19 +103,19 @@ static inline void *window_capture_create_internal(obs_data_t *settings,
 
 	blog(LOG_INFO, "[window-capture] - Init Display Capture for permissions dialog");
 	
-	struct screen_capture *dc = bzalloc(sizeof(struct screen_capture));
-	if (!dc) {
+	wc->dc = bzalloc(sizeof(struct screen_capture));
+	if (!wc->dc) {
 		blog(LOG_INFO, "[window-capture] - Display Capture Alloc Fail"); 
 		return NULL;
 	}
-	dc->display = obs_data_get_int(settings, "display");
+	wc->dc->display = obs_data_get_int(settings, "display");
+	pthread_mutex_init(&wc->dc->mutex, NULL); //?
 
-	if (!init_screen_stream(dc)) {
+	if (!init_screen_stream(wc->dc)) {
 		blog(LOG_INFO, "[window-capture] - Display Capture Init Fail");
-		bfree(dc);
+		bfree(wc->dc);
 		return NULL;
 	}
-	bfree(dc);
 
 	init_window(&wc->window, settings);
 
@@ -153,7 +155,9 @@ static void window_capture_destroy(void *data)
 	os_event_destroy(cap->stop_event);
 
 	destroy_window(&cap->window);
-
+	pthread_mutex_destroy(&cap->dc->mutex);
+	bfree(cap->dc);
+    
 	bfree(cap);
 }
 

--- a/plugins/mac-capture/mac-window-capture.m
+++ b/plugins/mac-capture/mac-window-capture.m
@@ -7,7 +7,7 @@
 
 struct window_capture {
 	obs_source_t *source;
-    struct screen_capture* dc;
+	struct screen_capture* dc;
 
 	struct cocoa_window window;
 

--- a/plugins/mac-capture/screen-utils.h
+++ b/plugins/mac-capture/screen-utils.h
@@ -42,6 +42,6 @@ struct screen_capture {
 	pthread_mutex_t mutex;
 };
 
-bool init_screen_stream(struct screen_capture *dc);
+bool init_screen_stream(struct screen_capture *dc, bool update_display_stream);
 
 #endif

--- a/plugins/mac-capture/screen-utils.m
+++ b/plugins/mac-capture/screen-utils.m
@@ -59,6 +59,7 @@ static inline void display_stream_update(struct screen_capture *dc,
 	}
 
 	size_t dropped_frames = CGDisplayStreamUpdateGetDropCount(update_ref);
+ 
 	if (dropped_frames > 0)
 		blog(LOG_INFO, "%s: Dropped %zu frames",
 		     obs_source_get_name(dc->source), dropped_frames);

--- a/plugins/mac-capture/screen-utils.m
+++ b/plugins/mac-capture/screen-utils.m
@@ -59,7 +59,6 @@ static inline void display_stream_update(struct screen_capture *dc,
 	}
 
 	size_t dropped_frames = CGDisplayStreamUpdateGetDropCount(update_ref);
- 
 	if (dropped_frames > 0)
 		blog(LOG_INFO, "%s: Dropped %zu frames",
 		     obs_source_get_name(dc->source), dropped_frames);


### PR DESCRIPTION
Wincapture: do not use display_stream_update  , as not needed for displaying the permissions dialog