### PR TITLE
fix empty sdk path

### DIFF
--- a/plugins/obs-filters/noise-suppress-filter.c
+++ b/plugins/obs-filters/noise-suppress-filter.c
@@ -217,14 +217,14 @@ static void noise_suppress_destroy(void *data)
 		audio_resampler_destroy(ng->nvafx_resampler);
 		audio_resampler_destroy(ng->nvafx_resampler_back);
 	}
-	bfree(ng->model);
-	bfree(ng->sdk_path);
 	bfree((void *)ng->fx);
 	if (ng->nvafx_enabled) {
 		if (ng->use_nvafx)
 			pthread_join(ng->nvafx_thread, NULL);
 		pthread_mutex_unlock(&ng->nvafx_mutex);
 		pthread_mutex_destroy(&ng->nvafx_mutex);
+		bfree(ng->model);
+		bfree(ng->sdk_path);
 	}
 #endif
 
@@ -431,6 +431,10 @@ static inline enum speaker_layout convert_speaker_layout(uint8_t channels)
 static void set_model(void *data, const char *method)
 {
 	struct noise_suppress_data *ng = data;
+
+	if (ng->sdk_path == NULL)
+		return;
+
 	const char *file;
 	if (strcmp(NVAFX_EFFECT_DEREVERB, method) == 0)
 		file = NVAFX_EFFECT_DEREVERB_MODEL;
@@ -443,6 +447,10 @@ static void set_model(void *data, const char *method)
 
 	strcpy(buffer, ng->sdk_path);
 	strcat(buffer, file);
+
+	if (ng->model)
+		bfree(ng->model);
+
 	ng->model = buffer;
 }
 #endif


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
If code failed to get sdk_path it should not try to use it for model path.
Model array should release memory before setting to another pointer. 
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
in filter creation a call to set_model will crash on sdk_path dereference. 
state of noise_suppress_data object when it happens. 
```
    last_timestamp: 0
    latency: 10000000
    frames: 0
    channels: 0
    info_buffer: {data=0x0000000000000000 size=0 start_pos=0 ...}
    input_buffers: 0x000001fdafac32d8 {{data=0x0000000000000000 size=0 start_pos=0 ...}, {data=0x0000000000000000 size=...}, ...}
    output_buffers: 0x000001fdafac3418 {{data=0x0000000000000000 size=0 start_pos=0 ...}, {data=0x0000000000000000 size=...}, ...}
    use_rnnoise: false
    use_nvafx: false
    nvafx_enabled: false
    has_mono_src: false
    reinit_done: false
    spx_states: 0x000001fdafac3560 {0x0000000000000000 <NULL>, 0x0000000000000000 <NULL>, 0x0000000000000000 <NULL>, ...}
    rnn_states: 0x000001fdafac35a0 {0x0000000000000000 <NULL>, 0x0000000000000000 <NULL>, 0x0000000000000000 <NULL>, ...}
    rnn_resampler: 0x0000000000000000 <NULL>
    rnn_resampler_back: 0x0000000000000000 <NULL>
    handle: 0x000001fdafac35f0 {0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000, ...}
    sample_rate: 0
    intensity_ratio: 0.00000000
    num_samples_per_frame: 0
    num_channels: 0
    model: 0x0000000000000000 <NULL>
    nvafx_initialized: false
    fx: 0x0000000000000000 <NULL>
    sdk_path: 0x0000000000000000 <NULL>
    nvafx_resampler: 0x0000000000000000 <NULL>
    nvafx_resampler_back: 0x0000000000000000 <NULL>
    nvafx_loading: false
    nvafx_thread: {p=0x0000000000000000 x=0 }
    nvafx_mutex: 0x0000000000000000 <NULL>
```
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Crash conditions was simulated by changing condition in noise_suppress_create() to be similar to situation when nvafx_get_sdk_path returned with an error. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
