### PR TITLE
Add missing support for plugin 'filter_add' in libobs

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -3034,6 +3034,10 @@ void obs_source_filter_add(obs_source_t *source, obs_source_t *filter)
 
 	blog(LOG_DEBUG, "- filter '%s' (%s) added to source '%s'",
 	     filter->context.name, filter->info.id, source->context.name);
+
+	if (filter->info.filter_add)
+		filter->info.filter_add(filter->context.data,
+					filter->filter_parent);
 }
 
 static bool obs_source_filter_remove_refless(obs_source_t *source,


### PR DESCRIPTION
### Description
There is a function titled 'filter_add' described as "Called when the filter is added to a source". It's never actually consumed anywhere in libobs. This was probably never noticed because it doesn't seem to be used by any plugins other than our own mediasoup-connector, while 'filter_remove' on the other hand is in use by async_delay_filter

### Motivation and Context
An obviously missing snippet of code, and necessary for the functionality of "Share Video Source" in our Collab Cam feature.

### How Has This Been Tested?
Compiled and swapped dll's. The function is called and the Collab Cam feature now works.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
