### PR TITLE
libobs-opengl: remove the view creation from within obs

### DIFF
--- a/libobs-opengl/gl-cocoa.m
+++ b/libobs-opengl/gl-cocoa.m
@@ -194,10 +194,6 @@ struct gl_windowinfo *gl_windowinfo_create(const struct gs_init_data *info)
 
 	struct gl_windowinfo *wi = bzalloc(sizeof(struct gl_windowinfo));
 
-	wi->view = info->window.view;
-	wi->view.window.colorSpace = NSColorSpace.sRGBColorSpace;
-	wi->view.wantsBestResolutionOpenGLSurface = YES;
-
 	return wi;
 }
 


### PR DESCRIPTION
### Description
Remove the code settings up the display view on Mac.

### Motivation and Context
In the case of Streamlabs Desktop, drawing is handled in a separate module from within the client app. OBS only shares the final texture.

### How Has This Been Tested?
Made sure that the rendering / drawing work fine without any crash.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
