### PR TITLE
fix game capture size for manual modes

### DIFF
--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -2403,8 +2403,7 @@ static void game_capture_render(void *data, gs_effect_t *unused)
 
 	struct game_capture *gc = data;
 	if (!gc->texture || !gc->active) {
-		if (gc->config.mode == CAPTURE_MODE_AUTO ||
-		    gc->config.mode == CAPTURE_MODE_WINDOW) {
+		if (gc->config.mode == CAPTURE_MODE_AUTO) {
 			if (gc->placeholder_image.image.texture) {
 				//draw placeholder image
 				gs_effect_t *effect;
@@ -2480,8 +2479,7 @@ static void game_capture_render(void *data, gs_effect_t *unused)
 	gs_effect_t *const effect = obs_get_base_effect(
 		allow_transparency ? OBS_EFFECT_DEFAULT : OBS_EFFECT_OPAQUE);
 
-	if (gc->config.mode == CAPTURE_MODE_AUTO ||
-	    gc->config.mode == CAPTURE_MODE_WINDOW) {
+	if (gc->config.mode == CAPTURE_MODE_AUTO) {
 		float cx_scale = gc->config.base_width / (float)gc->cx;
 		float cy_scale = gc->config.base_height / (float)gc->cy;
 		gs_matrix_push();
@@ -2720,8 +2718,7 @@ static void game_capture_render(void *data, gs_effect_t *unused)
 		gs_set_linear_srgb(previous);
 	}
 
-	if (gc->config.mode == CAPTURE_MODE_AUTO ||
-	    gc->config.mode == CAPTURE_MODE_WINDOW) {
+	if (gc->config.mode == CAPTURE_MODE_AUTO) {
 		gs_matrix_pop();
 	}
 }
@@ -2729,9 +2726,7 @@ static void game_capture_render(void *data, gs_effect_t *unused)
 static uint32_t game_capture_width(void *data)
 {
 	struct game_capture *gc = data;
-	if (gc->config.mode == CAPTURE_MODE_AUTO ||
-	    (gc->config.mode == CAPTURE_MODE_WINDOW &&
-	     !gc->is_internal_source)) {
+	if (gc->config.mode == CAPTURE_MODE_AUTO) {
 		return gc->config.base_width;
 	}
 	return (gc->active && gc->capturing) ? gc->cx : 0;
@@ -2740,9 +2735,7 @@ static uint32_t game_capture_width(void *data)
 static uint32_t game_capture_height(void *data)
 {
 	struct game_capture *gc = data;
-	if (gc->config.mode == CAPTURE_MODE_AUTO ||
-	    (gc->config.mode == CAPTURE_MODE_WINDOW &&
-	     !gc->is_internal_source)) {
+	if (gc->config.mode == CAPTURE_MODE_AUTO) {
 		return gc->config.base_height;
 	}
 	return (gc->active && gc->capturing) ? gc->cy : 0;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Manual game capture mode was switched to use sizing approach from auto mode. 
It make to not great result for games on wide wide screens. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
