### PR TITLE
obs-module:  possible crash 'load_all_callback' uninitialized pointer

### DIFF
--- a/libobs/obs-module.c
+++ b/libobs/obs-module.c
@@ -293,7 +293,7 @@ void obs_add_module_path(const char *bin, const char *data)
 
 static void load_all_callback(void *param, const struct obs_module_info *info)
 {
-	obs_module_t *module;
+	obs_module_t *module = NULL;
 
 	if (!os_is_obs_plugin(info->bin_path))
 		blog(LOG_WARNING, "Skipping module '%s', not an OBS plugin",
@@ -306,6 +306,7 @@ static void load_all_callback(void *param, const struct obs_module_info *info)
 		return;
 	}
 
+	if (module != NULL)
 	obs_init_module(module);
 
 	UNUSED_PARAMETER(param);

--- a/libobs/obs-module.c
+++ b/libobs/obs-module.c
@@ -307,7 +307,7 @@ static void load_all_callback(void *param, const struct obs_module_info *info)
 	}
 
 	if (module != NULL)
-	obs_init_module(module);
+		obs_init_module(module);
 
 	UNUSED_PARAMETER(param);
 }


### PR DESCRIPTION
obs_open_module can return success without initializing the parameter due to some kind of "skip" logic that function has