### PR TITLE
fix for graphics thread race conditions

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -652,6 +652,12 @@ static int obs_init_video()
 		}
 	}
 
+	if(&video->video_thread)
+	{
+		blog(LOG_INFO, "[VIDEO_CANVAS] wait obs_graphics_thread to stop");
+		pthread_join(video->video_thread, NULL);
+	}
+
 	uint32_t max_fps_den = 0;
 	uint32_t max_fps_num = 1;
 	for (size_t i = 0, num = obs->video.canvases.num; i < num; i++) {

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -652,8 +652,7 @@ static int obs_init_video()
 		}
 	}
 
-	if(&video->video_thread)
-	{
+	if (&video->video_thread) {
 		blog(LOG_INFO, "[VIDEO_CANVAS] wait obs_graphics_thread to stop");
 		pthread_join(video->video_thread, NULL);
 	}

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -654,7 +654,7 @@ static int obs_init_video()
 
 	if (&video->video_thread) {
 		blog(LOG_INFO,
-			"[VIDEO_CANVAS] wait obs_graphics_thread to stop");
+		     "[VIDEO_CANVAS] wait obs_graphics_thread to stop");
 		pthread_join(video->video_thread, NULL);
 	}
 

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -653,7 +653,8 @@ static int obs_init_video()
 	}
 
 	if (&video->video_thread) {
-		blog(LOG_INFO, "[VIDEO_CANVAS] wait obs_graphics_thread to stop");
+		blog(LOG_INFO,
+			"[VIDEO_CANVAS] wait obs_graphics_thread to stop");
 		pthread_join(video->video_thread, NULL);
 	}
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Wait for prev instance of graphics thread to finish before creating mixes and starting new one.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Graphics thread use mixes to check if it should exit. 
We set flag in mix object to stop thread. But if we create new mixes right after that then graphics thread might miss what flag was set to stop. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
