### PR TITLE
Adding Eddy's fix for obs-studio's crash on launch

### DIFF
--- a/libobs/obs-nix.c
+++ b/libobs/obs-nix.c
@@ -51,13 +51,18 @@ const char *get_module_extension(void)
 #define BIT_STRING "32bit"
 #endif
 
-static const char *module_bin[] = {"../../obs-plugins/" BIT_STRING,
-				   OBS_INSTALL_PREFIX
-				   "/" OBS_PLUGIN_DESTINATION};
+#define FLATPAK_PLUGIN_PATH "/app/plugins"
+
+static const char *module_bin[] = {
+	"../../obs-plugins/" BIT_STRING,
+	OBS_INSTALL_PREFIX "/" OBS_PLUGIN_DESTINATION,
+	FLATPAK_PLUGIN_PATH "/" OBS_PLUGIN_DESTINATION,
+};
 
 static const char *module_data[] = {
 	OBS_DATA_PATH "/obs-plugins/%module%",
 	OBS_INSTALL_DATA_PATH "/obs-plugins/%module%",
+	FLATPAK_PLUGIN_PATH "/share/obs/obs-plugins/%module%",
 };
 
 static const int module_patterns_size =

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -937,6 +937,10 @@ char *obs_find_data_file(const char *file)
 {
 	struct dstr path = {0};
 
+	char *result = find_libobs_data_file(file);
+	if (result)
+		return result;
+
 	for (size_t i = 0; i < core_module_paths.num; ++i) {
 		if (check_path(file, core_module_paths.array[i].array, &path))
 			return path.array;


### PR DESCRIPTION
Adding Eddy's fix because we don't load all plugins and our version of OBS-Studio crashes on launch without this code.