### PR TITLE
Adds SIGABRT handler to route to crash handlerSigabrt route

### DIFF
--- a/libobs/obs-module.h
+++ b/libobs/obs-module.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "obs.h"
+#include <signal.h>
 
 #ifdef __cplusplus
 #define MODULE_EXPORT extern "C" EXPORT
@@ -77,7 +78,8 @@ bool obs_module_load(void)
 	static obs_module_t *obs_module_pointer;                              \
 	MODULE_EXPORT void obs_module_set_pointer(obs_module_t *module);      \
 	void obs_module_set_pointer(obs_module_t *module)                     \
-	{                                                                     \
+	{								      \
+		signal(SIGABRT, &handle_aborts);			      \
 		obs_module_pointer = module;                                  \
 	}                                                                     \
 	obs_module_t *obs_current_module(void) { return obs_module_pointer; } \

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -16,6 +16,7 @@
 ******************************************************************************/
 
 #include <inttypes.h>
+#include <signal.h>
 
 #include "graphics/matrix4.h"
 #include "callback/calldata.h"
@@ -980,6 +981,7 @@ bool obs_startup(const char *locale, const char *module_config_path,
 {
 	bool success;
 
+	signal(SIGABRT, &handle_aborts); 
 	profile_start(obs_startup_name);
 
 	if (obs) {

--- a/libobs/util/base.c
+++ b/libobs/util/base.c
@@ -126,3 +126,8 @@ void blog(int log_level, const char *format, ...)
 	blogva(log_level, format, args);
 	va_end(args);
 }
+
+void handle_aborts(int signal_number)
+{
+	bcrash("abort()");
+}

--- a/libobs/util/base.h
+++ b/libobs/util/base.h
@@ -89,6 +89,7 @@ PRINTFATTR(1, 2)
 OBS_NORETURN
 #endif
 EXPORT void bcrash(const char *format, ...);
+EXPORT void handle_aborts(int signal_number);
 
 #undef PRINTFATTR
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
It was discovered that abort() is sometimes called by msvc headers or windows dll's in some unrecoverable states. This PR will instead route abort() to the obs bcrash function which will then subsequently call the registered crash handler, which allows us to document the event properly. This is done with signal.h/signal() which is exists on linux, so ifdef/win32 isn't required.

### Motivation and Context
The process should never disappear without documenting what happened. Each module needs to register its own signal handler pointer. To ensure all modules perform this within their context, I simply added it to a macro that is mandatory amongst them. As for obs.dll itself, I added it to the startup function, which makes sense.

### How Has This Been Tested?
I compiled obs.dll locally which has the exported function, then added a crash scenario to mediasoup-connector that calls abort and compiled it locally as well. Then replaced the dll's in a preview-build installation. Producing this same crash within the plugin hits my breakpoint inside my handler function and the process no longer aborts/vanishes, and the crash handler appears - allowing me to create a dmp.

### Types of changes
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
