### PR TITLE
Synchronizing encoder creation and shutdown process

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -836,6 +836,8 @@ static void obs_free_video(bool full_clean)
 	}
 	if (num_views > 0)
 		blog(LOG_WARNING, "Number of remaining views: %ld", num_views);
+
+	obs->video.main_mix = NULL;
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
 
 	pthread_mutex_destroy(&obs->video.mixes_mutex);
@@ -857,7 +859,6 @@ static void obs_free_video(bool full_clean)
 	pthread_mutex_destroy(&obs->video.task_mutex);
 	pthread_mutex_init_value(&obs->video.task_mutex);
 	circlebuf_free(&obs->video.tasks);
-	obs->video.main_mix = NULL;
 }
 
 static void obs_free_graphics(void)


### PR DESCRIPTION
### Description
Attempt to fix crash with following stacktrace. It happens on encoder creation during shutdown.
```
obs_p010_tex_active (obs.c:3410)
nvenc_create_h264_hevc (jim-nvenc.c:1057)
obs_encoder_initialize_internal (obs-encoder.c:494)
obs_encoder_initialize (obs-encoder.c:539)
obs_output_initialize_encoders (obs-output.c:2155)
rtmp_stream_start (rtmp-stream.c:1257)
obs_output_actual_start (obs-output.c:281)
reconnect_thread (obs-output.c:2414)
free_base
ptw32_threadStart (ptw32_threadStart.c:225)
prune_interleaved_packets (obs-output.c:1522)
_acrt_getptd
thread_start<T>
BaseThreadInitThunk
RtlUserThreadStart
```

### Motivation and Context
The crash happens because `main_mix` of `obs_core_video` is null in `obs_p010_tex_active ` function.
So now either encoder will be created during shutdown and immediately destroyed as a regular shutdown routine, or its creation will not be started at all.

### How Has This Been Tested?
Manually

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
