### PR TITLE
Add 'bool obs_output_connecting' to check if output is connecting

### DIFF
--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -2712,6 +2712,14 @@ void obs_output_set_last_error(obs_output_t *output, const char *message)
 		output->last_error_message = NULL;
 }
 
+bool obs_output_connecting(const obs_output_t* output)
+{
+	if (!obs_output_valid(output, "obs_output_reconnecting"))
+		return false;
+
+	return connecting(output);
+}
+
 bool obs_output_reconnecting(const obs_output_t *output)
 {
 	if (!obs_output_valid(output, "obs_output_reconnecting"))

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -2712,12 +2712,12 @@ void obs_output_set_last_error(obs_output_t *output, const char *message)
 		output->last_error_message = NULL;
 }
 
-bool obs_output_connecting(const obs_output_t* output)
+bool obs_output_connecting(const obs_output_t *output)
 {
-	if (!obs_output_valid(output, "obs_output_reconnecting"))
+	if (output->context.data == NULL)
 		return false;
 
-	return connecting(output);
+	return output->info.connecting(output->context.data);
 }
 
 bool obs_output_reconnecting(const obs_output_t *output)

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -2714,7 +2714,7 @@ void obs_output_set_last_error(obs_output_t *output, const char *message)
 
 bool obs_output_connecting(const obs_output_t *output)
 {
-	if (output->context.data == NULL)
+	if (output->info.connecting == NULL || output->context.data == NULL)
 		return false;
 
 	return output->info.connecting(output->context.data);

--- a/libobs/obs-output.h
+++ b/libobs/obs-output.h
@@ -71,6 +71,7 @@ struct obs_output_info {
 
 	float (*get_congestion)(void *data);
 	int (*get_connect_time_ms)(void *data);
+	bool (*connecting)(void *data);
 
 	bool (*is_ready_to_update)(void *data);
 

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2305,8 +2305,9 @@ EXPORT float obs_output_get_congestion(obs_output_t *output);
 EXPORT int obs_output_get_connect_time_ms(obs_output_t *output);
 
 EXPORT bool obs_output_reconnecting(const obs_output_t *output);
+EXPORT bool obs_output_connecting(const obs_output_t *output);
 
-/** Pass a string of the last output error, for UI use */
+	/** Pass a string of the last output error, for UI use */
 EXPORT void obs_output_set_last_error(obs_output_t *output,
 				      const char *message);
 EXPORT const char *obs_output_get_last_error(obs_output_t *output);

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2307,7 +2307,7 @@ EXPORT int obs_output_get_connect_time_ms(obs_output_t *output);
 EXPORT bool obs_output_reconnecting(const obs_output_t *output);
 EXPORT bool obs_output_connecting(const obs_output_t *output);
 
-	/** Pass a string of the last output error, for UI use */
+/** Pass a string of the last output error, for UI use */
 EXPORT void obs_output_set_last_error(obs_output_t *output,
 				      const char *message);
 EXPORT const char *obs_output_get_last_error(obs_output_t *output);

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -1695,4 +1695,5 @@ struct obs_output_info rtmp_output_info = {
 	.get_connect_time_ms = rtmp_stream_connect_time,
 	.get_dropped_frames = rtmp_stream_dropped_frames,
 	.is_ready_to_update = rtmp_stream_is_ready_to_update,
+	.connecting = connecting,
 };


### PR DESCRIPTION
### Description
Adds bool function to output '.connecting' and exposes via exported bool obs_output_connecting

### Motivation and Context
The pointer to obs->video cannot be disrupted during the rtmp-stream connection phase. This exposes a function can be used to check if it is still in the middle of connecting.

### How Has This Been Tested?
Compiled code and stepped through function by triggering OBS_service::doResetVideoContext() in OSN, which how checks for streaming outputs with obs_output_connecting equal to true.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
