### PR TITLE
Change osx sentry script to search build folder

### DIFF
--- a/slobs_CI/sentry-osx.py
+++ b/slobs_CI/sentry-osx.py
@@ -4,7 +4,7 @@ os.system('curl -sL https://sentry.io/get-cli/ | bash')
 def process_sentry(directory):
     for root, dirs, files in os.walk(directory):
         for file in files:
-            if 'lib' in file or 'obs' in file or '.so' in file or '.dylib' in file:
+            if 'lib' in file or 'obs' in file or '.so' in file or '.dylib' in file or '.' not in file:
                 path = os.path.join(root, file)
                 os.system("dsymutil " + path)
                 os.system("sentry-cli --auth-token ${SENTRY_AUTH_TOKEN} upload-dif --org streamlabs-desktop --project obs-server " + path + ".dSYM/Contents/Resources/DWARF/" + file)                

--- a/slobs_CI/sentry-osx.py
+++ b/slobs_CI/sentry-osx.py
@@ -2,20 +2,14 @@ import os
 os.system('curl -sL https://sentry.io/get-cli/ | bash')
 
 def process_sentry(directory):
-    for r, d, f in os.walk(directory):
-        for file in f:
+    for root, dirs, files in os.walk(directory):
+        for file in files:
             if 'lib' in file or 'obs' in file or '.so' in file or '.dylib' in file:
-                path = os.path.join(directory, file)
+                path = os.path.join(root, file)
                 os.system("dsymutil " + path)
-                os.system("sentry-cli --auth-token ${SENTRY_AUTH_TOKEN} upload-dif --org streamlabs-desktop --project obs-server " + path + ".dSYM/Contents/Resources/DWARF/" + file)
-    for r, d, f in os.walk(directory):
-        for file in f:
-            if 'lib' in file or 'obs' in file or '.so' in file or '.dylib' in file:
-                path = os.path.join(directory, file)
+                os.system("sentry-cli --auth-token ${SENTRY_AUTH_TOKEN} upload-dif --org streamlabs-desktop --project obs-server " + path + ".dSYM/Contents/Resources/DWARF/" + file)                
                 os.system("dsymutil " + path)
                 os.system("sentry-cli --auth-token ${SENTRY_AUTH_TOKEN} upload-dif --org streamlabs-desktop --project obs-server-preview " + path + ".dSYM/Contents/Resources/DWARF/" + file)
 
 # Upload obs debug files
-process_sentry(os.path.join(os.environ['PWD'], 'build', 'rundir', os.environ['BUILDCONFIG'], 'bin'))
-# Upload obs-plugins debug files
-process_sentry(os.path.join(os.environ['PWD'], 'build', 'rundir', os.environ['BUILDCONFIG'], 'obs-plugins'))
+process_sentry(os.path.join(os.environ['PWD'], 'build'))

--- a/slobs_CI/sentry-osx.py
+++ b/slobs_CI/sentry-osx.py
@@ -4,7 +4,7 @@ os.system('curl -sL https://sentry.io/get-cli/ | bash')
 def process_sentry(directory):
     for root, dirs, files in os.walk(directory):
         for file in files:
-            if 'lib' in file or 'obs' in file or '.so' in file or '.dylib' in file or '.' not in file:
+            if '.so' in file or '.dylib' in file or '.' not in file:
                 path = os.path.join(root, file)
                 os.system("dsymutil " + path)
                 os.system("sentry-cli --auth-token ${SENTRY_AUTH_TOKEN} upload-dif --org streamlabs-desktop --project obs-server " + path + ".dSYM/Contents/Resources/DWARF/" + file)                


### PR DESCRIPTION
### Description
Revise python script for finding/uploading Mac debug information to sentry. Searches build folder for files instead of expecting them in a specific location. Also removed second loop as it seemed redundant.

### Motivation and Context
Script was uploading nothing to sentry and libobs crashes could not be debugged.

### How Has This Been Tested?
Tagged a commit in another branch to see if output was finding files. It now does.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
