### PR TITLE
skip hotkeys functionality

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -26,6 +26,7 @@
 struct obs_core *obs = NULL;
 
 static THREAD_LOCAL bool is_ui_thread = false;
+const bool key_processing_enabled = true;
 
 extern void add_default_module_paths(void);
 extern char *find_libobs_data_file(const char *file);
@@ -794,7 +795,6 @@ static inline bool obs_init_hotkeys(void)
 {
 	struct obs_core_hotkeys *hotkeys = &obs->hotkeys;
 	bool success = false;
-	const bool use_thread = false;
 
 	assert(hotkeys != NULL);
 
@@ -808,15 +808,16 @@ static inline bool obs_init_hotkeys(void)
 	hotkeys->sceneitem_show = bstrdup("Show '%1'");
 	hotkeys->sceneitem_hide = bstrdup("Hide '%1'");
 
-	if (!obs_hotkeys_platform_init(hotkeys))
-		return false;
+	if (key_processing_enabled)
+		if (!obs_hotkeys_platform_init(hotkeys))
+			return false;
 
 	if (pthread_mutex_init_recursive(&hotkeys->mutex) != 0)
 		goto fail;
 
 	if (os_event_init(&hotkeys->stop_event, OS_EVENT_TYPE_MANUAL) != 0)
 		goto fail;
-	if (use_thread) {
+	if (key_processing_enabled) {
 		if (pthread_create(&hotkeys->hotkey_thread, NULL, obs_hotkey_thread,
 			   NULL))
 			goto fail;
@@ -858,7 +859,9 @@ static inline void obs_free_hotkeys(void)
 
 	obs_hotkey_name_map_free();
 
-	obs_hotkeys_platform_free(hotkeys);
+	if (key_processing_enabled)
+		obs_hotkeys_platform_free(hotkeys);
+
 	pthread_mutex_destroy(&hotkeys->mutex);
 }
 

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -26,7 +26,7 @@
 struct obs_core *obs = NULL;
 
 static THREAD_LOCAL bool is_ui_thread = false;
-const bool key_processing_enabled = true;
+const bool key_processing_enabled = false;
 
 extern void add_default_module_paths(void);
 extern char *find_libobs_data_file(const char *file);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Skip both initialization and use of platform specific functionality of hotkeys. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
We receive reports of crashes on launch on macOS.
One happens inside TISCopyCurrentKeyboardLayoutInputSource function. 
And another is abort with a message "Text Input Sources or Text Services Manager API is being called in two threads concurrently." 
As we don't use native hotkeys functionality on macOS skipping it should fix this two crashes. 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
