### PR TITLE
Update compile variable name to match changes

### DIFF
--- a/slobs_CI/install-script-win.cmd
+++ b/slobs_CI/install-script-win.cmd
@@ -46,7 +46,7 @@ cmake -H. ^
          -DCMAKE_INSTALL_PREFIX=%CD%\%InstallPath% ^
          -DVLCPath=%CD%\build\vlc ^
          -DCEF_ROOT_DIR=%CEFPATH% ^
-         -DUSE_UI_LOOP=false ^
+         -DENABLE_BROWSER_QT_LOOP=false ^
          -DENABLE_UI=false ^
          -DCOPIED_DEPENDENCIES=false ^
          -DCOPY_DEPENDENCIES=true ^


### PR DESCRIPTION
### Description
USE_UI_LOOP was renamed to ENABLE_BROWSER_QT_LOOP recently

### Motivation and Context
Just maintenance, option is false by default anyway.

### How Has This Been Tested?
Not needed, option is false by default regardless.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
