### PR TITLE
Fixed data race in GPU encode thread

### DIFF
--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -281,6 +281,7 @@ struct obs_core_video_mix {
 	pthread_t gpu_encode_thread;
 	bool gpu_encode_thread_initialized;
 	volatile bool gpu_encode_stop;
+	bool gpu_want_destroy_thread;
 
 	video_t *video;
 	struct obs_video_info *ovi;


### PR DESCRIPTION
### Description
Fixed data race in GPU encode thread which led to crashes.

### Motivation and Context
Data race is happening between `start_gpu_encode` and `stop_gpu_encode` which are called from different threads and have an edge case which is not protected by synchronization logic.

Below are some technical details in annotated code:
![Issue details](https://gcdnb.pbrd.co/images/yeguZmXzlwnB.png?o=1)

### How Has This Been Tested?
Manual testing to ensure there is no dead locks

### Types of changes
- Bug fix (non-breaking change which fixes an issue)