### PR TITLE
obs->video.video_thread joined before destroy mutexes

### DIFF
--- a/libobs/media-io/video-io.c
+++ b/libobs/media-io/video-io.c
@@ -305,8 +305,6 @@ void video_output_close(video_t *video)
 {
 	if (!video)
 		return;
-	
-	pthread_mutex_lock(&obs->video_stop_mutex);
 
 	video_output_stop(video);
 
@@ -322,8 +320,6 @@ void video_output_close(video_t *video)
 	}
 
 	bfree(video);
-
-	pthread_mutex_unlock(&obs->video_stop_mutex);
 }
 
 static size_t video_get_input_idx(const video_t *video,
@@ -560,8 +556,6 @@ void video_output_stop(video_t *video)
 	if (!video)
 		return;
 
-	pthread_mutex_lock(&obs->video_stop_mutex);
-
 	if (video->initialized) {
 		video->initialized = false;
 		video->stop = true;
@@ -571,8 +565,6 @@ void video_output_stop(video_t *video)
 		pthread_mutex_destroy(&video->data_mutex);
 		pthread_mutex_destroy(&video->input_mutex);
 	}
-
-	pthread_mutex_unlock(&obs->video_stop_mutex);
 }
 
 bool video_output_stopped(video_t *video)

--- a/libobs/media-io/video-io.c
+++ b/libobs/media-io/video-io.c
@@ -561,6 +561,16 @@ void video_output_stop(video_t *video)
 		video->stop = true;
 		os_sem_post(video->update_semaphore);
 		pthread_join(video->thread, &thread_ret);
+		
+		if (video == obs->video.video)
+		{
+			// The graphics thread must end before mutexes are destroyed
+			if (obs->video.thread_initialized) {
+				pthread_join(obs->video.video_thread, &thread_ret);
+				obs->video.thread_initialized = false;
+			}
+		}
+
 		os_sem_destroy(video->update_semaphore);
 		pthread_mutex_destroy(&video->data_mutex);
 		pthread_mutex_destroy(&video->input_mutex);

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -448,8 +448,6 @@ struct obs_core {
 	enum obs_audio_rendering_mode audio_rendering_mode;
 
 	obs_task_handler_t ui_task_handler;
-
-	pthread_mutex_t video_stop_mutex;
 };
 
 extern struct obs_core *obs;

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -1045,9 +1045,8 @@ static const char *render_displays_name = "render_displays";
 static const char *output_frame_name = "output_frame";
 bool obs_graphics_thread_loop(struct obs_graphics_context *context)
 {
-	// This should only fail to lock if there's a shutdown happening 
-	if (pthread_mutex_trylock(&obs->video_stop_mutex) != 0)
-		return !video_output_stopped(obs->video.video);
+	/* defer loop break to clean up sources */
+	const bool stop_requested = video_output_stopped(obs->video.video);
 
 	uint64_t frame_start = os_gettime_ns();
 	uint64_t frame_time_ns;
@@ -1127,9 +1126,8 @@ bool obs_graphics_thread_loop(struct obs_graphics_context *context)
 		context->fps_total_ns = 0;
 		context->fps_total_frames = 0;
 	}
-	
-	pthread_mutex_unlock(&obs->video_stop_mutex);
-	return !video_output_stopped(obs->video.video);
+
+	return !stop_requested;
 }
 
 void *obs_graphics_thread(void *param)

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -456,8 +456,6 @@ static int obs_init_video(struct obs_video_info *ovi)
 
 static void stop_video(void)
 {
-	pthread_mutex_lock(&obs->video_stop_mutex);
-
 	struct obs_core_video *video = &obs->video;
 	void *thread_retval;
 
@@ -468,14 +466,10 @@ static void stop_video(void)
 			video->thread_initialized = false;
 		}
 	}
-
-	pthread_mutex_unlock(&obs->video_stop_mutex);
 }
 
 static void obs_free_video(void)
 {
-	pthread_mutex_lock(&obs->video_stop_mutex);
-
 	struct obs_core_video *video = &obs->video;
 
 	if (video->video) {
@@ -573,8 +567,6 @@ static void obs_free_video(void)
 		video->gpu_encoder_active = 0;
 		video->cur_texture = 0;
 	}
-
-	pthread_mutex_unlock(&obs->video_stop_mutex);
 }
 
 static void obs_free_graphics(void)
@@ -887,7 +879,6 @@ static bool obs_init(const char *locale, const char *module_config_path,
 	pthread_mutex_init_value(&obs->audio.monitoring_mutex);
 	pthread_mutex_init_value(&obs->video.gpu_encoder_mutex);
 	pthread_mutex_init_value(&obs->video.task_mutex);
-	pthread_mutex_init_recursive(&obs->video_stop_mutex);
 
 	obs->name_store_owned = !store;
 	obs->name_store = store ? store : profiler_name_store_create();
@@ -1087,8 +1078,6 @@ void obs_shutdown(void)
 	if (obs->name_store_owned)
 		profiler_name_store_free(obs->name_store);
 
-	pthread_mutex_destroy(&obs->video_stop_mutex);
-
 	bfree(obs->module_config_path);
 	bfree(obs->locale);
 	bfree(obs);
@@ -1160,8 +1149,6 @@ int obs_reset_video(struct obs_video_info *ovi)
 	    !size_valid(ovi->base_width, ovi->base_height))
 		return OBS_VIDEO_INVALID_PARAM;
 
-	pthread_mutex_lock(&obs->video_stop_mutex);
-
 	struct obs_core_video *video = &obs->video;
 
 	blog(LOG_INFO, "About to stop and reset video");
@@ -1177,7 +1164,6 @@ int obs_reset_video(struct obs_video_info *ovi)
 		int errorcode = obs_init_graphics(ovi);
 		if (errorcode != OBS_VIDEO_SUCCESS) {
 			obs_free_graphics();
-			pthread_mutex_unlock(&obs->video_stop_mutex);
 			return errorcode;
 		}
 	}
@@ -1223,7 +1209,6 @@ int obs_reset_video(struct obs_video_info *ovi)
 	     get_video_format_name(ovi->output_format),
 	     yuv ? yuv_format : "None", yuv ? "/" : "", yuv ? yuv_range : "");
 
-	pthread_mutex_unlock(&obs->video_stop_mutex);
 	return obs_init_video(ovi);
 }
 

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -461,10 +461,6 @@ static void stop_video(void)
 
 	if (video->video) {
 		video_output_stop(video->video);
-		if (video->thread_initialized) {
-			pthread_join(video->video_thread, &thread_retval);
-			video->thread_initialized = false;
-		}
 	}
 }
 


### PR DESCRIPTION
Moved this block of code into the function above it, but before the mutexes are destroyed. The video thread should be assured to end because "video->stop" is set to true. Likewise, that video thread must not remain active when stop is signaled.

- Reverts this commit
https://github.com/stream-labs/obs-studio/commit/b4656f188cec9c088088a1b05e5a9caf3d9a939e