### PR TITLE
Fix mac hotkeys init leading to a crash

### DIFF
--- a/libobs/obs-cocoa.m
+++ b/libobs/obs-cocoa.m
@@ -1560,11 +1560,10 @@ static bool init_hotkeys_platform(obs_hotkeys_platform_t **plat_)
 
 	if (!plat->layout_data) {
 		blog(LOG_ERROR, "hotkeys-cocoa: Failed getting LayoutData");
-		goto fail;
+	} else {
+		CFRetain(plat->layout_data);
+		plat->layout = (UCKeyboardLayout *)CFDataGetBytePtr(plat->layout_data);
 	}
-
-	CFRetain(plat->layout_data);
-	plat->layout = (UCKeyboardLayout *)CFDataGetBytePtr(plat->layout_data);
 
 	plat->manager =
 		IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone);
@@ -1573,10 +1572,9 @@ static bool init_hotkeys_platform(obs_hotkeys_platform_t **plat_)
 		IOHIDManagerOpen(plat->manager, kIOHIDOptionsTypeNone);
 	if (openStatus != kIOReturnSuccess) {
 		blog(LOG_ERROR, "hotkeys-cocoa: Failed opening HIDManager");
-		goto fail;
+	} else {
+		init_keyboard(plat);
 	}
-
-	init_keyboard(plat);
 
 	return true;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Do not fail whole obs initialization on hotkeys init error. 
We have some sentry reports pointing to this issue. With a crash happening on cleaning this not initialized hotkeys. 
Also could be issue for users who have reported crash on launch. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This part of code was skipped on prev releases. 
We had to unlock it to have hotkeys object fully initialized to fix a crash on memory corruption. 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Cannot reproduce. 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
