### PR TITLE
detach volmeter on remove signal without waiting for destroy

### DIFF
--- a/libobs/obs-audio-controls.c
+++ b/libobs/obs-audio-controls.c
@@ -816,6 +816,8 @@ bool obs_volmeter_attach_source(obs_volmeter_t *volmeter, obs_source_t *source)
 			       volmeter);
 	signal_handler_connect(sh, "destroy", volmeter_source_destroyed,
 			       volmeter);
+	signal_handler_connect(sh, "remove", volmeter_source_destroyed,
+			       volmeter);
 	obs_source_add_audio_capture_callback(
 		source, volmeter_source_data_received, volmeter);
 	vol = obs_source_get_volume(source);
@@ -843,13 +845,15 @@ void obs_volmeter_detach_source(obs_volmeter_t *volmeter)
 	volmeter->source = NULL;
 	pthread_mutex_unlock(&volmeter->mutex);
 
-	if (!source || obs_source_removed(source))
+	if (!source)
 		return;
 
 	sh = obs_source_get_signal_handler(source);
 	signal_handler_disconnect(sh, "volume", volmeter_source_volume_changed,
 				  volmeter);
 	signal_handler_disconnect(sh, "destroy", volmeter_source_destroyed,
+				  volmeter);
+	signal_handler_disconnect(sh, "remove", volmeter_source_destroyed,
 				  volmeter);
 	obs_source_remove_audio_capture_callback(
 		source, volmeter_source_data_received, volmeter);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
detach volmeter from a source as soon as possible. 
add callback for source remove.  
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
