### PR TITLE
Add a comment to describe that this format is inaccurately named

### DIFF
--- a/libobs/media-io/video-io.h
+++ b/libobs/media-io/video-io.h
@@ -44,7 +44,7 @@ enum video_format {
 
 	/* packed uncompressed formats */
 	VIDEO_FORMAT_RGBA,
-	VIDEO_FORMAT_BGRA, /* ARGB */
+	VIDEO_FORMAT_BGRA, /* ARGB from win-dshow*/
 	VIDEO_FORMAT_BGRX,
 	VIDEO_FORMAT_Y800, /* grayscale */
 

--- a/libobs/media-io/video-io.h
+++ b/libobs/media-io/video-io.h
@@ -44,7 +44,7 @@ enum video_format {
 
 	/* packed uncompressed formats */
 	VIDEO_FORMAT_RGBA,
-	VIDEO_FORMAT_BGRA,
+	VIDEO_FORMAT_BGRA, /* ARGB */
 	VIDEO_FORMAT_BGRX,
 	VIDEO_FORMAT_Y800, /* grayscale */
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Indicates that BGRA is being confused with ARGB when coming from win-dshow

### Motivation and Context
There is no ARGB format in libOBS so not much else can be done in the short term

### How Has This Been Tested?
N/A

### Types of changes
Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the streamlabs branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
