### PR TITLE
Enabled debug mode for audio

### DIFF
--- a/libobs/audio-monitoring/win32/wasapi-output.c
+++ b/libobs/audio-monitoring/win32/wasapi-output.c
@@ -50,7 +50,7 @@ struct audio_monitor {
 	SRWLOCK playback_mutex;
 };
 
-/* #define DEBUG_AUDIO */
+#define DEBUG_AUDIO
 
 static bool process_audio_delay(struct audio_monitor *monitor, float **data,
 				uint32_t *frames, uint64_t ts, uint32_t pad)

--- a/libobs/obs-audio.c
+++ b/libobs/obs-audio.c
@@ -24,8 +24,8 @@ struct ts_info {
 	uint64_t end;
 };
 
-#define DEBUG_AUDIO 0
-#define DEBUG_LAGGED_AUDIO 0
+#define DEBUG_AUDIO 1
+#define DEBUG_LAGGED_AUDIO 1
 
 // Cached state of multiple rendering so each run of in audio-io thread work with same state
 static bool audio_multiple_rendering = false;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
More logs to troubleshoot audio issues

### Motivation and Context
Follow up for static audio (constant noise) task for App Audio Capture.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
