### PR TITLE
fix deadlock what happens on output stop

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -3755,8 +3755,7 @@ void stop_gpu_encode(obs_encoder_t *encoder)
 		os_event_wait(video->gpu_encode_inactive);
 		stop_gpu_encoding_thread(video);
 		free_gpu_encoding(video);
-	} else {
-		}
+	}
 	obs_leave_graphics();
 }
 

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -3746,23 +3746,17 @@ void stop_gpu_encode(obs_encoder_t *encoder)
 		video->gpu_want_destroy_thread = true;
 	pthread_mutex_unlock(&video->gpu_encoder_mutex);
 
-	os_event_wait(video->gpu_encode_inactive);
-
-	blog(LOG_INFO, "stop_gpu_encode - inactive '%s' (%s) (%p)",
-	     obs_encoder_get_name(encoder), obs_encoder_get_id(encoder),
-	     encoder);
-
 	obs_enter_graphics();
-	pthread_mutex_lock(&video->gpu_encoder_mutex);
 	if (video->gpu_want_destroy_thread) {
 		blog(LOG_INFO,
 		     "stop_gpu_encode - gpu_want_destroy_thread: 1 '%s' (%s) (%p)",
 		     obs_encoder_get_name(encoder), obs_encoder_get_id(encoder),
 		     encoder);
+		os_event_wait(video->gpu_encode_inactive);
 		stop_gpu_encoding_thread(video);
 		free_gpu_encoding(video);
-	}
-	pthread_mutex_unlock(&video->gpu_encoder_mutex);
+	} else {
+		}
 	obs_leave_graphics();
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
previously stop_gpu_encode was calling stop_gpu_encoding_thread what should set exit flag and wait for a thread to stop. 
but also it locks gpu_encoder_mutex. 
in gpu_encode_thread  there two segments of code what locks same mutex gpu_encode_thread. 
it have lead to situations when first thread waiting for second thread to finish but second thread waiting for first thread to unlock mutex. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
