### PR TITLE
fix game capture activation detection

### DIFF
--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -2734,8 +2734,9 @@ static void game_capture_render(void *data, gs_effect_t *unused)
 static uint32_t game_capture_width(void *data)
 {
 	struct game_capture *gc = data;
-	if (gc->config.mode == CAPTURE_MODE_AUTO || (
-	    gc->config.mode == CAPTURE_MODE_WINDOW && !gc->is_internal_source)) {
+	if (gc->config.mode == CAPTURE_MODE_AUTO ||
+	    (gc->config.mode == CAPTURE_MODE_WINDOW &&
+	     !gc->is_internal_source)) {
 		return gc->config.base_width;
 	}
 	return (gc->active && gc->capturing) ? gc->cx : 0;
@@ -2744,8 +2745,9 @@ static uint32_t game_capture_width(void *data)
 static uint32_t game_capture_height(void *data)
 {
 	struct game_capture *gc = data;
-	if (gc->config.mode == CAPTURE_MODE_AUTO || (
-	    gc->config.mode == CAPTURE_MODE_WINDOW && !gc->is_internal_source)) {
+	if (gc->config.mode == CAPTURE_MODE_AUTO ||
+	    (gc->config.mode == CAPTURE_MODE_WINDOW &&
+	     !gc->is_internal_source)) {
 		return gc->config.base_height;
 	}
 	return (gc->active && gc->capturing) ? gc->cy : 0;

--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -38,6 +38,7 @@ extern struct obs_core *obs = NULL;
 #define SETTING_WINDOW_PRIORITY      "priority"
 #define SETTING_WINDOW_DEFAULT_WIDTH "default_width"
 #define SETTING_WINDOW_DEFAULT_HEIGHT "default_height"
+#define SETTING_WINDOW_INTERNAL_MODE "internal_mode"
 #define SETTING_COMPATIBILITY        "sli_compatibility"
 #define SETTING_CURSOR               "capture_cursor"
 #define SETTING_TRANSPARENCY         "allow_transparency"
@@ -103,6 +104,7 @@ extern struct obs_core *obs = NULL;
 
 #define TEXT_HOTKEY_START        obs_module_text("GameCapture.HotkeyStart")
 #define TEXT_HOTKEY_STOP         obs_module_text("GameCapture.HotkeyStop")
+#define TEXT_WINDOW_INTERNAL_MODE obs_module_text("GameCapture.WindowInternalMode")
 
 /* clang-format on */
 
@@ -190,6 +192,7 @@ struct game_capture {
 	bool convert_16bit;
 	bool is_app;
 	bool cursor_hidden;
+	bool is_internal_source;
 
 	struct game_capture_config config;
 	struct auto_game_capture auto_capture;
@@ -820,6 +823,9 @@ static void game_capture_update(void *data, obs_data_t *settings)
 		free_whitelist(&gc->auto_capture);
 	}
 
+	gc->is_internal_source =
+		obs_data_get_bool(settings, SETTING_WINDOW_INTERNAL_MODE);
+
 	const char *img_path = NULL;
 	const char *placeholder_text = NULL;
 	const char *placeholder_wait_text = NULL;
@@ -1371,7 +1377,6 @@ static bool target_suspended(struct game_capture *gc)
 }
 
 static bool init_events(struct game_capture *gc);
-//static void set_compat_info_visible(struct game_capture* gc, bool visible); // TODO: remove????
 
 static bool init_hook(struct game_capture *gc)
 {
@@ -2729,8 +2734,8 @@ static void game_capture_render(void *data, gs_effect_t *unused)
 static uint32_t game_capture_width(void *data)
 {
 	struct game_capture *gc = data;
-	if (gc->config.mode == CAPTURE_MODE_AUTO ||
-	    gc->config.mode == CAPTURE_MODE_WINDOW) {
+	if (gc->config.mode == CAPTURE_MODE_AUTO || (
+	    gc->config.mode == CAPTURE_MODE_WINDOW && !gc->is_internal_source)) {
 		return gc->config.base_width;
 	}
 	return (gc->active && gc->capturing) ? gc->cx : 0;
@@ -2739,8 +2744,8 @@ static uint32_t game_capture_width(void *data)
 static uint32_t game_capture_height(void *data)
 {
 	struct game_capture *gc = data;
-	if (gc->config.mode == CAPTURE_MODE_AUTO ||
-	    gc->config.mode == CAPTURE_MODE_WINDOW) {
+	if (gc->config.mode == CAPTURE_MODE_AUTO || (
+	    gc->config.mode == CAPTURE_MODE_WINDOW && !gc->is_internal_source)) {
 		return gc->config.base_height;
 	}
 	return (gc->active && gc->capturing) ? gc->cy : 0;
@@ -2784,6 +2789,8 @@ static void game_capture_defaults(obs_data_t *settings)
 				 (int)1920);
 	obs_data_set_default_int(settings, SETTING_WINDOW_DEFAULT_HEIGHT,
 				 (int)1080);
+	obs_data_set_default_bool(settings, SETTING_WINDOW_INTERNAL_MODE,
+				  false);
 }
 
 static bool mode_callback(obs_properties_t *ppts, obs_property_t *p,
@@ -2839,6 +2846,9 @@ static bool mode_callback(obs_properties_t *ppts, obs_property_t *p,
 	obs_property_set_visible(p, false);
 
 	p = obs_properties_get(ppts, SETTING_WINDOW_DEFAULT_HEIGHT);
+	obs_property_set_visible(p, false);
+
+	p = obs_properties_get(ppts, SETTING_WINDOW_INTERNAL_MODE);
 	obs_property_set_visible(p, false);
 
 	return true;
@@ -3056,6 +3066,8 @@ static obs_properties_t *game_capture_properties(void *data)
 	obs_property_list_add_string(p, TEXT_RGBA10A2_SPACE_2100PQ,
 				     RGBA10A2_SPACE_2100PQ);
 
+	p = obs_properties_add_bool(ppts, SETTING_WINDOW_INTERNAL_MODE,
+				    TEXT_WINDOW_INTERNAL_MODE);
 	return ppts;
 }
 

--- a/plugins/win-capture/screen-capture.c
+++ b/plugins/win-capture/screen-capture.c
@@ -322,6 +322,7 @@ static void switch_to_game_capture_mode(struct screen_capture *context)
 							S_CAPTURE_WINDOW));
 		break;
 	}
+	obs_data_set_bool(game_capture_settings, "internal_mode", true);
 
 	WaitForSingleObject(context->subsources_mutex, INFINITE);
 	context->game_capture = obs_source_create_private(


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Add option to recognize when game capture running as an internal source and we do need to know its real state.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
As there is limited number of ways what sources can communicate their state height was used as a proxy for source active or not. 
A recent feature what improves detection of game windows broke this by enabling image placeholder for game capture. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
