### PR TITLE
reset filter texture if output size different

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -4510,10 +4510,22 @@ bool obs_source_process_filter_begin_with_color_space(
 		return false;
 	}
 
-	if (filter->filter_texrender &&
-	    (gs_texrender_get_format(filter->filter_texrender) != format)) {
-		gs_texrender_destroy(filter->filter_texrender);
-		filter->filter_texrender = NULL;
+	if (filter->filter_texrender) {
+		bool need_recreate =
+			(gs_texrender_get_format(filter->filter_texrender) !=
+			 format);
+
+		gs_texture_t *texture =
+			gs_texrender_get_texture(filter->filter_texrender);
+		if (!texture || (gs_texture_get_width(texture) != cx ||
+				 gs_texture_get_height(texture) != cy)) {
+			need_recreate = true;
+		}
+
+		if (need_recreate) {
+			gs_texrender_destroy(filter->filter_texrender);
+			filter->filter_texrender = NULL;
+		}
 	}
 
 	if (!filter->filter_texrender) {

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -4515,13 +4515,15 @@ bool obs_source_process_filter_begin_with_color_space(
 			(gs_texrender_get_format(filter->filter_texrender) !=
 			 format);
 
-		gs_texture_t *texture =
-			gs_texrender_get_texture(filter->filter_texrender);
-		if (!texture || (gs_texture_get_width(texture) != cx ||
-				 gs_texture_get_height(texture) != cy)) {
-			need_recreate = true;
+		if (!need_recreate) {
+			gs_texture_t *texture = gs_texrender_get_texture(
+				filter->filter_texrender);
+			if (!texture ||
+			    (gs_texture_get_width(texture) != (uint32_t)cx ||
+			     gs_texture_get_height(texture) != (uint32_t)cy)) {
+				need_recreate = true;
+			}
 		}
-
 		if (need_recreate) {
 			gs_texrender_destroy(filter->filter_texrender);
 			filter->filter_texrender = NULL;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
