### PR TITLE
fix crash on logging

### DIFF
--- a/CI/check-format.sh
+++ b/CI/check-format.sh
@@ -59,3 +59,5 @@ find . -type d \( \
     -name '*.c' -or \
     -name '*.cpp' \
  | xargs -L100 -P ${NPROC} "${CLANG_FORMAT}" ${VERBOSITY} -i -style=file -fallback-style=none
+
+git diff

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -361,7 +361,8 @@ obs_source_create_internal(const char *id, const char *name,
 		 *
 		 * XXX: Fix design flaws with filters */
 		if (info->type == OBS_SOURCE_TYPE_FILTER)
-		private = true;
+		private 
+		= true;
 	}
 
 	source->mute_unmute_key = OBS_INVALID_HOTKEY_PAIR_ID;

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -361,7 +361,7 @@ obs_source_create_internal(const char *id, const char *name,
 		 *
 		 * XXX: Fix design flaws with filters */
 		if (info->type == OBS_SOURCE_TYPE_FILTER)
-			private = true;
+		private = true;
 	}
 
 	source->mute_unmute_key = OBS_INVALID_HOTKEY_PAIR_ID;

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -361,8 +361,7 @@ obs_source_create_internal(const char *id, const char *name,
 		 *
 		 * XXX: Fix design flaws with filters */
 		if (info->type == OBS_SOURCE_TYPE_FILTER)
-		private
-		= true;
+			private = true;
 	}
 
 	source->mute_unmute_key = OBS_INVALID_HOTKEY_PAIR_ID;
@@ -3071,7 +3070,9 @@ static bool obs_source_filter_remove_refless(obs_source_t *source,
 	signal_handler_signal(source->context.signals, "filter_remove", &cd);
 
 	blog(LOG_DEBUG, "- filter '%s' (%s) removed from source '%s'",
-	     filter->context.name, filter->info.id, source->context.name);
+	     (filter->context.name ? filter->context.name : "null"),
+	     (filter->info.id ? filter->info.id : "null"),
+	     (source->context.name ? source->context.name : "null"));
 
 	if (filter->info.filter_remove)
 		filter->info.filter_remove(filter->context.data,

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -751,7 +751,9 @@ static void obs_source_destroy_defer(struct obs_source *source)
 
 	if (source->owns_info_id) {
 		bfree((void *)source->info.id);
+		source->info.id = NULL;
 		bfree((void *)source->info.unversioned_id);
+		source->info.unversioned_id = NULL;
 	}
 
 	bfree(source);

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -360,9 +360,9 @@ obs_source_create_internal(const char *id, const char *name,
 		 * source enum/search functions.
 		 *
 		 * XXX: Fix design flaws with filters */
-		if (info->type == OBS_SOURCE_TYPE_FILTER) {
-			private = true;
-		}
+		if (info->type == OBS_SOURCE_TYPE_FILTER)
+		private
+		= true;
 	}
 
 	source->mute_unmute_key = OBS_INVALID_HOTKEY_PAIR_ID;

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -360,9 +360,9 @@ obs_source_create_internal(const char *id, const char *name,
 		 * source enum/search functions.
 		 *
 		 * XXX: Fix design flaws with filters */
-		if (info->type == OBS_SOURCE_TYPE_FILTER)
-		private 
-		= true;
+		if (info->type == OBS_SOURCE_TYPE_FILTER) {
+			private = true;
+		}
 	}
 
 	source->mute_unmute_key = OBS_INVALID_HOTKEY_PAIR_ID;

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1337,8 +1337,10 @@ void obs_shutdown(void)
 		struct obs_source_info *item = &obs->source_types.array[i];
 		if (item->type_data && item->free_type_data)
 			item->free_type_data(item->type_data);
-		if (item->id)
+		if (item->id) {
 			bfree((void *)item->id);
+			item->id = NULL;
+		}
 	}
 	da_free(obs->source_types);
 
@@ -2869,6 +2871,7 @@ void obs_context_data_free(struct obs_context_data *context)
 	obs_context_data_remove(context);
 	pthread_mutex_destroy(&context->rename_cache_mutex);
 	bfree(context->name);
+	context->name = NULL;
 
 	for (size_t i = 0; i < context->rename_cache.num; i++)
 		bfree(context->rename_cache.array[i]);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
There is a crash on shutdown when function print logs. 
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
From information available on Sentry name or id might be unallocated but not set to NULL.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
