### PR TITLE
Restore feature: Use device name to lookup audio input device

### DIFF
--- a/plugins/win-wasapi/enum-wasapi.cpp
+++ b/plugins/win-wasapi/enum-wasapi.cpp
@@ -79,12 +79,15 @@ static void GetWASAPIAudioDevices_(vector<AudioDeviceInfo> &devices, bool input,
 		info.id.resize(size);
 		os_wcs_to_utf8(w_id, len, &info.id[0], size);
 
-		if (!searchbyName.empty() && info.name == searchbyName) {
-			info.device = device;
+		if (!searchbyName.empty()) {
+			if (info.name == searchbyName) {
+				info.device = device;
+				devices.push_back(info);
+				return;
+			}
+		} else {
 			devices.push_back(info);
-			return;
 		}
-		devices.push_back(info);
 	}
 }
 

--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -261,8 +261,6 @@ class WASAPISource {
 	void Start();
 	void Stop();
 
-	static string
-	WASAPISource::FixDeviceNameFromID(const string &device_id);
 	static ComPtr<IMMDevice>
 	_InitDevice(IMMDeviceEnumerator *enumerator, bool isDefaultDevice,
 		    SourceType type, bool &isInputDevice, string &device_id,
@@ -709,19 +707,6 @@ void WASAPISource::Deactivate()
 	}
 }
 
-// Restore device name from device id corrupted by dshow device id.
-string WASAPISource::FixDeviceNameFromID(const string &device_id)
-{
-	size_t pos = device_id.find(":");
-	string device_name = "";
-	if (pos != string::npos) {
-		device_name = device_id.substr(0, pos);
-		blog(LOG_INFO, "Fixing device name from ID: %s to %s",
-		     device_id.c_str(), device_name.c_str());
-	}
-	return device_name;
-}
-
 ComPtr<IMMDevice>
 WASAPISource::_InitDevice(IMMDeviceEnumerator *enumerator, bool isDefaultDevice,
 			  SourceType type, bool &isInputDevice,
@@ -749,19 +734,14 @@ WASAPISource::_InitDevice(IMMDeviceEnumerator *enumerator, bool isDefaultDevice,
 		bfree(w_id);
 
 		if (FAILED(res)) {
-			if (device_name.empty())
-				device_name = FixDeviceNameFromID(device_id);
-
 			if (!device_name.empty()) {
 				std::vector<AudioDeviceInfo> devices;
 				GetWASAPIAudioDevices(devices, isInputDevice,
 						      device_name);
 				if (devices.size()) {
 					blog(LOG_INFO,
-					     "[WASAPISource::InitDevice]: Use device from GetWASAPIAudioDevices, for a name '%s', will replace '%s' with '%s'",
-					     device_name.c_str(),
-					     device_id.c_str(),
-					     devices[0].id.c_str());
+					     "[WASAPISource::InitDevice]: Use device from GetWASAPIAudioDevices, for a name '%s'",
+					     device_name.c_str());
 
 					device = devices[0].device;
 					device_id = devices[0].id;

--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -1019,8 +1019,6 @@ void WASAPISource::Initialize()
 
 		device_name = GetDeviceName(device);
 	}
-	if (!device)
-		throw "Failed to get wasapi device";
 
 	ResetEvent(receiveSignal);
 

--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -746,9 +746,11 @@ WASAPISource::_InitDevice(IMMDeviceEnumerator *enumerator, bool isDefaultDevice,
 					device = devices[0].device;
 					device_id = devices[0].id;
 				} else {
-					throw HRError("Failed to init device",
+					throw HRError("Failed to init device by id and no device found by name",
 						      res);
 				}
+			} else {
+				throw HRError("Failed to init device by id", res);
 			}
 		}
 	}
@@ -770,10 +772,7 @@ ComPtr<IMMDevice> WASAPISource::InitDevice(IMMDeviceEnumerator *enumerator,
 	if (device_name.empty())
 		device_name = GetDeviceName(device);
 
-	if (device)
-		return device;
-
-	throw "Failed to init device";
+	return device;
 }
 
 #define BUFFER_TIME_100NS (5 * 10000000)

--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -746,11 +746,13 @@ WASAPISource::_InitDevice(IMMDeviceEnumerator *enumerator, bool isDefaultDevice,
 					device = devices[0].device;
 					device_id = devices[0].id;
 				} else {
-					throw HRError("Failed to init device by id and no device found by name",
-						      res);
+					throw HRError(
+						"Failed to init device by id and no device found by name",
+						res);
 				}
 			} else {
-				throw HRError("Failed to init device by id", res);
+				throw HRError("Failed to init device by id",
+					      res);
 			}
 		}
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Use device name to lookup audio input device when device id became unavailable. 
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
This feature become inactive when _initDevice start to throw exceptions. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Hard to test this feature directly as it designed for very specific situation when Windows restarts an audio device and changes device id. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
