### PR TITLE
Use SLD specific ids for virtual cam

### DIFF
--- a/plugins/win-dshow/shared-memory-queue.c
+++ b/plugins/win-dshow/shared-memory-queue.c
@@ -2,7 +2,7 @@
 #include "shared-memory-queue.h"
 #include "tiny-nv12-scale.h"
 
-#define VIDEO_NAME L"OBSVirtualCamVideo"
+#define VIDEO_NAME L"SLDVirtualCamVideo"
 
 enum queue_type {
 	SHARED_QUEUE_TYPE_VIDEO,

--- a/plugins/win-dshow/virtualcam-module/virtualcam-filter.cpp
+++ b/plugins/win-dshow/virtualcam-module/virtualcam-filter.cpp
@@ -68,7 +68,7 @@ VCamFilter::VCamFilter()
 		SHGetFolderPathW(nullptr, CSIDL_APPDATA, nullptr,
 				 SHGFP_TYPE_CURRENT, res_file);
 		StringCbCat(res_file, sizeof(res_file),
-			    L"\\obs-virtualcam.txt");
+			    L"\\sld-virtualcam.txt");
 
 		HANDLE file = CreateFileW(res_file, GENERIC_READ, 0, nullptr,
 					  OPEN_EXISTING, 0, nullptr);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Use SLD specific ids for virtual cam 
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
SLD and OBS virtual cameras presented as separate devices. 
But using same id for shared memory makes them work as same and interfere with another app. 
And when a config file used as alternative for shared memory it creates similar issues as two apps will try to work with same config.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Start virtual camera in SLD and OBS at the same time. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
