### PR TITLE
Add signals to the recording output

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -400,7 +400,8 @@ int deactivate(struct ffmpeg_muxer *stream, int code)
 		     dstr_is_empty(&stream->printable_path)
 			     ? stream->path.array
 			     : stream->printable_path.array);
-		do_output_signal(stream->output, "wrote");
+		if (strcmp(stream->output->info.id, "ffmpeg_muxer") == 0)
+			do_output_signal(stream->output, "wrote");
 	}
 
 	if (code) {

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -80,6 +80,13 @@ static void ffmpeg_mux_destroy(void *data)
 	bfree(stream);
 }
 
+static void get_last_file(void *data, calldata_t *cd)
+{
+	struct ffmpeg_muxer *stream = data;
+	if (!os_atomic_load_bool(&stream->muxing))
+		calldata_set_string(cd, "path", stream->path.array);
+}
+
 static void *ffmpeg_mux_create(obs_data_t *settings, obs_output_t *output)
 {
 	struct ffmpeg_muxer *stream = bzalloc(sizeof(*stream));
@@ -87,6 +94,10 @@ static void *ffmpeg_mux_create(obs_data_t *settings, obs_output_t *output)
 
 	if (obs_output_get_flags(output) & OBS_OUTPUT_SERVICE)
 		stream->is_network = true;
+
+	proc_handler_t *ph = obs_output_get_proc_handler(output);
+	proc_handler_add(ph, "void get_last_file(out string path)",
+			 get_last_file, stream);
 
 	UNUSED_PARAMETER(settings);
 	return stream;
@@ -411,6 +422,7 @@ int deactivate(struct ffmpeg_muxer *stream, int code)
 	}
 
 	os_atomic_set_bool(&stream->stopping, false);
+	do_output_signal(stream->output, "wrote");
 	return ret;
 }
 
@@ -672,13 +684,6 @@ static void save_replay_proc(void *data, calldata_t *cd)
 	UNUSED_PARAMETER(cd);
 }
 
-static void get_last_replay(void *data, calldata_t *cd)
-{
-	struct ffmpeg_muxer *stream = data;
-	if (!os_atomic_load_bool(&stream->muxing))
-		calldata_set_string(cd, "path", stream->path.array);
-}
-
 static void *replay_buffer_create(obs_data_t *settings, obs_output_t *output)
 {
 	UNUSED_PARAMETER(settings);
@@ -692,8 +697,8 @@ static void *replay_buffer_create(obs_data_t *settings, obs_output_t *output)
 
 	proc_handler_t *ph = obs_output_get_proc_handler(output);
 	proc_handler_add(ph, "void save()", save_replay_proc, stream);
-	proc_handler_add(ph, "void get_last_replay(out string path)",
-			 get_last_replay, stream);
+	proc_handler_add(ph, "void get_last_file(out string path)",
+			 get_last_file, stream);
 
 	signal_handler_t *sh = obs_output_get_signal_handler(output);
 	signal_handler_add(sh, "void saved()");

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -400,6 +400,7 @@ int deactivate(struct ffmpeg_muxer *stream, int code)
 		     dstr_is_empty(&stream->printable_path)
 			     ? stream->path.array
 			     : stream->printable_path.array);
+		do_output_signal(stream->output, "wrote");
 	}
 
 	if (code) {
@@ -422,7 +423,6 @@ int deactivate(struct ffmpeg_muxer *stream, int code)
 	}
 
 	os_atomic_set_bool(&stream->stopping, false);
-	do_output_signal(stream->output, "wrote");
 	return ret;
 }
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -400,8 +400,6 @@ int deactivate(struct ffmpeg_muxer *stream, int code)
 		     dstr_is_empty(&stream->printable_path)
 			     ? stream->path.array
 			     : stream->printable_path.array);
-		if (strcmp(stream->output->info.id, "ffmpeg_muxer") == 0)
-			do_output_signal(stream->output, "wrote");
 	}
 
 	if (code) {
@@ -424,6 +422,9 @@ int deactivate(struct ffmpeg_muxer *stream, int code)
 	}
 
 	os_atomic_set_bool(&stream->stopping, false);
+
+	if (strcmp(stream->output->info.id, "ffmpeg_muxer") == 0)
+		do_output_signal(stream->output, "wrote");
 	return ret;
 }
 


### PR DESCRIPTION
### Description
These changes are serving 2 purposes:
 1. Add the get last file handler to the ffmpeg_mux output
 2. Add the `wrote` signal to the ffmpeg_mux

### Motivation and Context
This is for the client to inform better the users where their recording is located and what is the file name.

### How Has This Been Tested?
I ran this output in the client and I made sure that I'm getting the correct file name and the wrote signal after stopping the output. Our C++ unit tests are also passing.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the streamlabs branch.
- [X] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
