### PR TITLE
libobs-winrt: don't use active state to check if the window exists

### DIFF
--- a/libobs-winrt/winrt-capture.cpp
+++ b/libobs-winrt/winrt-capture.cpp
@@ -333,8 +333,6 @@ extern "C" EXPORT BOOL winrt_capture_active(const struct winrt_capture *capture)
 static void winrt_capture_device_loss_rebuild(void *device_void, void *data)
 {
 	winrt_capture *capture = static_cast<winrt_capture *>(data);
-	if (!winrt_capture_active(capture))
-		return;
 
 	auto activation_factory = winrt::get_activation_factory<
 		winrt::Windows::Graphics::Capture::GraphicsCaptureItem>();


### PR DESCRIPTION
### Description
Revert added check to the `active` state when rebuilding the device. This state is not only used to tell if the window still exists but also to say if we released the device or not.

### Motivation and Context
We are wrongly assuming that the window doesn't exist and do not allocate memory and capture. This is causing a crash later on when trying to capture the cursor.

### How Has This Been Tested?
I verified that the old crash is still fix and that the new cursor crash doesn't happen anymore.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the streamlabs branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
