### PR TITLE
mac-audio.c race condition fix

### DIFF
--- a/plugins/mac-capture/mac-audio.c
+++ b/plugins/mac-capture/mac-audio.c
@@ -33,6 +33,7 @@
 #define TEXT_DEVICE_DEFAULT obs_module_text("CoreAudio.Device.Default")
 
 struct coreaudio_data {
+	pthread_mutex_t mutex;
 	char *device_name;
 	char *device_uid;
 	AudioUnit unit;
@@ -372,9 +373,7 @@ static void coreaudio_uninit(struct coreaudio_data *ca);
 
 static void *reconnect_thread(void *param)
 {
-	struct coreaudio_data *ca = param;
-
-	ca->reconnecting = true;
+	struct coreaudio_data *ca = param;	
 
 	while (os_event_timedwait(ca->exit_event, ca->retry_time) ==
 	       ETIMEDOUT) {
@@ -394,6 +393,9 @@ static void coreaudio_begin_reconnect(struct coreaudio_data *ca)
 	if (ca->reconnecting)
 		return;
 
+	// It is better to set the 'reconnecting' status here to avoid desynchronization.
+	// If the thread creation fails, something is broken anyway.
+	ca->reconnecting = true;
 	ret = pthread_create(&ca->reconnect_thread, NULL, reconnect_thread, ca);
 	if (ret != 0)
 		blog(LOG_WARNING,
@@ -712,11 +714,21 @@ static void coreaudio_destroy(void *data)
 	struct coreaudio_data *ca = data;
 
 	if (ca) {
-		coreaudio_shutdown(ca);
 
-		os_event_destroy(ca->exit_event);
+		pthread_mutex_lock(&ca->mutex);
+
+		coreaudio_shutdown(ca);		
+
 		bfree(ca->device_name);
 		bfree(ca->device_uid);
+
+		os_event_destroy(ca->exit_event);
+		ca->exit_event = NULL;
+
+		pthread_mutex_unlock(&ca->mutex);
+
+		pthread_mutex_destroy(&ca->mutex);
+
 		bfree(ca);
 	}
 }
@@ -725,12 +737,16 @@ static void coreaudio_update(void *data, obs_data_t *settings)
 {
 	struct coreaudio_data *ca = data;
 
+	pthread_mutex_lock(&ca->mutex);
+
 	coreaudio_shutdown(ca);
 
 	bfree(ca->device_uid);
 	ca->device_uid = bstrdup(obs_data_get_string(settings, "device_id"));
 
 	coreaudio_try_init(ca);
+
+	pthread_mutex_unlock(&ca->mutex);
 }
 
 static void coreaudio_defaults(obs_data_t *settings)
@@ -742,6 +758,18 @@ static void *coreaudio_create(obs_data_t *settings, obs_source_t *source,
 			      bool input)
 {
 	struct coreaudio_data *ca = bzalloc(sizeof(struct coreaudio_data));
+
+	if (pthread_mutex_init(&ca->mutex, NULL) != 0) {
+		blog(LOG_ERROR,
+		     "[coreaudio_create] failed to create "
+		     "mutex: %d",
+		     errno);
+		bfree(ca);
+		return NULL;
+	}
+
+	// This is obviosly overhead here but let's just be consistent
+	pthread_mutex_lock(&ca->mutex);
 
 	if (os_event_init(&ca->exit_event, OS_EVENT_TYPE_MANUAL) != 0) {
 		blog(LOG_ERROR,
@@ -760,6 +788,9 @@ static void *coreaudio_create(obs_data_t *settings, obs_source_t *source,
 		ca->device_uid = bstrdup("default");
 
 	coreaudio_try_init(ca);
+
+	pthread_mutex_unlock(&ca->mutex);
+
 	return ca;
 }
 

--- a/plugins/mac-capture/mac-audio.c
+++ b/plugins/mac-capture/mac-audio.c
@@ -373,7 +373,7 @@ static void coreaudio_uninit(struct coreaudio_data *ca);
 
 static void *reconnect_thread(void *param)
 {
-	struct coreaudio_data *ca = param;	
+	struct coreaudio_data *ca = param;
 
 	while (os_event_timedwait(ca->exit_event, ca->retry_time) ==
 	       ETIMEDOUT) {
@@ -717,7 +717,7 @@ static void coreaudio_destroy(void *data)
 
 		pthread_mutex_lock(&ca->mutex);
 
-		coreaudio_shutdown(ca);		
+		coreaudio_shutdown(ca);
 
 		bfree(ca->device_name);
 		bfree(ca->device_uid);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Fixes race condition like this:
```
Thread XX Crashed:
0   libsystem_pthread.dylib   0x7ff805352589 pthread_mutex_lock + 4
1   libobs                    0x10fd41bcc os_event_timedwait + 28 (threading-posix.c:109)
2   mac-capture               0x113bcbd5d reconnect_thread + 61 (mac-audio.c:381)
3   libsystem_pthread.dylib   0x7ff805357259 _pthread_start + 125
4   libsystem_pthread.dylib   0x7ff805352c7b thread_start + 15
```

### Motivation and Context
One of the Streamlabs employee has the issue. Probably it happens if a scene has a lot of items and CPU consumption is high.

### How Has This Been Tested?
The original code crashes with a specific SceneCollection and does not crash with the fix.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
