### PR TITLE
CI: fix invalid OBS version

### DIFF
--- a/slobs_CI/build-script-osx.sh
+++ b/slobs_CI/build-script-osx.sh
@@ -54,6 +54,8 @@ cmake \
     -DOPENSSL_CRYPTO_LIBRARY=/usr/local/opt/openssl@3/lib/libcrypto.a \
     -DOPENSSL_INCLUDE_DIR=/usr/local/opt/openssl@3/include \
     -DOPENSSL_SSL_LIBRARY=/usr/local/opt/openssl@3/lib/libssl.a \
+    -DOBS_VERSION="28.0.3" \
+    -DOBS_VERSION_OVERRIDE="28.0.3" \
     ${QUIET:+-Wno-deprecated -Wno-dev --log-level=ERROR}
 
 cmake --build ${BUILD_DIR} --target install --config ${BUILD_CONFIG:-${CI_BUILD_CONFIG}} -v

--- a/slobs_CI/win-build.cmd
+++ b/slobs_CI/win-build.cmd
@@ -57,7 +57,9 @@ cmake -H. ^
          -DBUILD_FOR_DISTRIBUTION=true ^
          -DCURL_INCLUDE_DIR=%DEPS_DIR%/ ^
          -DENABLE_VLC=true ^
-         -DVIRTUALCAM_GUID="27B05C2D-93DC-474A-A5DA-9BBA34CB2A9C"
+         -DVIRTUALCAM_GUID="27B05C2D-93DC-474A-A5DA-9BBA34CB2A9C" ^
+         -DOBS_VERSION="28.0.3" ^
+         -DOBS_VERSION_OVERRIDE="28.0.3"
 
 del /q /s %CD%\%InstallPath%
 cmake --build %CD%\%BUILD_DIRECTORY% --config %BuildConfig% -v


### PR DESCRIPTION
### Description
Hardcode OBS version number on CI.

### Motivation and Context
The cmake configure broke on CI since we recently merge changes from OBS upstream due to not passing a correct version number when building. I am just hardcoding it for now since in our case we don't really use this versioning. It is working when tagging hence the issue wasn't caught directly.

### How Has This Been Tested?
Made sure that it now builds on CI.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)