### PR TITLE
Fixed the source data creation issue which leads to crashes later

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -407,9 +407,6 @@ obs_source_create_internal(const char *id, const char *name,
 			goto fail;
 		}
 	}
-	
-	if ((!info || info->create) && !source->context.data)
-		blog(LOG_ERROR, "Failed to create source '%s'!", name);
 
 	blog(LOG_DEBUG, "%ssource '%s' (%s) created", private ? "private " : "",
 	     name, id);

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -394,11 +394,20 @@ obs_source_create_internal(const char *id, const char *name,
 	if (!private)
 		obs_source_init_audio_hotkeys(source);
 
-	/* allow the source to be created even if creation fails so that the
-	 * user's data doesn't become lost */
-	if (info && info->create)
+	if (info && info->create) {
+		// The |info->create| function description is "Creates the source data for the source".
+		// So if the function returns nullptr, we consider that the function fails.
+		// If a source does not need to create any data, the function either should be nullptr itself or
+		// return the |source| pointer as its data.
 		source->context.data =
 			info->create(source->context.settings, source);
+		if (!source->context.data) {
+			// We cannot ignore the error because it causes crashes later.
+			blog(LOG_ERROR, "Failed to create data for the source '%s'!", name);
+			goto fail;
+		}
+	}
+	
 	if ((!info || info->create) && !source->context.data)
 		blog(LOG_ERROR, "Failed to create source '%s'!", name);
 

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -2375,6 +2375,9 @@ void obs_context_data_remove(struct obs_context_data *context)
 
 void obs_context_wait(struct obs_context_data *context)
 {
+	if (!context->mutex) {
+		return;
+	}
 	pthread_mutex_lock(context->mutex);
 	pthread_mutex_unlock(context->mutex);
 }


### PR DESCRIPTION
### Description
This change does not allow `obs_source_create_internal` to ignore errors during source data creation. Now it destroys the created source and returns `nullptr` if the returned data is `nullptr`,

There is not actual description to clarify if returning `nullptr` by `info->create` is an error or not. I think some sources can just use the function for additional initialization and return `nullptr`. I went through obs-studio sources and saw the following cases:
- `info->create` is not `nullptr`. It creates and returns a real data object. (in case of success)
- `info->create` is `nullptr`. `obs_source_create_internal` does not call it but just prints an error message.
- `info->create` is not `nullptr`. It does not create any data but just returns the source pointer which was passed as an argument: `info->create(source->context.settings, SOURCE)`.

None of the cases return `nullptr` if the calls finish successful. So, it looks like `nullptr` return should mean an error. Anyway, there is a chance I miss something. Let's wait for regression issues?

### Motivation and Context
Our users have a lot of crashes which are connected to the issue. At least one of them happens the following way:
1. DirectX goes to an incorrect state (probably because of issues which are not caused by our code).
2. Our calls to DirectX fail with various error codes.
3. The stinger transition source cannot create the data object but the error is ignored by `obs_source_create_internal`.
4. Later when the stinger transition effect is called, it crashes the process.

### How Has This Been Tested?
Hardcoded `stinger_create` to return `nullptr`.
- In case of the original code, it crashed the process with logs and crash dumps similar to what our users have.
- In case of the fixed code, there was not any crashes. The error is returned to the UI layer. The application resets scenes/sources, etc.

### Types of changes
- Bug fix (non-breaking change which fixes an issue). Although probability of regression issues is high this time.

### Checklist:
- [x] The code has been tested.
