### PR TITLE
use Auto to select any first display

### DIFF
--- a/plugins/win-capture/duplicator-monitor-capture.c
+++ b/plugins/win-capture/duplicator-monitor-capture.c
@@ -212,6 +212,7 @@ static BOOL CALLBACK enum_monitor(HMONITOR handle, HDC hdc, LPRECT rect,
 					EDD_GET_DEVICE_INTERFACE_NAME)) {
 			match = strcmp(monitor->device_id, device.DeviceID) ==
 				0;
+			match |= strcmp(monitor->device_id, "Auto") == 0;
 			if (match) {
 				strcpy_s(monitor->id, _countof(monitor->id),
 					 device.DeviceID);
@@ -411,7 +412,7 @@ static void duplicator_capture_destroy(void *data)
 static void duplicator_capture_defaults(obs_data_t *settings)
 {
 	obs_data_set_default_int(settings, "method", METHOD_AUTO);
-	obs_data_set_default_string(settings, "monitor_id", "DUMMY");
+	obs_data_set_default_string(settings, "monitor_id", "Auto");
 	obs_data_set_default_int(settings, "monitor_wgc", 0);
 	obs_data_set_default_bool(settings, "capture_cursor", true);
 	obs_data_set_default_bool(settings, "force_sdr", false);
@@ -903,6 +904,7 @@ static obs_properties_t *duplicator_capture_properties(void *data)
 	obs_properties_add_bool(props, "capture_cursor", TEXT_CAPTURE_CURSOR);
 	obs_properties_add_bool(props, "force_sdr", TEXT_FORCE_SDR);
 
+	obs_property_list_add_string(monitors, "Auto", "Auto");
 	EnumDisplayMonitors(NULL, NULL, enum_monitor_props, (LPARAM)monitors);
 
 	return props;

--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -3104,7 +3104,8 @@ struct obs_source_info game_capture_info = {
 	.id = "game_capture",
 	.type = OBS_SOURCE_TYPE_INPUT,
 	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW |
-			OBS_SOURCE_DO_NOT_DUPLICATE | OBS_SOURCE_SRGB | CUSTOM_REFRESH_UI_FLAG,
+			OBS_SOURCE_DO_NOT_DUPLICATE | OBS_SOURCE_SRGB |
+			CUSTOM_REFRESH_UI_FLAG,
 	.get_name = game_capture_name,
 	.create = game_capture_create,
 	.destroy = game_capture_destroy,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Use Auto instead of DUMMY as default value for display. 
Auto will capture any first available display. 
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Our UI shows only real displays in a list. But DUMMY will be used internally till user change something on UI forcing selected display to rewrite default value. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
On Windows local build. 
Create new display capture source and check what it start capturing display without settings reapplied. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
