### PR TITLE
Protect obs->video stop/start with mutex

### DIFF
--- a/libobs/media-io/video-io.c
+++ b/libobs/media-io/video-io.c
@@ -556,6 +556,8 @@ void video_output_stop(video_t *video)
 	if (!video)
 		return;
 
+	pthread_mutex_lock(&obs->video_stop_mutex);
+
 	if (video->initialized) {
 		video->initialized = false;
 		video->stop = true;
@@ -565,6 +567,8 @@ void video_output_stop(video_t *video)
 		pthread_mutex_destroy(&video->data_mutex);
 		pthread_mutex_destroy(&video->input_mutex);
 	}
+
+	pthread_mutex_unlock(&obs->video_stop_mutex);
 }
 
 bool video_output_stopped(video_t *video)

--- a/libobs/media-io/video-io.c
+++ b/libobs/media-io/video-io.c
@@ -305,6 +305,8 @@ void video_output_close(video_t *video)
 {
 	if (!video)
 		return;
+	
+	pthread_mutex_lock(&obs->video_stop_mutex);
 
 	video_output_stop(video);
 
@@ -320,6 +322,8 @@ void video_output_close(video_t *video)
 	}
 
 	bfree(video);
+
+	pthread_mutex_unlock(&obs->video_stop_mutex);
 }
 
 static size_t video_get_input_idx(const video_t *video,

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -448,6 +448,8 @@ struct obs_core {
 	enum obs_audio_rendering_mode audio_rendering_mode;
 
 	obs_task_handler_t ui_task_handler;
+
+	pthread_mutex_t video_stop_mutex;
 };
 
 extern struct obs_core *obs;

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -1046,8 +1046,9 @@ static const char *render_displays_name = "render_displays";
 static const char *output_frame_name = "output_frame";
 bool obs_graphics_thread_loop(struct obs_graphics_context *context)
 {
-	/* defer loop break to clean up sources */
-	const bool stop_requested = video_output_stopped(obs->video.video);
+	// This should only fail to lock if there's a shutdown happening 
+	if (pthread_mutex_trylock(&obs->video_stop_mutex) != 0)
+		return false;
 
 	uint64_t frame_start = os_gettime_ns();
 	uint64_t frame_time_ns;
@@ -1127,8 +1128,9 @@ bool obs_graphics_thread_loop(struct obs_graphics_context *context)
 		context->fps_total_ns = 0;
 		context->fps_total_frames = 0;
 	}
-
-	return !stop_requested;
+	
+	pthread_mutex_unlock(&obs->video_stop_mutex);
+	return !video_output_stopped(obs->video.video);
 }
 
 void *obs_graphics_thread(void *param)

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -1048,7 +1048,7 @@ bool obs_graphics_thread_loop(struct obs_graphics_context *context)
 {
 	// This should only fail to lock if there's a shutdown happening 
 	if (pthread_mutex_trylock(&obs->video_stop_mutex) != 0)
-		return false;
+		return !video_output_stopped(obs->video.video);
 
 	uint64_t frame_start = os_gettime_ns();
 	uint64_t frame_time_ns;


### PR DESCRIPTION
The interaction between these two functions was not thread safe
- obs_graphics_thread_loop
- stop_video
- obs_reset_video