### PR TITLE
Char pointer exception handling into D3D11 device_create

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -1342,6 +1342,9 @@ int device_create(gs_device_t **p_device, uint32_t adapter)
 		blog(LOG_ERROR, "device_create (D3D11): %s (%08lX)", error.str,
 		     error.hr);
 		errorcode = GS_ERROR_FAIL;
+	} catch (const char *error) {
+		blog(LOG_ERROR, "device_create (D3D11): %s", error);
+		errorcode = GS_ERROR_FAIL;
 	}
 
 	*p_device = device;


### PR DESCRIPTION
### Description
Added char pointer exception handling into D3D11 `device_create`. Exceptions of this type can be thrown by `gs_device::InitCompiler()` at least.

### Motivation and Context
This change fixes (most?) crashes with the following call stacks:

**gs_device::gs_device**

```
terminate
FindHandler<T>
__InternalCxxFrameHandler<T>
__CxxFrameHandler4
RtlpExecuteHandlerForException
RtlDispatchException
RtlRaiseException
RaiseException
_CxxThrowException
gs_device::gs_device
device_create
gs_create
obs_init_graphics
obs_reset_video
```

**RtlDispatchException**

```
terminate
FindHandler<T>
__InternalCxxFrameHandler<T>
__CxxFrameHandler4
RtlpExecuteHandlerForException
RtlDispatchException
```

### How Has This Been Tested?
- Move/rename **all** files with mask D3DCompiler_*.dll from C:\Windows\System32 (temporarily!). For example,
```
D3DCompiler_36.dll
D3DCompiler_37.dll
D3DCompiler_38.dll
D3DCompiler_39.dll
D3DCompiler_40.dll
D3DCompiler_41.dll
D3DCompiler_42.dll
D3DCompiler_43.dll
D3DCompiler_47.dll
```

- Start the non-fixed version of Streamlabs Desktop. It will crash. The issue will probably have one of the call stack above. If it does not crash, you also have the DLLs in another location. Find and rename/move them.
- Start the fixed version of Streamlabs Desktop. It will show an error message box instead of crashing.
- Return the DLLs back to the original place.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] The code has been tested.