### PR TITLE
slobs_ci: fix sentry org

### DIFF
--- a/slobs_CI/sentry-osx.py
+++ b/slobs_CI/sentry-osx.py
@@ -7,13 +7,13 @@ def process_sentry(directory):
             if 'lib' in file or 'obs' in file or '.so' in file or '.dylib' in file:
                 path = os.path.join(directory, file)
                 os.system("dsymutil " + path)
-                os.system("sentry-cli --auth-token ${SENTRY_AUTH_TOKEN} upload-dif --org streamlabs-obs --project obs-server " + path + ".dSYM/Contents/Resources/DWARF/" + file)
+                os.system("sentry-cli --auth-token ${SENTRY_AUTH_TOKEN} upload-dif --org streamlabs-desktop --project obs-server " + path + ".dSYM/Contents/Resources/DWARF/" + file)
     for r, d, f in os.walk(directory):
         for file in f:
             if 'lib' in file or 'obs' in file or '.so' in file or '.dylib' in file:
                 path = os.path.join(directory, file)
                 os.system("dsymutil " + path)
-                os.system("sentry-cli --auth-token ${SENTRY_AUTH_TOKEN} upload-dif --org streamlabs-obs --project obs-server-preview " + path + ".dSYM/Contents/Resources/DWARF/" + file)
+                os.system("sentry-cli --auth-token ${SENTRY_AUTH_TOKEN} upload-dif --org streamlabs-desktop --project obs-server-preview " + path + ".dSYM/Contents/Resources/DWARF/" + file)
 
 # Upload obs debug files
 process_sentry(os.path.join(os.environ['PWD'], 'build', 'rundir', os.environ['BUILDCONFIG'], 'bin'))


### PR DESCRIPTION
### Description
Rename Sentry organization to match the new name.

### Motivation and Context
Uploading debug information on Sentry has been broken on MacOS since we renamed the organization.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
