### PR TITLE
Improved encoder unpairing

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -557,19 +557,6 @@ void obs_encoder_shutdown(obs_encoder_t *encoder)
 	     obs_encoder_get_name(encoder), obs_encoder_get_id(encoder),
 	     encoder);
 
-	// Unpairing encoders, if any
-	if (encoder->paired_encoder) {
-		pthread_mutex_lock(&encoder->paired_encoder->init_mutex);
-
-		blog(LOG_INFO, "obs_encoder_shutdown - unpair '%s' (%s) (%p)",
-		     obs_encoder_get_name(encoder->paired_encoder),
-		     obs_encoder_get_id(encoder->paired_encoder),
-		     encoder->paired_encoder);
-
-		encoder->paired_encoder->paired_encoder = NULL;
-		pthread_mutex_unlock(&encoder->paired_encoder->init_mutex);
-	}
-
 	pthread_mutex_lock(&encoder->init_mutex);
 	if (encoder->context.data) {
 		encoder->info.destroy(encoder->context.data);

--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -3104,7 +3104,8 @@ struct obs_source_info game_capture_info = {
 	.id = "game_capture",
 	.type = OBS_SOURCE_TYPE_INPUT,
 	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW |
-			OBS_SOURCE_DO_NOT_DUPLICATE | OBS_SOURCE_SRGB | CUSTOM_REFRESH_UI_FLAG,
+			OBS_SOURCE_DO_NOT_DUPLICATE | OBS_SOURCE_SRGB |
+			CUSTOM_REFRESH_UI_FLAG,
 	.get_name = game_capture_name,
 	.create = game_capture_create,
 	.destroy = game_capture_destroy,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Unpair encoders (updated version)

### Motivation and Context
This is a fix for crash with the following stack:
```
pthread_mutex_lock (pthread_mutex_lock.c:73)
blogva (base.c:111)
blog (base.c:119)
obs_encoder_shutdown (obs-encoder.c:553)
obs_encoder_initialize_internal (obs-encoder.c:487)
obs_encoder_initialize (obs-encoder.c:539)
initialize_audio_encoders (obs-output.c:2089)
obs_output_initialize_encoders (obs-output.c:2161)
os_gettime_ns (platform-windows.c:489)
obs_output_delay_start (obs-output-delay.c:147)
fdexp
std::_Char_traits<T>::move (xstring:119)
std::basic_string<T>::assign (xstring:3380)
obs_output_start (obs-output.c:311)
OBS_service::startStreaming (nodeobs_service.cpp:1132)
```
It started to happen because of incorrect attempt to fix crash in GPU encode thread.
Now I've found more proper place ho unpair encoders which is still needed to avoid operations with potentially dangling pointer.

### How Has This Been Tested?
Manually, windows only.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
