### PR TITLE
motion-effect: fix broken compilation of the motion-transition plugin

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -26,6 +26,7 @@ if(OS_WINDOWS)
   add_subdirectory(vlc-video)
   add_subdirectory(obs-vst)
   add_subdirectory(mediasoup-connector)
+  add_subdirectory(motion-effect)
 
   if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/enc-amf/CMakeLists.txt")
     add_subdirectory(enc-amf)


### PR DESCRIPTION
### Description
Put back building the motion-effect plugin for windows and update the submodule.

### Motivation and Context
We were not building this plugin anymore and the recent cmake changes from upstream broke the building and installing the plugin itself.

### How Has This Been Tested?
I made sure that the plugin is now being built and that it works the same as before.

### Types of changes
- - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the streamlabs branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
