### PR TITLE
Changed way of audio frames timestamps calculation for process audio capture

### DIFF
--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -251,8 +251,6 @@ class WASAPISource {
 	audio_format format;
 	uint32_t sampleRate;
 
-	uint64_t framesProcessed = 0;
-
 	static DWORD WINAPI ReconnectThread(LPVOID param);
 	static DWORD WINAPI CaptureThread(LPVOID param);
 
@@ -378,6 +376,7 @@ WASAPISource::WASAPISource(obs_data_t *settings, obs_source_t *source_,
 	  sampleReady(this),
 	  restart(this)
 {
+	blog(LOG_INFO, "WASAPISource::WASAPISource");
 	mmdevapi_module = LoadLibrary(L"Mmdevapi");
 	if (mmdevapi_module) {
 		activate_audio_interface_async =
@@ -1178,10 +1177,8 @@ bool WASAPISource::ProcessCaptureData()
 		data.samples_per_sec = sampleRate;
 		data.format = format;
 		if (sourceType == SourceType::ProcessOutput) {
-			data.timestamp = util_mul_div64(framesProcessed,
-							UINT64_C(1000000000),
-							sampleRate);
-			framesProcessed += frames;
+			// Using plain device timestamps to avoid static audio issue
+			data.timestamp = ts * 100;
 		} else {
 			data.timestamp = useDeviceTiming ? ts * 100
 							 : os_gettime_ns();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Attempt to fix static audio noise after a while

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I noticed that some special cases are not handled according to MS docs and this solution might be a good workaround. As the feature is still in BETA status, fix seems to be safe enough

Technical details:
In the code above the lines modified by me there is a call
`res = capture->GetBuffer(&buffer, &frames, &flags, &pos, &ts);`
but the field `flags` is left unused.
The `flags` is a field for signaling error state, one of
```
AUDCLNT_BUFFERFLAGS_SILENT
AUDCLNT_BUFFERFLAGS_DATA_DISCONTINUITY
AUDCLNT_BUFFERFLAGS_TIMESTAMP_ERROR
```
I think that names are self explanatory.
Essentially, there is no proper error handling. And I think in case of any of these errors signaled the calculated timestamps may drift or something like that.
So my assumption is that timestamps got from the device are always valid in case of app audio capture and we can safely use them instead of trying calculate our own.

### How Has This Been Tested?
Manual testing + Veronika tested custom provided build
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

