### PR TITLE
Forcing to play source in ffmpeg_source_play_pause if it was inactive

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -438,6 +438,8 @@ static bool requires_mpegts(const char *path)
 	       !astrcmpi_n(path, RIST_PROTO, sizeof(RIST_PROTO) - 1);
 }
 
+static void ffmpeg_source_play_pause(void *data, bool pause);
+
 static void ffmpeg_source_update(void *data, obs_data_t *settings)
 {
 	struct ffmpeg_source *s = data;
@@ -521,6 +523,13 @@ static void ffmpeg_source_update(void *data, obs_data_t *settings)
 	dump_source_info(s, input, input_format);
 	if (!s->restart_on_activate || active)
 		ffmpeg_source_start(s);
+
+	const bool force_play_start =
+		obs_data_get_bool(settings, "force_play_start");
+	if (s->is_local_file && !active && input && force_play_start) {
+		obs_data_set_bool(settings, "force_play_start", false);
+		ffmpeg_source_play_pause(s, false);
+	}
 }
 
 static const char *ffmpeg_source_getname(void *unused)
@@ -808,8 +817,22 @@ static void ffmpeg_source_play_pause(void *data, bool pause)
 	if (!s->media_valid)
 		ffmpeg_source_open(s);
 
-	if (!s->media_valid)
+	if (!s->media_valid) {
+		// If media was not valid and we want (really want!) to start media source playback,
+		// setting the flag here to be reused later when media becomes valid.
+		// This is the case when new media source is added. At first it is created and added to scene,
+		// but as there is no file path, media stays invalid. A moment later when user selects a path,
+		// the media source will become playable and we will start playback during settings update with the new path property.
+		// The main use case of this behavior is to support the 'Studio Mode' feature.
+		if (!pause) {
+			obs_data_t *settings =
+				obs_source_get_settings(s->source);
+			obs_data_set_bool(settings, "force_play_start", true);
+			obs_data_release(settings);
+		}
+
 		return;
+	}
 
 	// Forcing to start playback of source if it was inactive and we are going to 'unpause' it.
 	// Notice that this action does not make the source active.

--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -811,6 +811,12 @@ static void ffmpeg_source_play_pause(void *data, bool pause)
 	if (!s->media_valid)
 		return;
 
+	// Forcing to start playback of source if it was inactive and we are going to 'unpause' it.
+	// Notice that this action does not make the source active.
+	if (!pause && !obs_source_active(s->source)) {
+		mp_media_play(&s->media, s->is_looping, s->reconnecting);
+	}
+
 	mp_media_play_pause(&s->media, pause);
 
 	if (pause) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Forcing to play source in `ffmpeg_source_play_pause` if it was inactive

### Motivation and Context
Change seems to be safe and logical. It is used to fix non-playing videos in studio mode.

### How Has This Been Tested?
Manually

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!---  -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

