### PR TITLE
Handle null interval_ns division by zero crash

### DIFF
--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -817,6 +817,7 @@ static inline void video_sleep(struct obs_core_video *video, uint64_t *p_time,
 		count = (int)(clamped_diff / interval_ns);
 		*p_time = cur_time + interval_ns * count;
 	} else {
+		*p_time = cur_time;
 		return;
 	}
 

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -807,7 +807,7 @@ static inline void video_sleep(struct obs_core_video *video, uint64_t *p_time,
 	if (os_sleepto_ns(t)) {
 		*p_time = t;
 		count = 1;
-	} else {
+	} else if (interval_ns > 0) {
 		const uint64_t udiff = os_gettime_ns() - cur_time;
 		int64_t diff;
 		memcpy(&diff, &udiff, sizeof(diff));
@@ -816,6 +816,8 @@ static inline void video_sleep(struct obs_core_video *video, uint64_t *p_time,
 						      : interval_ns;
 		count = (int)(clamped_diff / interval_ns);
 		*p_time = cur_time + interval_ns * count;
+	} else {
+		return;
 	}
 
 	video->total_frames += count;

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -643,7 +643,7 @@ static int obs_init_video(struct obs_video_info *ovi)
 	video->video_half_frame_interval_ns =
 		util_mul_div64(500000000ULL, ovi->fps_den, ovi->fps_num);
 
-	if (video->video_half_frame_interval_ns == 0) {
+	if (video->video_frame_interval_ns == 0) {
 		blog(LOG_ERROR,
 		     "Invalid FPS parameters for obs_init_video, fps_den = %d, fps_num = %d",
 		     ovi->fps_den, ovi->fps_num);

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -643,13 +643,6 @@ static int obs_init_video(struct obs_video_info *ovi)
 	video->video_half_frame_interval_ns =
 		util_mul_div64(500000000ULL, ovi->fps_den, ovi->fps_num);
 
-	if (video->video_frame_interval_ns == 0) {
-		blog(LOG_ERROR,
-		     "Invalid FPS parameters for obs_init_video, fps_den = %d, fps_num = %d",
-		     ovi->fps_den, ovi->fps_num);
-		return OBS_VIDEO_FAIL;
-	}
-
 	if (pthread_mutex_init(&video->task_mutex, NULL) < 0)
 		return OBS_VIDEO_FAIL;
 	if (pthread_mutex_init(&video->mixes_mutex, NULL) < 0)

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -643,6 +643,13 @@ static int obs_init_video(struct obs_video_info *ovi)
 	video->video_half_frame_interval_ns =
 		util_mul_div64(500000000ULL, ovi->fps_den, ovi->fps_num);
 
+	if (video->video_half_frame_interval_ns == 0) {
+		blog(LOG_ERROR,
+		     "Invalid FPS parameters for obs_init_video, fps_den = %d, fps_num = %d",
+		     ovi->fps_den, ovi->fps_num);
+		return OBS_VIDEO_FAIL;
+	}
+
 	if (pthread_mutex_init(&video->task_mutex, NULL) < 0)
 		return OBS_VIDEO_FAIL;
 	if (pthread_mutex_init(&video->mixes_mutex, NULL) < 0)


### PR DESCRIPTION
### Description
Null sleep duration to video_sleep is causing a crash due to division by zero.

### Motivation and Context
Standard bug fix.

### How Has This Been Tested?
Compiled and ran streamlabs with the new dll's. Nothing unusual would be expected as my system has typical values.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
