### PR TITLE
fix parsing of auto game capture rules

### DIFF
--- a/libobs/util/windows/window-helpers.c
+++ b/libobs/util/windows/window-helpers.c
@@ -98,29 +98,22 @@ bool ms_check_window_property_setting(obs_properties_t *ppts, obs_property_t *p,
 }
 
 struct game_capture_matching_rule
-convert_json_to_matching_rule(json_t *json_rule)
+convert_to_matching_rule(const char *exe, const char *rule_class,
+			 const char *title, const char *type)
 {
 	struct game_capture_matching_rule rule = {0};
 
-	const char *exe = json_string_value(json_object_get(json_rule, "exe"));
-	const char *class =
-		json_string_value(json_object_get(json_rule, "class"));
-	const char *title =
-		json_string_value(json_object_get(json_rule, "title"));
-	const char *type =
-		json_string_value(json_object_get(json_rule, "type"));
-
 	title = decode_str(title);
 	dstr_copy(&rule.title, title);
-	class = decode_str(class);
-	dstr_copy(&rule.classW, class);
+	rule_class = decode_str(rule_class);
+	dstr_copy(&rule.classW, rule_class);
 	exe = decode_str(exe);
 	dstr_copy(&rule.executable, exe);
 
 	rule.mask = 0;
 	if (exe && exe[0])
 		rule.mask |= WINDOW_MATCH_EXE;
-	if (class && class[0])
+	if (rule_class && rule_class[0])
 		rule.mask |= WINDOW_MATCH_CLASS;
 	if (title && title[0])
 		rule.mask |= WINDOW_MATCH_TITLE;

--- a/libobs/util/windows/window-helpers.h
+++ b/libobs/util/windows/window-helpers.h
@@ -53,7 +53,8 @@ EXPORT bool ms_is_uwp_window(HWND hwnd);
 EXPORT HWND ms_get_uwp_actual_window(HWND parent);
 
 EXPORT struct game_capture_matching_rule
-convert_json_to_matching_rule(json_t *json_rule);
+convert_to_matching_rule(const char *exe, const char *rule_class,
+			 const char *title, const char *type);
 
 EXPORT void get_captured_window_line(HWND hwnd, struct dstr *window_line);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Fix parsing a json of auto game capture feature
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
After latest update functions of jansson what we used before stop working. 
It silently failed somewhere in combination of json_array_foreach, json_string_value and json_object_get. 
Debugging complicated as code used macroses and private fields hidden behind constructions like  
((type_ *)((char *)ptr_ - offsetof(type_, member_)))

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Run local build with auto game capture activated.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
