### PR TITLE
Fixed game capture memory leak

### DIFF
--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -865,9 +865,11 @@ static void game_capture_update(void *data, obs_data_t *settings)
 		}
 	}
 
-	dstr_copy(&gc->placeholder_text, placeholder_text);
-	dstr_copy(&gc->placeholder_wait_text, placeholder_wait_text);
-	dstr_copy(&gc->placeholder_error_text, placeholder_error_text);
+	if (dstr_is_empty(&gc->placeholder_text)) {
+		dstr_copy(&gc->placeholder_text, placeholder_text);
+		dstr_copy(&gc->placeholder_wait_text, placeholder_wait_text);
+		dstr_copy(&gc->placeholder_error_text, placeholder_error_text);
+	}
 
 	reset_capture = capture_needs_reset(&cfg, &gc->config);
 


### PR DESCRIPTION
### Description
Fixed memory leak which happens in the 'Specified window is not a game' state.

### Motivation and Context
Seems like OBS has an old bug, if create and release textures frequently, they leak.
So the fix is to keep currently valid textures as long as possible, which is reasonable.

Code note: the proposed fix has nothing related to the textures, but if we not update messages, textures are not reloaded.

### How Has This Been Tested?
Manually. Windows.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)