### PR TITLE
macos arm64 support

### DIFF
--- a/.github/workflows/main-streamlabs.yml
+++ b/.github/workflows/main-streamlabs.yml
@@ -36,10 +36,13 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET_X86_64: '10.15'
       MACOSX_DEPLOYMENT_TARGET_ARM64: '11.0'
       CEF_BUILD_VERSION_MAC: '5060'
-      DEPS_VERSION_MAC: '2022-08-02'
+      DEPS_VERSION_MAC: '2022-08-02-b230130'
+      QT_DEPS_VERSION_MAC: '2022-08-02'
       VLC_VERSION_MAC: '3.0.8'
       QT_VERSION_MAC: '6.3.1'
       SPARKLE_VERSION: '1.26.0'
+      WEBRTC_VERSION_MAC: 'm94-b230130'
+      LIBMEDIASOUPCLIENT_VERSION_MAC: '55d724f-b230130'
 
     steps:
       - name: 'Checkout'
@@ -73,6 +76,7 @@ jobs:
           ReleaseName: ${{matrix.ReleaseName}}
           BuildConfig: ${{matrix.BuildConfig}}
           CefBuildConfig: ${{matrix.CefBuildConfig}}
+          ARCH: ${{matrix.arch}}
       - name: Tar artifact for deployment
         if: startsWith(github.ref, 'refs/tags/')
         run: cd ${{env.InstallPath}} && 7z a -r ../${{env.TARGET_ARTIFACT}}.7z *

--- a/slobs_CI/01_install_dependencies.sh
+++ b/slobs_CI/01_install_dependencies.sh
@@ -36,8 +36,8 @@ install_qt-deps() {
     else
         _ARCH="${ARCH:-x86_64}"
     fi
-    _ARCH="x86_64"
-    wget --quiet --retry-connrefused --waitretry=1 "https://github.com/obsproject/obs-deps/releases/download/${1}/macos-deps-qt6-${1}-${ARCH:-x86_64}.tar.xz"
+
+    wget --quiet --retry-connrefused --waitretry=1 "https://github.com/obsproject/obs-deps/releases/download/${1}/macos-deps-qt6-${1}-${_ARCH:-x86_64}.tar.xz"
     mkdir -p obs-deps
     step "Unpack..."
     /usr/bin/tar -xf "./macos-deps-qt6-${1}-${_ARCH}.tar.xz" -C ./obs-deps
@@ -130,15 +130,49 @@ install_cef() {
     fi
 }
 
+install_webrtc() {
+    WEBRTC_DIST_FOLDER=webrtc-dist-osx-${1}-${ARCH:-x86_64}
+    WEBRTC_DIST_FILENAME=${WEBRTC_DIST_FOLDER}.zip
+    WEBRTC_DIST_URL=https://obs-studio-deployment.s3-us-west-2.amazonaws.com/${WEBRTC_DIST_FILENAME}
+    WEBRTC_DIST_FINAL_FOLDER=webrtc-dist
+
+    echo "${WEBRTC_DIST_URL}"
+    status "Set up precompiled macOS WebRTC ${1}"
+    ensure_dir "${DEPS_BUILD_DIR}"
+    step "Download..."
+    wget --quiet --retry-connrefused --waitretry=1 "${WEBRTC_DIST_URL}"
+    step "Unpack..."
+    /usr/bin/tar -xf "./${WEBRTC_DIST_FILENAME}" && mv "${WEBRTC_DIST_FOLDER}" "${WEBRTC_DIST_FINAL_FOLDER}"
+    /usr/bin/xattr -r -d com.apple.quarantine "./${WEBRTC_DIST_FINAL_FOLDER}"
+}
+
+install_libmediasoupclient() {
+    LIBMEDIASOUPCLIENT_DIST_FOLDER=libmediasoupclient-dist-osx-${1}-${ARCH:-x86_64}
+    LIBMEDIASOUPCLIENT_DIST_FILENAME=${LIBMEDIASOUPCLIENT_DIST_FOLDER}.zip
+    LIBMEDIASOUPCLIENT_DIST_URL=https://obs-studio-deployment.s3-us-west-2.amazonaws.com/${LIBMEDIASOUPCLIENT_DIST_FILENAME}
+    LIBMEDIASOUPCLIENT_DIST_FINAL_FOLDER=libmediasoupclient-dist
+
+    echo "${LIBMEDIASOUPCLIENT_DIST_URL}"
+    status "Set up precompiled macOS libmediasoupclient ${1}"
+    ensure_dir "${DEPS_BUILD_DIR}"
+    step "Download..."
+    wget --quiet --retry-connrefused --waitretry=1 "${LIBMEDIASOUPCLIENT_DIST_URL}"
+    step "Unpack..."
+    /usr/bin/tar -xf "./${LIBMEDIASOUPCLIENT_DIST_FILENAME}" && mv "${LIBMEDIASOUPCLIENT_DIST_FOLDER}" "${LIBMEDIASOUPCLIENT_DIST_FINAL_FOLDER}"
+    /usr/bin/xattr -r -d com.apple.quarantine "./${LIBMEDIASOUPCLIENT_DIST_FINAL_FOLDER}"
+}
+
 install_dependencies() {
     status "Install Homebrew dependencies"
     trap "caught_error 'install_dependencies'" ERR
 
     BUILD_DEPS=(
         "obs-deps ${MACOS_DEPS_VERSION:-${CI_DEPS_VERSION}} ${MACOS_DEPS_HASH:-${CI_DEPS_HASH}}"
-        "qt-deps ${MACOS_DEPS_VERSION:-${CI_DEPS_VERSION}} ${QT_HASH:-${CI_QT_HASH}}"
+        "qt-deps ${MACOS_QT_DEPS_VERSION:-${CI_QT_DEPS_VERSION}} ${QT_HASH:-${CI_QT_HASH}}"
         "cef ${MACOS_CEF_BUILD_VERSION:-${CI_MACOS_CEF_VERSION}} ${CEF_HASH:-${CI_CEF_HASH}}"
         "vlc ${VLC_VERSION:-${CI_VLC_VERSION}} ${VLC_HASH:-${CI_VLC_HASH}}"
+        "webrtc ${WEBRTC_VERSION:-${CI_WEBRTC_VERSION}} ${MACOS_WEBRTC_HASH:-${CI_WEBRTC_HASH}}"
+        "libmediasoupclient ${LIBMEDIASOUPCLIENT_VERSION:-${CI_LIBMEDIASOUPCLIENT_VERSION}} ${MACOS_LIBMEDIASOUPCLIENT_HASH:-${CI_LIBMEDIASOUPCLIENT_HASH}}"
     )
 
     install_homebrew_deps

--- a/slobs_CI/build-script-osx.sh
+++ b/slobs_CI/build-script-osx.sh
@@ -14,16 +14,6 @@ cd "${CHECKOUT_DIR}"
 DEPS_BUILD_DIR="${CHECKOUT_DIR}/../obs-build-dependencies"
 BUILD_DIR="${CHECKOUT_DIR}/${BUILD_DIRECTORY}"
 
-# Fetch and unzip prebuilt WEBRTC deps
-wget --quiet --retry-connrefused --waitretry=1 https://obs-studio-deployment.s3.us-west-2.amazonaws.com/webrtc_dist_m94_mac.zip
-unzip -q webrtc_dist_m94_mac.zip
-rm ./webrtc_dist_m94_mac.zip
-
-# Fetch and unzip prebuilt LIBMEDIASOUP deps
-wget --quiet --retry-connrefused --waitretry=1 https://obs-studio-deployment.s3.us-west-2.amazonaws.com/libmediasoupclient_dist_8b36a915_mac.zip
-unzip -q libmediasoupclient_dist_8b36a915_mac.zip
-rm ./libmediasoupclient_dist_8b36a915_mac.zip
-
 cmake \
     -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-${CI_MACOSX_DEPLOYMENT_TARGET}} \
     -S ${CHECKOUT_DIR} -B ${BUILD_DIR} \
@@ -44,15 +34,14 @@ cmake \
     -DENABLE_BROWSER_PANELS=false \
     -DENABLE_UI=false \
     -DUSE_UI_LOOP=true \
-    -DENABLE_UNIT_TESTS=ON \
     -DENABLE_SERVICE_UPDATES=true \
     -DOBS_CODESIGN_LINKER=true \
-    -DWEBRTC_INCLUDE_PATH=$PWD/webrtc_dist \
-    -DWEBRTC_LIB_PATH=$PWD/webrtc_dist/libwebrtc.a \
-    -DMEDIASOUP_INCLUDE_PATH=$PWD/libmediasoupclient_dist/include/mediasoupclient/ \
-    -DMEDIASOUP_LIB_PATH=$PWD/libmediasoupclient_dist/lib/libmediasoupclient.a \
-    -DMEDIASOUP_SDP_LIB_PATH=$PWD/libmediasoupclient_dist/lib/libsdptransform.a \
-    -DMEDIASOUP_SDP_INCLUDE_PATH=$PWD/libmediasoupclient_dist/include/sdptransform \
+    -DWEBRTC_INCLUDE_PATH="${DEPS_BUILD_DIR}/webrtc-dist" \
+    -DWEBRTC_LIB_PATH="${DEPS_BUILD_DIR}/webrtc-dist/libwebrtc.a" \
+    -DMEDIASOUP_INCLUDE_PATH="${DEPS_BUILD_DIR}/libmediasoupclient-dist/include/mediasoupclient/" \
+    -DMEDIASOUP_LIB_PATH="${DEPS_BUILD_DIR}/libmediasoupclient-dist/lib/libmediasoupclient.a" \
+    -DMEDIASOUP_SDP_LIB_PATH="${DEPS_BUILD_DIR}/libmediasoupclient-dist/lib/libsdptransform.a" \
+    -DMEDIASOUP_SDP_INCLUDE_PATH="${DEPS_BUILD_DIR}/libmediasoupclient-dist/include/sdptransform" \
     -DOPENSSL_CRYPTO_LIBRARY=/usr/local/opt/openssl@3/lib/libcrypto.a \
     -DOPENSSL_INCLUDE_DIR=/usr/local/opt/openssl@3/include \
     -DOPENSSL_SSL_LIBRARY=/usr/local/opt/openssl@3/lib/libssl.a \

--- a/slobs_CI/build_support_macos.sh
+++ b/slobs_CI/build_support_macos.sh
@@ -14,7 +14,8 @@
 # Setup build environment
 CI_WORKFLOW="${CHECKOUT_DIR}/.github/workflows/main-streamlabs.yml"
 WORKFLOW_CONTENT=$(/bin/cat "${CI_WORKFLOW}")
-CI_DEPS_VERSION=$(echo "${WORKFLOW_CONTENT}" | /usr/bin/sed -En "s/[ ]+DEPS_VERSION_MAC: '([0-9\-]+)'/\1/p")
+CI_DEPS_VERSION=$(echo "${WORKFLOW_CONTENT}" | /usr/bin/sed -En "s/[ ]+DEPS_VERSION_MAC: '([0-9a-z\-]+)'/\1/p")
+CI_QT_DEPS_VERSION=$(echo "${WORKFLOW_CONTENT}" | /usr/bin/sed -En "s/[ ]+QT_DEPS_VERSION_MAC: '([0-9\-]+)'/\1/p")
 CI_DEPS_HASH_X86_64=$(echo "${WORKFLOW_CONTENT}" | /usr/bin/sed -En "s/[ ]+DEPS_HASH_MAC_X86_64: '([0-9a-f]+)'/\1/p")
 CI_DEPS_HASH_ARM64=$(echo "${WORKFLOW_CONTENT}" | /usr/bin/sed -En "s/[ ]+DEPS_HASH_MAC_ARM64: '([0-9a-f]+)'/\1/p")
 CI_VLC_VERSION=$(echo "${WORKFLOW_CONTENT}" | /usr/bin/sed -En "s/[ ]+VLC_VERSION_MAC: '([0-9\.]+)'/\1/p")
@@ -27,6 +28,12 @@ CI_CEF_HASH_X86_64=$(echo "${WORKFLOW_CONTENT}" | /usr/bin/sed -En "s/[ ]+CEF_HA
 CI_CEF_HASH_ARM64=$(echo "${WORKFLOW_CONTENT}" | /usr/bin/sed -En "s/[ ]+CEF_HASH_MAC_ARM64: '([0-9a-f]+)'/\1/p")
 CI_BUILD_CONFIG=$(echo "${WORKFLOW_CONTENT}" | /usr/bin/sed -En "s/[ ]+BUILD_CONFIG: '([0-9a-f]+)'/\1/p")
 CI_SPARKLE_VERSION=$(echo "${WORKFLOW_CONTENT}" | /usr/bin/sed -En "s/[ ]+SPARKLE_VERSION: '([0-9\.]+)'/\1/p")
+CI_WEBRTC_VERSION=$(echo "${WORKFLOW_CONTENT}" | /usr/bin/sed -En "s/[ ]+WEBRTC_VERSION_MAC: '([0-9a-z\-]+)'/\1/p")
+CI_WEBRTC_HASH_X86_64=$(echo "${WORKFLOW_CONTENT}" | /usr/bin/sed -En "s/[ ]+WEBRTC_HASH_MAC_X86_64: '([0-9a-f]+)'/\1/p")
+CI_WEBRTC_HASH_ARM64=$(echo "${WORKFLOW_CONTENT}" | /usr/bin/sed -En "s/[ ]+WEBRTC_HASH_MAC_ARM64: '([0-9a-f]+)'/\1/p")
+CI_LIBMEDIASOUPCLIENT_VERSION=$(echo "${WORKFLOW_CONTENT}" | /usr/bin/sed -En "s/[ ]+LIBMEDIASOUPCLIENT_VERSION_MAC: '([0-9a-z\-]+)'/\1/p")
+CI_LIBMEDIASOUPCLIENT_HASH_X86_64=$(echo "${WORKFLOW_CONTENT}" | /usr/bin/sed -En "s/[ ]+LIBMEDIASOUPCLIENT_HASH_MAC_X86_64: '([0-9a-f]+)'/\1/p")
+CI_LIBMEDIASOUPCLIENT_HASH_ARM64=$(echo "${WORKFLOW_CONTENT}" | /usr/bin/sed -En "s/[ ]+LIBMEDIASOUPCLIENT_HASH_MAC_ARM64: '([0-9a-f]+)'/\1/p")
 
 MACOS_VERSION="$(/usr/bin/sw_vers -productVersion)"
 MACOS_MAJOR="$(echo ${MACOS_VERSION} | /usr/bin/cut -d '.' -f 1)"

--- a/slobs_CI/macos-deps/create-libmediasoupclient-package.zsh
+++ b/slobs_CI/macos-deps/create-libmediasoupclient-package.zsh
@@ -1,0 +1,217 @@
+#!/bin/zsh
+
+# 1. Precompile the webrtc library for arm64 or/and x84_64
+# 2. Place the script to an empty folder
+# 3. ./create-libmediasoupclient-package.zsh --architecture=arm64 --webrtc-include-folder=...  --webrtc-lib-folder=ARM64_OR_UNIVERSAL_LIB_FOLDER
+# 4. ./create-libmediasoupclient-package.zsh --architecture=x86_64 --webrtc-include-folder=...  --webrtc-lib-folder=X86_64_OR_UNIVERSAL_LIB_FOLDER
+
+download_libmediasoupclient() {    
+    # Check if the webrtc folder exists
+    if [ -d "${GIT_FOLDER}" ]
+    then
+        echo "### The '${GIT_FOLDER}' folder exists. It will be reused. Remove it if you want to clone the git repositoty again."
+        return
+    fi
+
+    # Clone
+    git clone --recurse-submodules https://github.com/versatica/libmediasoupclient.git ${GIT_FOLDER}
+    if [ $? -ne 0 ]
+    then
+        echo "### ould not clone libmediasoupclient."
+        exit 1
+    fi
+
+    # Check if the source folder name is correct and the folder exists
+    if [ ! -d "${GIT_FOLDER}" ]
+    then
+        echo "### The source folder '${GIT_FOLDER}' could not be found. Probably the 'git clone' command failed. Please check manually"
+        exit 1
+    fi
+}
+
+patch_libmediasoupclient() {
+    CATCH_HPP=${GIT_FOLDER}/deps/libsdptransform/test/include/catch.hpp
+    if grep -q "0xd4200000" "${CATCH_HPP}"
+    then
+        echo "### It looks like the '${CATCH_HPP}' does not need to be patched!"
+    else
+        echo "### Patching '${GIT_FOLDER}/deps/libsdptransform/test/include/catch.hpp' ..."
+
+        PATCH_FILENAME=catch-hpp-arm64-fix.patch
+        PATCH_PATH=${GIT_FOLDER}/${PATCH_FILENAME}
+
+        cat <<'EOT' > "${PATCH_PATH}"
+--- a/deps/libsdptransform/test/include/catch.hpp	2023-01-18 20:24:16
++++ b/deps/libsdptransform/test/include/catch.hpp	2023-01-18 20:21:40
+@@ -7852,7 +7852,11 @@
+ 
+ #ifdef CATCH_PLATFORM_MAC
+ 
+-    #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
++    #if defined(__i386__) || defined(__x86_64__)
++        #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
++    #elif defined(__aarch64__)
++        #define CATCH_TRAP()  __asm__(".inst 0xd4200000")
++    #endif
+ 
+ #elif defined(CATCH_PLATFORM_LINUX)
+     // If we can use inline assembler, do it because this allows us to break
+EOT
+
+        if [ $? -ne 0 ]
+        then
+            echo "### Could not prepare the arm64 patch!"
+            exit 1
+        fi 
+
+        cd "${GIT_FOLDER}"
+        git apply "${PATCH_FILENAME}"
+        if [ $? -ne 0 ]
+        then
+            echo "### Could not apply the arm64 patch!"
+            cd "${INITIAL_WORKING_FOLDER}"
+            exit 1
+        fi 
+
+        cd "${INITIAL_WORKING_FOLDER}"
+    fi
+}
+
+build_libmediasoupclient() {
+    # Prepare build parameters
+    case "${ARCHITECTURE}" in
+        arm64)
+            MIN_MACOS_VERSION=11.0
+            ;;
+        x86_64)
+            MIN_MACOS_VERSION=10.15
+            ;;
+        *)
+            echo "### Unknown architecture! Only 'arm64' or 'x86_64' is supported."
+            exit 1
+            ;;
+    esac
+
+    # Check if the build folder exists
+    if [ -d "${BUILD_FOLDER}" ]
+    then
+        echo "### The '${BUILD_FOLDER}' folder exists. Configuring will be skiped. Remove the folder if you want to configure from scratch."
+        cd "${BUILD_FOLDER}"
+    else
+        mkdir -p "${BUILD_FOLDER}"
+        if [ $? -ne 0 ]
+        then
+            echo "### Could not create the build folder: ${BUILD_FOLDER}"
+            exit 1
+        fi
+        cd "${BUILD_FOLDER}"
+        cmake .. -DLIBWEBRTC_INCLUDE_PATH="${WEBRTC_INCLUDE_FOLDER}" -DLIBWEBRTC_BINARY_PATH="${WEBRTC_LIB_FOLDER}" -DCMAKE_OSX_ARCHITECTURES="${ARCHITECTURE}" -DCMAKE_OSX_DEPLOYMENT_TARGET=${MIN_MACOS_VERSION}
+        if [ $? -ne 0 ]
+        then
+            echo "### Could not configure to build for ${ARCHITECTURE}"
+            cd "${INITIAL_WORKING_FOLDER}"
+            exit 1
+        fi
+    fi
+
+    cmake --build .
+    if [ $? -ne 0 ]
+    then
+        echo "### Build failed for ${ARCHITECTURE}"
+        cd "${INITIAL_WORKING_FOLDER}"
+        exit 1
+    fi    
+}
+
+package_libmediasoupclient() {
+    PACKAGE_FOLDER_NAME=libmediasoupclient-dist-osx-$(git -C ${GIT_FOLDER} rev-parse --short HEAD)-b$(date +'%y%m%d')-${ARCHITECTURE}
+    PACKAGE_FOLDER=${INITIAL_WORKING_FOLDER}/${PACKAGE_FOLDER_NAME}
+
+    if [ -d "${PACKAGE_FOLDER}" ]; then
+        echo "### Package folder ${PACKAGE_FOLDER} exists. Plrease remove it manually and start the script again."
+        exit 1    
+    fi
+
+    # Create the folder
+    echo "### Creating the package folder: ${PACKAGE_FOLDER}"
+    mkdir -p "${PACKAGE_FOLDER}/include/mediasoupclient"
+    mkdir -p "${PACKAGE_FOLDER}/include/sdptransform"
+    mkdir -p "${PACKAGE_FOLDER}/lib"
+    
+    # Copy libs
+    echo "### Copying libraries ..."
+    cp "${BUILD_FOLDER}/libmediasoupclient.a" "${PACKAGE_FOLDER}/lib"
+    cp "${BUILD_FOLDER}/libsdptransform/libsdptransform.a" "${PACKAGE_FOLDER}/lib"
+
+    # Copy includes    
+    echo "### Copying includes ..."
+    cp -R "${GIT_FOLDER}/include/." "${PACKAGE_FOLDER}/include/mediasoupclient"
+    cp -R "${GIT_FOLDER}/deps/libsdptransform/include/." "${PACKAGE_FOLDER}/include/sdptransform"
+
+    # Copy the script
+    cp "${SCRIPT_PATH}" "${PACKAGE_FOLDER}"
+
+    cd ${INITIAL_WORKING_FOLDER}
+
+    # Zip everything
+    echo "### Compressing ..."
+    zip --quiet --recurse-paths ${PACKAGE_FOLDER_NAME}.zip ${PACKAGE_FOLDER_NAME}
+}
+
+# SCRIPT START
+
+ARCHITECTURE=$(uname -m)
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --architecture=*)
+            ARCHITECTURE="${1#*=}"
+            ;;
+        --webrtc-include-folder=*)
+            WEBRTC_INCLUDE_FOLDER="${1#*=}"
+            ;;
+        --webrtc-lib-folder=*)
+            WEBRTC_LIB_FOLDER="${1#*=}"
+            ;;
+        *)
+            echo "### Error: Invalid command line parameter. Please use --architecture=arm64|x86_64 --webrtc-include-folder=...  --webrtc-lib-folder=..."
+            exit 1
+    esac
+    shift
+done
+
+if [ -z "${WEBRTC_INCLUDE_FOLDER}" ]; then
+    echo "### The webrtc include folder is not set. Please specify --webrtc-include-folder=..."
+    exit 1
+fi
+
+if [ -z "${WEBRTC_LIB_FOLDER}" ]; then
+    echo "### The webrtc lib folder is not set. Please specify --webrtc-lib-folder=..."
+    exit 1
+fi
+
+INITIAL_WORKING_FOLDER=${PWD}
+SCRIPT_PATH=$(realpath $0)
+GIT_FOLDER_NAME=libmediasoupclient
+GIT_FOLDER=${PWD}/${GIT_FOLDER_NAME}
+BUILD_FOLDER_NAME=build-${ARCHITECTURE}
+BUILD_FOLDER=${GIT_FOLDER}/${BUILD_FOLDER_NAME}
+
+# Check if git is available
+if ! command -v git &> /dev/null
+then
+    echo "'git' could not be found. Please install 'git' and start the script again."
+    exit 1
+fi
+
+# Download the sources
+download_libmediasoupclient
+
+# Patch if necessary
+patch_libmediasoupclient
+
+# Build
+build_libmediasoupclient
+
+# Package
+package_libmediasoupclient

--- a/slobs_CI/macos-deps/create-obs-deps-package.zsh
+++ b/slobs_CI/macos-deps/create-obs-deps-package.zsh
@@ -1,0 +1,264 @@
+#!/bin/zsh
+
+# 1. Place the script to an empty folder
+# 2. ./create-obs-deps-package.zsh --architecture=arm64
+# 3. ./create-obs-deps-package.zsh --architecture=x86_64
+
+download_obs_deps() {    
+    # Check if the webrtc folder exists
+    if [ -d "${GIT_FOLDER}" ]
+    then
+        echo "### The '${GIT_FOLDER}' folder exists. It will be reused. Remove it if you want to clone the git repositoty again."
+        return
+    fi
+
+    # Clone
+    git clone --recurse-submodules https://github.com/obsproject/obs-deps.git ${GIT_FOLDER}
+    if [ $? -ne 0 ]
+    then
+        echo "### Could not clone!"
+        exit 1
+    fi
+
+    # Check if the source folder name is correct and the folder exists
+    if [ ! -d "${GIT_FOLDER}" ]
+    then
+        echo "### The source folder '${GIT_FOLDER}' could not be found. Probably the 'git clone' command failed. Please check manually!"
+        exit 1
+    fi
+
+    cd "${GIT_FOLDER}"
+    git checkout -b ${GIT_TAG}-$(date +"%s") ${GIT_TAG}
+    if [ $? -ne 0 ]
+    then
+        echo "### Could not checkout the tag ${GIT_TAG}"
+        cd "${INITIAL_WORKING_FOLDER}"
+        exit 1
+    fi
+
+    cd "${INITIAL_WORKING_FOLDER}"
+}
+
+patch_obs_deps() {
+    ONLY_FOR_TAG=2022-08-02
+    if [ "${GIT_TAG}" != "${ONLY_FOR_TAG}" ]; then
+        echo "### Review patch_obs_deps() function in this script which is written for obs_deps ${ONLY_FOR_TAG}. Modify it to patch obs_deps ${GIT_TAG} correctly!"
+        cd "${INITIAL_WORKING_FOLDER}"
+        exit 1        
+    fi
+
+    # Copy the prepared C++ patch first
+    CUVIDDEC_C_PATCH=${GIT_FOLDER}/deps.ffmpeg/patches/FFmpeg/0004-FFmpeg-5.0.1-cuvid.patch
+    if [ ! -d "${CUVIDDEC_C_PATCH}" ]
+    then
+        echo "### Saving ${CUVIDDEC_C_PATCH} ..."
+
+        cat <<'EOT' > "${CUVIDDEC_C_PATCH}"
+diff --git a/libavcodec/cuviddec.c b/libavcodec/cuviddec.c
+index f03bbd8..7b8ec3a 100644
+--- a/libavcodec/cuviddec.c
++++ b/libavcodec/cuviddec.c
+@@ -817,7 +817,7 @@ static av_cold int cuvid_decode_init(AVCodecContext *avctx)
+                                    &ctx->resize.width, &ctx->resize.height) != 2) {
+         av_log(avctx, AV_LOG_ERROR, "Invalid resize expressions\n");
+         ret = AVERROR(EINVAL);
+-        goto error;
++        return ret;
+     }
+ 
+     if (ctx->crop_expr && sscanf(ctx->crop_expr, "%dx%dx%dx%d",
+@@ -825,13 +825,13 @@ static av_cold int cuvid_decode_init(AVCodecContext *avctx)
+                                  &ctx->crop.left, &ctx->crop.right) != 4) {
+         av_log(avctx, AV_LOG_ERROR, "Invalid cropping expressions\n");
+         ret = AVERROR(EINVAL);
+-        goto error;
++        return ret;
+     }
+ 
+     ret = cuvid_load_functions(&ctx->cvdl, avctx);
+     if (ret < 0) {
+         av_log(avctx, AV_LOG_ERROR, "Failed loading nvcuvid.\n");
+-        goto error;
++        return ret;
+     }
+ 
+     ctx->frame_queue = av_fifo_alloc(ctx->nb_surfaces * sizeof(CuvidParsedFrame));
+EOT
+        if [ $? -ne 0 ]
+        then
+            echo "### Could not save patch: ${CUVIDDEC_C_PATCH}"
+            cd "${INITIAL_WORKING_FOLDER}"
+            exit 1
+        fi
+    else
+        echo "### Found ${CUVIDDEC_C_PATCH}"
+    fi
+
+    FFMPEG_ZSH_PATCH=${GIT_FOLDER}/99-ffmpeg-zsh.patch
+    FFMPEG_ZSH=${GIT_FOLDER}/deps.ffmpeg/99-ffmpeg.zsh
+    if grep -q "0004-FFmpeg-5.0.1-cuvid.patch" "${FFMPEG_ZSH}"
+    then
+        echo "### It looks like the '${FFMPEG_ZSH} does not need to be patched!"
+    else
+        echo "### Saving ${FFMPEG_ZSH_PATCH} ..."
+
+        cat <<'EOT' > "${FFMPEG_ZSH_PATCH}"
+--- a/deps.ffmpeg/99-ffmpeg.zsh	2023-01-24 20:34:49
++++ b/deps.ffmpeg/99-ffmpeg.zsh	2023-01-24 20:50:51
+@@ -12,6 +12,8 @@
+     710fb5a381f7b68c95dcdf865af4f3c63a9405c305abef55d24c7ab54e90b182"
+   "* ${0:a:h}/patches/FFmpeg/0003-FFmpeg-5.0.1-librist-7f3f3539e8.patch \
+     6b5797b7d897d04db5c8d82009a3705c330fc7461676d51712b1012ff0916f0b"
++  "* ${0:a:h}/patches/FFmpeg/0004-FFmpeg-5.0.1-cuvid.patch \
++    d44609a43f7f09819c74cdfa6fa90c9a1de61b3673aa95e87a294c259f203717"
+ )
+ 
+ ## Build Steps
+@@ -210,6 +212,8 @@
+     --disable-outdev=sdl
+     --disable-doc
+     --disable-postproc
++    --disable-encoder="hevc"
++    --disable-decoder="hevc"
+   )
+ 
+   if (( ! shared_libs )) args+=(--pkg-config-flags="--static")
+EOT
+        if [ $? -ne 0 ]
+        then
+            echo "### Could not save patch: ${FFMPEG_ZSH_PATCH}"
+            cd "${INITIAL_WORKING_FOLDER}"
+            exit 1
+        fi
+
+        cd "${GIT_FOLDER}"
+        echo "### Patching '${FFMPEG_ZSH}' ..."
+        git apply "${FFMPEG_ZSH_PATCH}"
+        if [ $? -ne 0 ]
+        then
+            echo "### Could not apply the FFmpeg patch to disable HEVC: ${FFMPEG_ZSH_PATCH}"
+            cd "${INITIAL_WORKING_FOLDER}"
+            exit 1
+        fi 
+    fi
+
+    cd "${INITIAL_WORKING_FOLDER}"
+}
+
+build_obs_deps() {
+    cd ${GIT_FOLDER}
+    echo "### ./build-deps.zsh --target macos-${ARCHITECTURE} --config Release --shared"
+    ./build-deps.zsh --target macos-${ARCHITECTURE} --config Release --shared
+    if [ $? -ne 0 ]
+    then
+        echo "### ./build-deps.zsh failed for ${ARCHITECTURE}"
+        cd "${INITIAL_WORKING_FOLDER}"
+        exit 1
+    fi
+    echo "### ./build-ffmpeg.zsh --target macos-${ARCHITECTURE} --config Release --static"
+    ./build-ffmpeg.zsh --target macos-${ARCHITECTURE} --config Release --static
+    if [ $? -ne 0 ]
+    then
+        echo "### ./build-ffmpeg.zsh failed for ${ARCHITECTURE}"
+        cd "${INITIAL_WORKING_FOLDER}"
+        exit 1
+    fi
+    cd "${INITIAL_WORKING_FOLDER}"
+}
+
+package_obs_deps() {
+    PACKAGE_FOLDER_NAME=macos-deps-${GIT_TAG}-b$(date +'%y%m%d')-${ARCHITECTURE}-sl
+    PACKAGE_FOLDER=${INITIAL_WORKING_FOLDER}/${PACKAGE_FOLDER_NAME}
+
+    if [ -d "${PACKAGE_FOLDER}" ]; then
+        echo "### Package folder ${PACKAGE_FOLDER} exists. Plrease remove it manually and start the script again."
+        exit 1    
+    fi
+
+    echo "### Copying files for the package ..."
+
+    OBS_DEPS_ARCH_FOLDER=${GIT_FOLDER}/macos-${ARCHITECTURE}/obs-deps-${ARCHITECTURE}/
+    cp -R "${OBS_DEPS_ARCH_FOLDER}" "${PACKAGE_FOLDER}"
+    if [ $? -ne 0 ]
+    then
+        echo "### Could not copy the folder: ${OBS_DEPS_ARCH_FOLDER}"
+        cd "${INITIAL_WORKING_FOLDER}"
+        exit 1
+    fi
+
+    OBS_FFMPEG_ARCH_FOLDER=${GIT_FOLDER}/macos-${ARCHITECTURE}/obs-ffmpeg-${ARCHITECTURE}/
+    cp -R "${OBS_FFMPEG_ARCH_FOLDER}" "${PACKAGE_FOLDER}"
+    if [ $? -ne 0 ]
+    then
+        echo "### Could not copy the folder: ${OBS_FFMPEG_ARCH_FOLDER}"
+        cd "${INITIAL_WORKING_FOLDER}"
+        exit 1
+    fi
+
+    FFMPEG_PATH=${GIT_FOLDER}/macos_build_temp/FFmpeg-5.0.1/build_${ARCHITECTURE}/ffmpeg
+    cp "${FFMPEG_PATH}" "${PACKAGE_FOLDER}/lib"
+    if [ $? -ne 0 ]
+    then
+        echo "### Could not copy the file: ${FFMPEG_PATH}"
+        cd "${INITIAL_WORKING_FOLDER}"
+        exit 1
+    fi
+
+    FFPROBE=${GIT_FOLDER}/macos_build_temp/FFmpeg-5.0.1/build_${ARCHITECTURE}/ffprobe
+    cp "${FFPROBE}" "${PACKAGE_FOLDER}/lib"
+    if [ $? -ne 0 ]
+    then
+        echo "### Could not copy the file: ${FFPROBE}"
+        cd "${INITIAL_WORKING_FOLDER}"
+        exit 1
+    fi
+
+    cp "${SCRIPT_PATH}" "${PACKAGE_FOLDER}"
+
+    echo "### Compressing the package ..."
+    cd ${PACKAGE_FOLDER_NAME}
+    tar -cJf "../${PACKAGE_FOLDER_NAME}.tar.xz" .
+
+    cd "${INITIAL_WORKING_FOLDER}"
+}
+
+# SCRIPT START
+
+ARCHITECTURE=$(uname -m)
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --architecture=*)
+            ARCHITECTURE="${1#*=}"
+            ;;
+        *)
+            echo "### Error: Invalid command line parameter. Please use --architecture=..."
+            exit 1
+    esac
+    shift
+done
+
+INITIAL_WORKING_FOLDER=${PWD}
+SCRIPT_PATH=$(realpath $0)
+GIT_FOLDER_NAME=obs-deps-${ARCHITECTURE}
+GIT_FOLDER=${PWD}/${GIT_FOLDER_NAME}
+GIT_TAG=2022-08-02
+
+# Check if git is available
+if ! command -v git &> /dev/null
+then
+    echo "'git' could not be found. Please install 'git' and start the script again."
+    exit 1
+fi
+
+# Download the sources
+download_obs_deps
+
+# Patch to disable HEVC
+patch_obs_deps
+
+# Build
+build_obs_deps
+
+# Package
+package_obs_deps

--- a/slobs_CI/macos-deps/create-webrtc-package.zsh
+++ b/slobs_CI/macos-deps/create-webrtc-package.zsh
@@ -1,0 +1,312 @@
+#!/bin/zsh
+
+# 1. Put the script to an empty folder
+# 2. ./create-webrtc-package.zsh --architecture=arm64
+# 3. ./create-webrtc-package.zsh --architecture=x86_64
+
+# If you have the following error during gclient sync:
+#   Error: Command 'python3 src/tools/clang/scripts/update.py' returned non-zero exit status 1 in /Users/eugen/devel/sl-webrtc-1/webrtc
+#   Downloading https://commondatastorage.googleapis.com/chromium-browser-clang/Mac_arm64/clang-llvmorg-16-init-17653-g39da55e8-2.tar.xz 
+#   <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:992)>
+#   Retrying in 5 s ...
+# Update Python 3 certificates. Just browse to Applications/Python 3.6 and double-click Install Certificates.command
+# if you installed Python 3 via the official installer.
+
+# if you have the following error during gclient sync:
+# 0> Downloading src/third_party/test_fonts/test_fonts.tar.gz@336e775eec536b2d785cc80eff6ac39051931286...
+# 0> Failed to fetch file gs://chromium-fonts/336e775eec536b2d785cc80eff6ac39051931286 for src/third_party/test_fonts/test_fonts.tar.gz, skipping. [Err: ]
+# 1. Check that your python/python3 is not outdated.
+#    Some google answers will recommend you to remove access to the system python binaries and force depot_tools/python-bin/python3
+#    That did not help me.
+# 2. After debugging download_from_google_storage.py I saw this warning: 
+#    "Using luci-auth login since OOB is deprecated.
+#    Override luci-auth by setting `BOTO_CONFIG` in your env.
+#    Not logged in.
+#    Login by running:
+#    $ gsutil.py config"
+#    So, run that command. It will show you some instructions and you have to login with you gmail/company account to chromium.org.
+# 3. Unfortunately, 2nd step did not help me enough. It is possible you have go to https://cloud.google.com/console#/project
+#    to accept the license. Then, run "gsutil.py config" again.
+# It looks like this feature is being developed right now. So the solution may be easier or more complicated in the future.
+
+# If you have the following error during compilation:
+#   NSString.h:371:81: error: function does not return string type
+# or other compilation erros on macOS Ventura and later/Xcode 14,
+# you have to downgrade to an older XCode version (for me Xcode 13 worked).
+# Download it from here: https://developer.apple.com/download/more/
+# Unpack it and copy to the /Application folder, then run sudo xcode-select --switch /Applications/Xcode-13.4.app/
+
+# if you have the following error during compilation:
+#   FAILED: nasm 
+#   TOOL_VERSION=1674864830 ../../build/toolchain/apple/linker_driver.py ...
+#   env: python: No such file or directory
+# then the solution should be something like this: sudo ln -sf /usr/bin/python3 /usr/local/bin/python
+# Unfortunately, that did not help me. Xcode started to ask me to install command line tools repeatedly.
+# Even using python3 from an Xcode subfolder did not help.
+# So, do the following:
+# - Delete the webrtc-checkout/src/... folders.
+# - Edit webrtc-checkout/src/build/toolchain/apple/toolchain.gni by changing
+#     linker_driver =
+#        "TOOL_VERSION=${tool_versions.linker_driver} " +
+#        rebase_path("//build/toolchain/apple/linker_driver.py", root_build_dir)
+#   to
+#     linker_driver =
+#        "TOOL_VERSION=${tool_versions.linker_driver} python3 " +
+#        rebase_path("//build/toolchain/apple/linker_driver.py", root_build_dir)
+
+install_depot_tools() {
+    # mkdir depot_tools
+    # cd depot_tools
+    # git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+    # export PATH=$PWD:$PATH
+    # cd ..
+
+    # Check if the folder exists
+    if [ -d "depot_tools" ]
+    then
+        echo "### The 'depot_tools' folder exists. Please delete it or install 'depot_tools' manually and add to the PATH, then start the script again."
+        exit 1
+    fi
+    # Clone
+    echo "### git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git"
+    git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git depot_tools
+    # Check if failed
+    if [ $? -ne 0 ]
+    then
+        echo "### Could not install 'depot_tools'. Please install it manually and add to the PATH, then start the script again."
+        exit 1
+    fi
+    # Add to PATH
+    export PATH=${PWD}/depot_tools:$PATH
+}
+
+download_webrtc() {
+    # mkdir webrtc
+    # cd webrtc
+    # fetch --nohooks webrtc
+    # gclient sync
+    # cd src
+    # git checkout -b m94 refs/remotes/branch-heads/4606
+    # gclient sync
+
+    if [ -d "${SRC_PARENT_FOLDER}" ]
+    then
+        echo "### The sources will not be downloaded because '${SRC_PARENT_FOLDER}' exists. Remove it manually if you want to re-download the sources!"
+        if [ ! -d "${GIT_FOLDER}" ]
+        then
+            echo "### '${GIT_FOLDER}' does not exist. The sources are broken. Remove '${SRC_PARENT_FOLDER}' and restart the script."
+            exit 1
+        fi
+        return
+    fi
+
+    # Create the source parent folder
+    mkdir "${SRC_PARENT_FOLDER}"
+    cd "${SRC_PARENT_FOLDER}"
+
+    # Fetch the source code
+    echo "### fetch --nohooks webrtc"
+    fetch --nohooks webrtc
+    if [ $? -ne 0 ]
+    then
+        echo "### Could not fetch the webrtc source code."
+        cd "${INITIAL_WORKING_FOLDER}"
+        exit 1
+    fi
+
+    # Check if the source folder name is correct and the folder exists
+    if [ ! -d "${GIT_FOLDER}" ]
+    then
+        echo "### The source folder '${GIT_FOLDER}' could not be found. Probably the 'fetch' command failed. Please check manually"
+        cd "${INITIAL_WORKING_FOLDER}"
+        exit 1
+    fi
+
+    # Sync
+    echo "### gclient sync"
+    gclient sync
+    if [ $? -ne 0 ]
+    then
+        echo "Could not sync the webrtc source code."
+        cd "${INITIAL_WORKING_FOLDER}"
+        exit 1
+    fi
+
+    # Get the appropriate version
+    cd "${GIT_FOLDER}"
+    echo "### git checkout -b ${GIT_BRANCH_NAME} ${GIT_REFS}"
+    git checkout -b ${VERSION_NAME} ${GIT_REFS}
+    if [ $? -ne 0 ]
+    then
+        echo "### Could not checkout the appropriate webrtc version."
+        cd "${INITIAL_WORKING_FOLDER}"
+        exit 1
+    fi
+
+    # Sync
+    echo "### gclient sync -D"
+    gclient sync -D
+    if [ $? -ne 0 ]
+    then
+        echo "### Could not sync the webrtc source code."
+        cd "${INITIAL_WORKING_FOLDER}"
+        exit 1
+    fi
+}
+
+build_webrtc() {
+    # cd src
+    # gn gen out/m94-arm64 --args='target_os="mac" target_cpu="arm64" mac_deployment_target="11.0" mac_min_system_version="11.0" mac_sdk_min="11.0" is_debug=false is_component_build=false is_clang=true rtc_include_tests=false use_rtti=true use_custom_libcxx=false treat_warnings_as_errors=false' --ide=xcode
+    # ninja -C out/m94-arm64
+    # gn gen out/m94-x86_64 --args='target_os="mac" target_cpu="x64" mac_deployment_target="10.15.0" mac_min_system_version="10.15.0" mac_sdk_min="10.15" is_debug=false is_component_build=false is_clang=true rtc_include_tests=false use_rtti=true use_custom_libcxx=false treat_warnings_as_errors=false' --ide=xcode
+    # ninja -C out/m94-x86_64
+
+    # Prepare build parameters
+    case "${ARCHITECTURE}" in
+        arm64)    
+            PARAMS="target_os=\"mac\" target_cpu=\"arm64\" mac_deployment_target=\"11.0\" mac_min_system_version=\"11.0\" mac_sdk_min=\"11.0\""
+            ;;
+        x86_64)
+            PARAMS="target_os=\"mac\" target_cpu=\"x64\" mac_deployment_target=\"10.15.0\" mac_min_system_version=\"10.15.0\" mac_sdk_min=\"10.15\""
+            ;;
+        *)
+            echo "Unknown architecture! Only 'arm64' or 'x86_64' is supported."
+            exit 1
+            ;;
+    esac
+
+    cd "${GIT_FOLDER}"
+
+    # Check if the folder exists
+    if [ -d "${BUILD_FOLDER_REL}" ]
+    then
+        echo "### The build folder '${BUILD_FOLDER}' exits. It will not be reconfigured. Remove it manually if you want to configure it from scratch."
+    else
+        # Configure
+        echo "### gn gen ${BUILD_FOLDER_REL} ..."
+        gn gen ${BUILD_FOLDER_REL} --args="${PARAMS} is_debug=false is_component_build=false is_clang=true rtc_include_tests=false use_rtti=true use_custom_libcxx=false treat_warnings_as_errors=false" --ide=xcode
+        if [ $? -ne 0 ]
+        then
+            echo "### Could not configure to build for ${ARCHITECTURE}"
+            cd "${INITIAL_WORKING_FOLDER}"
+            exit 1
+        fi    
+    fi
+
+    # Build
+    echo "### ninja -C ${BUILD_FOLDER_REL} ..."
+    ninja -C ${BUILD_FOLDER_REL}
+    if [ $? -ne 0 ]
+    then
+        echo "### Could not build for ${ARCHITECTURE}"
+        cd "${INITIAL_WORKING_FOLDER}"
+        exit 1
+    fi
+
+    cd "${INITIAL_WORKING_FOLDER}"
+}
+
+package_webrtc() {
+    PACKAGE_FOLDER_NAME=webrtc-dist-osx-${VERSION_NAME}-b$(date +'%y%m%d')-${ARCHITECTURE}
+    PACKAGE_FOLDER=${INITIAL_WORKING_FOLDER}/${PACKAGE_FOLDER_NAME}
+    if [ -d "$PACKAGE_FOLDER" ]
+    then
+        echo "### Package folder ${PACKAGE_FOLDER} exists. Remove it manually and start the script again."
+        exit 1    
+    fi
+    if [ -e "$PACKAGE_FOLDER.zip" ]
+    then
+        echo "### The package ${PACKAGE_FOLDER}.zip exists. Remove it manually and start the script again."
+        exit 1    
+    fi   
+    echo "### Creating the package folder: ${PACKAGE_FOLDER}"
+    # Create the package root folder
+    mkdir -p "${PACKAGE_FOLDER}"
+    # Copy libs
+    echo "### Copying libraries ..."
+    cp "${BUILD_FOLDER}/obj/libwebrtc.a" "${PACKAGE_FOLDER}"
+    # Copy includes
+    echo "### Copying includes ..."
+    cd "${GIT_FOLDER}"
+    find . -name '*.h' -not -path "./out/*" | cpio -pdm "${PACKAGE_FOLDER}"
+    echo "### Copying some sources ..."
+    # We also need some *.cc; if you like, just include all ccs
+    #find . -name '*.cc' -not -path "./out/*" | cpio -pdm "${PACKAGE_FOLDER}"
+    # Here I am trying to reduce the size of the package by including only what is necessary.
+    cd "${GIT_FOLDER}/test"
+    find . -name '*.cc' | cpio -pdm "${PACKAGE_FOLDER}/test"    
+    cd "${GIT_FOLDER}/api/test"
+    find . -name '*.cc' | cpio -pdm "${PACKAGE_FOLDER}/api/test"
+    cd "${GIT_FOLDER}/media/base"
+    find . -name '*.cc' | cpio -pdm "${PACKAGE_FOLDER}/media/base"
+    cd "${GIT_FOLDER}/pc/test"
+    find . -name '*.cc' | cpio -pdm "${PACKAGE_FOLDER}/pc/test"
+    cd "${GIT_FOLDER}/rtc_base"
+    find . -name '*.cc' | cpio -pdm "${PACKAGE_FOLDER}/rtc_base"
+
+    # Copy the script
+    cp "${SCRIPT_PATH}" "${PACKAGE_FOLDER}"
+
+    cd ${INITIAL_WORKING_FOLDER}
+
+    # Zip everything
+    echo "### Compressing ..."
+    zip --quiet --recurse-paths ${PACKAGE_FOLDER_NAME}.zip ${PACKAGE_FOLDER_NAME}
+}
+
+# SCRIPT START
+
+ARCHITECTURE=$(uname -m)
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --architecture=*)
+            ARCHITECTURE="${1#*=}"
+            ;;
+        *)
+            echo "Error: Invalid command line parameter. Please use --architecture=\"arm64\" or --architecture=\"x86_64\"."
+            exit 1
+    esac
+    shift
+done
+
+INITIAL_WORKING_FOLDER=${PWD}
+SCRIPT_PATH=$(realpath $0)
+SRC_PARENT_FOLDER_NAME=webrtc-checkout
+SRC_PARENT_FOLDER=${PWD}/${SRC_PARENT_FOLDER_NAME}
+GIT_FOLDER_NAME=src
+GIT_FOLDER=${SRC_PARENT_FOLDER}/${GIT_FOLDER_NAME}
+GIT_REFS=refs/remotes/branch-heads/4606
+VERSION_NAME=m94
+BUILD_FOLDER_NAME=${VERSION_NAME}-${ARCHITECTURE}
+BUILD_FOLDER_REL=out/${BUILD_FOLDER_NAME}
+BUILD_FOLDER=${GIT_FOLDER}/${BUILD_FOLDER_REL}
+
+# Check if git is available
+if ! command -v git &> /dev/null
+then
+    echo "'git' could not be found. Please install 'git' and start the script again."
+    exit 1
+fi
+
+# Check if depot_tools are available
+if ! command -v gclient &> /dev/null
+then
+    # Check the subfolder
+    export PATH=${PWD}/depot_tools:$PATH
+    if ! command -v gclient &> /dev/null
+    then
+        echo "Could not find 'depot_tools'. Installing..."
+        install_depot_tools
+    fi
+fi
+
+# Downlaod the source code if it is necessary
+download_webrtc
+
+# Build 
+build_webrtc
+
+# Package
+package_webrtc
+


### PR DESCRIPTION
### Description
1. Wrote macOS/zsh scripts to compile Streamlabs versions of obs-studio dependencies.
2. Recompiled all the dependencies for both x86_64/arm64.
3. Modified macOS scripts to build x86_64 obs-studio on Intel based macs, arm64 on Apple Silicon macs. You can specify  architecture with `export ARCH=x86_64|arm64'
4. Modified `main-streamlabs.yml` because the build scripts use it.

### Motivation and Context
This PR adds mac arm64/M1/M2 support.

### How Has This Been Tested?
Compiled on x86_64/arm64 macs, used with a modified obs-studio-node built for the architectures, tested with x86_64 desktop.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
