### PR TITLE
Fixed WAVEFORMATEX bytes count calculation

### DIFF
--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -830,7 +830,7 @@ ComPtr<IAudioClient> WASAPISource::InitClient(
 		wf.nAvgBytesPerSec = nSamplesPerSec * nBlockAlign;
 		wf.nBlockAlign = nBlockAlign;
 		wf.wBitsPerSample = wBitsPerSample;
-		wf.cbSize = sizeof(wfextensible) - sizeof(format);
+		wf.cbSize = sizeof(wfextensible) - sizeof(wf);
 		wfextensible.Samples.wValidBitsPerSample = wBitsPerSample;
 		wfextensible.dwChannelMask =
 			GetSpeakerChannelMask(oai.speakers);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixed potential memory corruption issue in `WASAPISource::InitClient` which might lead to audio distortion bug for application audio capture that we have sometimes.

### Motivation and Context
`WAVEFORMATEXTENSIBLE` struct has the following layout
```c++
typedef struct {
    WAVEFORMATEX    Format;
    union {
        WORD wValidBitsPerSample;       /* bits of precision  */
        WORD wSamplesPerBlock;          /* valid if wBitsPerSample==0 */
        WORD wReserved;                 /* If neither applies, set to zero. */
    } Samples;
    DWORD           dwChannelMask;      /* which channels are */
                                        /* present in stream  */
    GUID            SubFormat;
} WAVEFORMATEXTENSIBLE, *PWAVEFORMATEXTENSIBLE;
```
where `WAVEFORMATEX` should be treated carefully because according to the [docs](https://learn.microsoft.com/en-us/previous-versions/dd757713(v=vs.85)) its field should be calculated
```
cbSize
  Size, in bytes, of extra format information appended to the end of the WAVEFORMATEX structure.
  This information can be used by non-PCM formats to store extra attributes for the wFormatTag.
  If no extra information is required by the wFormatTag, this member must be set to 0.
  For WAVE_FORMAT_PCM formats (and only WAVE_FORMAT_PCM formats), this member is ignored.
  When this structure is included in a WAVEFORMATEXTENSIBLE structure, this value must be at least 22.
```
And this is exactly our case with `WAVEFORMATEXTENSIBLE`.
If we count sizes of `WAVEFORMATEXTENSIBLE` except the `WAVEFORMATEX` data members we will have `sizeof(WORD) + sizeof(DWORD) + sizeof(GUID) == 2 + 4 + 16 == 22`, thus we should set `Format.cbSize = 22`.
In the code of OBS this value is calculated like `sizeof(wfextensible) - sizeof(format)` where `sizeof(wfextensible) == sizeof(WAVEFORMATEXTENSIBLE) == 40` and `sizeof(format) == 4`, so it is set value of `36` instead of `22`. Init code provides to the system a chunk of potentially garbage memory. I think it is a typo, one of those which very hard to spot, because there is no reason to count size of `format` which is an app level enum and not related to WinAPI.

```c++
enum audio_format {
	AUDIO_FORMAT_UNKNOWN,

	AUDIO_FORMAT_U8BIT,
	AUDIO_FORMAT_16BIT,
	AUDIO_FORMAT_32BIT,
	AUDIO_FORMAT_FLOAT,

	AUDIO_FORMAT_U8BIT_PLANAR,
	AUDIO_FORMAT_16BIT_PLANAR,
	AUDIO_FORMAT_32BIT_PLANAR,
	AUDIO_FORMAT_FLOAT_PLANAR,
};
```

### How Has This Been Tested?
Manually.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!---  -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

