### PR TITLE
Unpair encoders on destruction + logs

### DIFF
--- a/libobs/obs-video-gpu-encode.c
+++ b/libobs/obs-video-gpu-encode.c
@@ -19,6 +19,7 @@
 
 static void *gpu_encode_thread(struct obs_core_video_mix *video)
 {
+	blog(LOG_INFO, "gpu_encode_thread (0x%I64X)", video);
 	uint64_t interval = video_output_get_frame_time(video->video);
 	DARRAY(obs_encoder_t *) encoders;
 	int wait_frames = NUM_ENCODE_TEXTURE_FRAMES_TO_WAIT;
@@ -150,6 +151,7 @@ static void *gpu_encode_thread(struct obs_core_video_mix *video)
 
 bool init_gpu_encoding(struct obs_core_video_mix *video)
 {
+	blog(LOG_INFO, "init_gpu_encoding - begin (0x%I64X)", video);
 #ifdef _WIN32
 	const struct video_output_info *info =
 		video_output_get_info(video->video);
@@ -205,15 +207,20 @@ bool init_gpu_encoding(struct obs_core_video_mix *video)
 void stop_gpu_encoding_thread(struct obs_core_video_mix *video)
 {
 	if (video->gpu_encode_thread_initialized) {
+		blog(LOG_INFO, "stop_gpu_encoding_thread - begin (0x%I64X)",
+		     video);
 		os_atomic_set_bool(&video->gpu_encode_stop, true);
 		os_sem_post(video->gpu_encode_semaphore);
 		pthread_join(video->gpu_encode_thread, NULL);
 		video->gpu_encode_thread_initialized = false;
+		blog(LOG_INFO, "stop_gpu_encoding_thread - end (0x%I64X)",
+		     video);
 	}
 }
 
 void free_gpu_encoding(struct obs_core_video_mix *video)
 {
+	blog(LOG_INFO, "free_gpu_encoding - begin (0x%I64X)", video);
 	if (video->gpu_encode_semaphore) {
 		os_sem_destroy(video->gpu_encode_semaphore);
 		video->gpu_encode_semaphore = NULL;
@@ -237,4 +244,5 @@ void free_gpu_encoding(struct obs_core_video_mix *video)
 	free_circlebuf(video->gpu_encoder_queue);
 	free_circlebuf(video->gpu_encoder_avail_queue);
 #undef free_circlebuf
+	blog(LOG_INFO, "free_gpu_encoding - end (0x%I64X)", video);
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Attempt to fix crash in GPU encode thread. It seems like there are several execution paths that lead to this crash. This change makes attempt to fix one of them.

### Motivation and Context
I noticed that during GPU encode data from paired (audio) encoder is used to check timings.
There is a function `pair_encoders` which sets `paired_encoder` for both sides (audio and video). But during call to `obs_encoder_shutdown` value is reset only from the one side => we have classic dangling pointer problem.

Also I added more logs for encoders lifecycle functions to help troubleshoot this nasty crash further.

### How Has This Been Tested?
Manually in UI.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
