### PR TITLE
Fixed the process_audio_delay function algorithm

### DIFF
--- a/libobs/audio-monitoring/win32/wasapi-output.c
+++ b/libobs/audio-monitoring/win32/wasapi-output.c
@@ -82,6 +82,7 @@ static bool process_audio_delay(struct audio_monitor *monitor, float **data,
 			*frames, 1000000000ULL, monitor->sample_rate);
 	} else {
 		monitor->time_since_prev = 0;
+		monitor->prev_video_ts = last_frame_ts;
 	}
 
 	while (monitor->delay_buffer.size != 0) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Added `monitor->prev_video_ts` update to the `process_audio_delay` function algorithm which was never updated after the initial assignment. Now the algorithm correctly calculates `monitor->time_since_prev`.

### Motivation and Context
The function algorithm was incorrect. Probably, someone just forgot to add the line to update `monitor->prev_video_ts`. So it was first set and until next video frame `monitor->time_since_prev` was calculated correctly. When a new video frame is received, `last_frame_ts` was changed so the algorithm always set `monitor->time_since_prev` to **0** which is incorrect.

For MP4 files and MP3 without album art, the bug either did not lead to any issue or an issue did not have significant impact to playback quality. The bug caused a lot of issues for an MP3 with album art.

### How Has This Been Tested?
- Logged almost every line of code starting from media loading/encoding, processing it via the ffmpeg pluging, then the source functions, ending the monitor source code. Checked the behavior. With the fix the code works much more correctly now.
- The audible issues (like not playing an MP3 with album art after app restart) are not reproduced with the fix.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
