### PR TITLE
Fix of obs_context_data_free rare crash

### DIFF
--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -553,8 +553,11 @@ struct obs_context_data {
 
 	bool private;
 
-	DARRAY(char *) rename_cache;
-	pthread_mutex_t rename_cache_mutex;
+	// This previously was named as 'rename_cache_mutex', but traces of 'rename_cache'
+	// were removed from the code completely as it was unused.
+	// The mutex might be excessive and should be removed in the future.
+	// If you do so, do not forget to update 'memset' line of 'obs_context_data_free'.
+	pthread_mutex_t name_mutex;
 };
 
 extern bool obs_context_data_init(struct obs_context_data *context,

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -2715,7 +2715,7 @@ void obs_output_set_last_error(obs_output_t *output, const char *message)
 bool obs_output_connecting(const obs_output_t *output)
 {
 	if (!obs_output_valid(output, "obs_output_connecting"))
-		return;
+		return false;
 
 	if (output->info.connecting == NULL || output->context.data == NULL)
 		return false;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
This is an attempt to fix rare crash that we have during `obs_context_data_free` call.

### Motivation and Context
During investigation I've found that this code might crash occasionally
```c++
	for (size_t i = 0; i < context->rename_cache.num; i++)
		bfree(context->rename_cache.array[i]);
	da_free(context->rename_cache);
```
Notice call to `da_free`. But there is no corresponding `da_init(context->rename_cache);` call which leads to uninitialized array (garbage memory).
As result, if a user was unlucky enough to have `rename_cache.num` != `0` the crash should happen.
Moreover, the `rename_cache` is only written but is never read, so I decided to remove it completely.
And I left related mutex because not sure if `obs_context_data_setname` is thread safe. This mutex can be removed in the future if required and its presence is not harmful, because it always was there.

### How Has This Been Tested?
Just code compilation. Overall proposed fix looks very safe.

### Types of changes
Bug fix (non-breaking change which fixes an issue) 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the streamlabs branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
