### PR TITLE
Fixed force UI refresh logic for OBS 29

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -6148,3 +6148,17 @@ void obs_source_restore_filters(obs_source_t *source, obs_data_array_t *array)
 
 	da_free(cur_filters);
 }
+
+void streamlabs_force_source_ui_refresh(obs_source_t *source)
+{
+	// Note: overall this is a bit hackish approach to force UI refresh.
+	// Proper solution could be implemented, but will be significantly more complicated.
+
+	// 30 is just big enought number to not overlap with the existing and possible future flags
+	const uint32_t CUSTOM_REFRESH_UI_FLAG = (1 << 30);
+
+	// Toggling custom output flag to force UI refresh
+	// For details see 'globalCallback::worker()' in obs-studio-node and
+	// 'updateSourceFlags' in desktop repo
+	source->info.output_flags ^= CUSTOM_REFRESH_UI_FLAG;
+}

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1481,6 +1481,9 @@ EXPORT obs_data_array_t *obs_source_backup_filters(obs_source_t *source);
 EXPORT void obs_source_restore_filters(obs_source_t *source,
 				       obs_data_array_t *array);
 
+/** Custom function to force source-related UI refresh from inside OBS */
+EXPORT void streamlabs_force_source_ui_refresh(obs_source_t *source);
+
 /* ------------------------------------------------------------------------- */
 /* Functions used by sources */
 

--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -2178,14 +2178,10 @@ static void check_foreground_window(struct game_capture *gc, float seconds)
 
 static void set_compat_info_visible(struct game_capture *gc, bool visible)
 {
-	// 30 is just big enought number to not overlap with the existing and possible future flags
-	const uint32_t CUSTOM_REFRESH_UI_FLAG = (1 << 30);
-
 	obs_data_t *setings = obs_source_get_settings(gc->source);
-	obs_data_set_bool(setings, COMPAT_INFO_VISIBLE, visible);
 
-	obs_properties_t *props = obs_source_properties(gc->source);
-	obs_properties_destroy(props);
+	obs_data_set_bool(setings, COMPAT_INFO_VISIBLE, visible);
+	streamlabs_force_source_ui_refresh(gc->source);
 
 	obs_data_release(setings);
 }
@@ -3112,14 +3108,11 @@ game_capture_get_color_space(void *data, size_t count,
 	return space;
 }
 
-#define CUSTOM_REFRESH_UI_FLAG (1 << 30)
-
 struct obs_source_info game_capture_info = {
 	.id = "game_capture",
 	.type = OBS_SOURCE_TYPE_INPUT,
 	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW |
-			OBS_SOURCE_DO_NOT_DUPLICATE | OBS_SOURCE_SRGB |
-			CUSTOM_REFRESH_UI_FLAG,
+			OBS_SOURCE_DO_NOT_DUPLICATE | OBS_SOURCE_SRGB,
 	.get_name = game_capture_name,
 	.create = game_capture_create,
 	.destroy = game_capture_destroy,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This logic was broken after merge of OBS 29

### Motivation and Context
Extracted code into the `streamlabs_force_source_ui_refresh` function. I've added the `streamlabs_` prefix to highlight that it is not original.

### How Has This Been Tested?
Manual testing. Windows only.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 
- New feature (non-breaking change which adds functionality) 
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
