### PR TITLE
Apple Software H.264 fallback to ABR if CBR is not supported

### DIFF
--- a/plugins/mac-videotoolbox/encoder.c
+++ b/plugins/mac-videotoolbox/encoder.c
@@ -178,18 +178,18 @@ static OSStatus session_set_bitrate(VTCompressionSessionRef session,
 					can_limit_bitrate = false;
 				} else {
 					VT_LOG(LOG_WARNING,
-				    	   "CBR support for VideoToolbox encoder requires Apple Silicon. "
-				           "Will use ABR instead.");
+					       "CBR support for VideoToolbox encoder requires Apple Silicon. "
+					       "Will use ABR instead.");
 				}
 #else
 				VT_LOG(LOG_WARNING,
-			       	   "CBR support for VideoToolbox not available in this build of OBS. "
-			       	   "Will use ABR instead.");
+				       "CBR support for VideoToolbox not available in this build of OBS. "
+				       "Will use ABR instead.");
 #endif
 			} else {
 				VT_LOG(LOG_WARNING,
-			    	   "CBR support for VideoToolbox encoder requires macOS 13 or newer. "
-			       	   "Will use ABR instead.");
+				       "CBR support for VideoToolbox encoder requires macOS 13 or newer. "
+				       "Will use ABR instead.");
 			}
 		} else if (strcmp(rate_control, "ABR") == 0) {
 			compressionPropertyKey =
@@ -204,37 +204,41 @@ static OSStatus session_set_bitrate(VTCompressionSessionRef session,
 				compressionPropertyKey =
 					kVTCompressionPropertyKey_Quality;
 				SESSION_CHECK(session_set_prop_float(
-					session, compressionPropertyKey, quality));
+					session, compressionPropertyKey,
+					quality));
 			} else {
 				VT_LOG(LOG_WARNING,
-			    	   "CRF support for VideoToolbox encoder requires Apple Silicon. "
-			       	   "Will use ABR instead.");
+				       "CRF support for VideoToolbox encoder requires Apple Silicon. "
+				       "Will use ABR instead.");
 				compressionPropertyKey =
 					kVTCompressionPropertyKey_AverageBitRate;
 			}
 			can_limit_bitrate = true;
 		} else {
 			VT_LOG(LOG_ERROR,
-		    	   "Selected rate control method is not supported: %s",
-		       	rate_control);
+			       "Selected rate control method is not supported: %s",
+			       rate_control);
 			return kVTParameterErr;
 		}
 
-		if (compressionPropertyKey != kVTCompressionPropertyKey_Quality) {
-			code = session_set_prop_int(
-				session, compressionPropertyKey, new_bitrate * 1000);
+		if (compressionPropertyKey !=
+		    kVTCompressionPropertyKey_Quality) {
+			code = session_set_prop_int(session,
+						    compressionPropertyKey,
+						    new_bitrate * 1000);
 			if (code != noErr) {
-				if (compressionPropertyKey == kVTCompressionPropertyKey_ConstantBitRate &&
-						code == kVTPropertyNotSupportedErr &&
-						!cbr_failed) {
+				if (compressionPropertyKey ==
+					    kVTCompressionPropertyKey_ConstantBitRate &&
+				    code == kVTPropertyNotSupportedErr &&
+				    !cbr_failed) {
 					cbr_failed = true;
 					code = noErr;
 					continue; // try to switch to ABR
-				} 
+				}
 				return code;
 			} else {
 				break; // leave the loop
-			}		
+			}
 		} else {
 			break; // leave the loop
 		}

--- a/plugins/mac-videotoolbox/encoder.c
+++ b/plugins/mac-videotoolbox/encoder.c
@@ -151,71 +151,93 @@ static OSStatus session_set_bitrate(VTCompressionSessionRef session,
 {
 	OSStatus code;
 
+	bool cbr_failed = false;
 	bool can_limit_bitrate;
 	CFStringRef compressionPropertyKey;
 
-	if (strcmp(rate_control, "CBR") == 0) {
-		compressionPropertyKey =
-			kVTCompressionPropertyKey_AverageBitRate;
-		can_limit_bitrate = true;
+	// It is possible we may need more than one attempt to choose a correct mode.
+	while (true) {
+		if (strcmp(rate_control, "CBR") == 0) {
+			compressionPropertyKey =
+				kVTCompressionPropertyKey_AverageBitRate;
+			can_limit_bitrate = true;
 
-		if (__builtin_available(macOS 13.0, *)) {
+			if (cbr_failed) {
+				VT_LOG(LOG_WARNING,
+				       "CBR configuration failed. Probably it is not suppported. "
+				       "Will use ABR instead.");
+			} else if (__builtin_available(macOS 13.0, *)) {
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
+#ifdef __aarch64__
+				if (true) {
+#else
+				if (os_get_emulation_status() == true) {
+#endif
+					compressionPropertyKey =
+						kVTCompressionPropertyKey_ConstantBitRate;
+					can_limit_bitrate = false;
+				} else {
+					VT_LOG(LOG_WARNING,
+				    	   "CBR support for VideoToolbox encoder requires Apple Silicon. "
+				           "Will use ABR instead.");
+				}
+#else
+				VT_LOG(LOG_WARNING,
+			       	   "CBR support for VideoToolbox not available in this build of OBS. "
+			       	   "Will use ABR instead.");
+#endif
+			} else {
+				VT_LOG(LOG_WARNING,
+			    	   "CBR support for VideoToolbox encoder requires macOS 13 or newer. "
+			       	   "Will use ABR instead.");
+			}
+		} else if (strcmp(rate_control, "ABR") == 0) {
+			compressionPropertyKey =
+				kVTCompressionPropertyKey_AverageBitRate;
+			can_limit_bitrate = true;
+		} else if (strcmp(rate_control, "CRF") == 0) {
 #ifdef __aarch64__
 			if (true) {
 #else
 			if (os_get_emulation_status() == true) {
 #endif
 				compressionPropertyKey =
-					kVTCompressionPropertyKey_ConstantBitRate;
-				can_limit_bitrate = false;
+					kVTCompressionPropertyKey_Quality;
+				SESSION_CHECK(session_set_prop_float(
+					session, compressionPropertyKey, quality));
 			} else {
 				VT_LOG(LOG_WARNING,
-				       "CBR support for VideoToolbox encoder requires Apple Silicon. "
-				       "Will use ABR instead.");
+			    	   "CRF support for VideoToolbox encoder requires Apple Silicon. "
+			       	   "Will use ABR instead.");
+				compressionPropertyKey =
+					kVTCompressionPropertyKey_AverageBitRate;
 			}
-#else
-			VT_LOG(LOG_WARNING,
-			       "CBR support for VideoToolbox not available in this build of OBS. "
-			       "Will use ABR instead.");
-#endif
+			can_limit_bitrate = true;
 		} else {
-			VT_LOG(LOG_WARNING,
-			       "CBR support for VideoToolbox encoder requires macOS 13 or newer. "
-			       "Will use ABR instead.");
+			VT_LOG(LOG_ERROR,
+		    	   "Selected rate control method is not supported: %s",
+		       	rate_control);
+			return kVTParameterErr;
 		}
-	} else if (strcmp(rate_control, "ABR") == 0) {
-		compressionPropertyKey =
-			kVTCompressionPropertyKey_AverageBitRate;
-		can_limit_bitrate = true;
-	} else if (strcmp(rate_control, "CRF") == 0) {
-#ifdef __aarch64__
-		if (true) {
-#else
-		if (os_get_emulation_status() == true) {
-#endif
-			compressionPropertyKey =
-				kVTCompressionPropertyKey_Quality;
-			SESSION_CHECK(session_set_prop_float(
-				session, compressionPropertyKey, quality));
-		} else {
-			VT_LOG(LOG_WARNING,
-			       "CRF support for VideoToolbox encoder requires Apple Silicon. "
-			       "Will use ABR instead.");
-			compressionPropertyKey =
-				kVTCompressionPropertyKey_AverageBitRate;
-		}
-		can_limit_bitrate = true;
-	} else {
-		VT_LOG(LOG_ERROR,
-		       "Selected rate control method is not supported: %s",
-		       rate_control);
-		return kVTParameterErr;
-	}
 
-	if (compressionPropertyKey != kVTCompressionPropertyKey_Quality) {
-		SESSION_CHECK(session_set_prop_int(
-			session, compressionPropertyKey, new_bitrate * 1000));
+		if (compressionPropertyKey != kVTCompressionPropertyKey_Quality) {
+			code = session_set_prop_int(
+				session, compressionPropertyKey, new_bitrate * 1000);
+			if (code != noErr) {
+				if (compressionPropertyKey == kVTCompressionPropertyKey_ConstantBitRate &&
+						code == kVTPropertyNotSupportedErr &&
+						!cbr_failed) {
+					cbr_failed = true;
+					code = noErr;
+					continue; // try to switch to ABR
+				} 
+				return code;
+			} else {
+				break; // leave the loop
+			}		
+		} else {
+			break; // leave the loop
+		}
 	}
 
 	if (limit_bitrate && can_limit_bitrate) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Added some code to the Apple Software H.264 encoder plugin to fallback to ABR if CBR failed.

### Motivation and Context
The original code uses CBR on macOS 13+ Apple Silicone. I found the same code in the other software. I am not sure if it is correct some sources say that you can even use CBR on Intel machines with the i5 CPU. Anyway, even on an Apple Silicon machine a CBR configuration call fails saying `not supported`.

### How Has This Been Tested?
Tested that the fallback code works.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
