### PR TITLE
Enable 32bit Windows virtualcam module compilation

### DIFF
--- a/.github/workflows/main-streamlabs.yml
+++ b/.github/workflows/main-streamlabs.yml
@@ -119,6 +119,7 @@ jobs:
       CEF_VERSION: 5060
       CEF_REVISION: v3
       WIN_DEPS_VERSION: windows-deps-2023-08-31sl1-x64
+      WIN_DEPS_VERSION_X86: 2023-04-12
       GRPC_VERSION: v1.47.0
       CMakeGenerator: Visual Studio 17 2022
       VLC_VERSION: vlc_3.0.0-git

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -420,6 +420,7 @@ jobs:
       CEF_VERSION: 5060
       CEF_REVISION: v3
       WIN_DEPS_VERSION: windows-deps-2023-08-31sl1-x64
+      WIN_DEPS_VERSION_X86: 2023-04-12
       GRPC_VERSION: v1.47.0
       CMakeGenerator: Visual Studio 17 2022
       VLC_VERSION: vlc_3.0.0-git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,17 +97,25 @@ if(INSTALLER_RUN)
 endif()
 
 # OBS sources and plugins
-add_subdirectory(deps)
-add_subdirectory(libobs-opengl)
-if(OS_WINDOWS)
-  add_subdirectory(libobs-d3d11)
-  add_subdirectory(libobs-winrt)
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  add_subdirectory(deps)
+  add_subdirectory(libobs-opengl)
+  if(OS_WINDOWS)
+    add_subdirectory(libobs-d3d11)
+    add_subdirectory(libobs-winrt)
+  endif()
+  add_subdirectory(libobs)
+  add_subdirectory(plugins)
+else()
+  add_subdirectory(deps)
+  add_subdirectory(libobs)
+  add_subdirectory(plugins/win-dshow)
 endif()
-add_subdirectory(libobs)
-add_subdirectory(plugins)
 
 # OBS main app
-add_subdirectory(UI)
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  add_subdirectory(UI)
+endif()
 
 # Tests
 if(ENABLE_UNIT_TESTS)
@@ -132,4 +140,39 @@ if(WIN32)
 		"-Ddeps_CMAKE_SOURCE_DIR=${CMAKE_SOURCE_DIR}"
 
 		-P "${CMAKE_SOURCE_DIR}/slobs_CI/check_libraries.cmake" )
+endif()
+
+# Configure 32-bit projects
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    execute_process(
+      COMMAND
+        "${CMAKE_COMMAND}"
+        -S ${CMAKE_CURRENT_SOURCE_DIR}
+        -B ${CMAKE_SOURCE_DIR}/build_x86
+        -G "${CMAKE_GENERATOR}" -A Win32
+        -DCMAKE_SYSTEM_VERSION:STRING='${CMAKE_SYSTEM_VERSION}'
+        -DCMAKE_INSTALL_PREFIX='${CMAKE_INSTALL_PREFIX}'
+        -DVLCPath="${VLCPath}"
+        -DCEF_ROOT_DIR="${CEF_ROOT_DIR}"
+        -DUSE_UI_LOOP=${USE_UI_LOOP}
+        -DENABLE_UI=${ENABLE_UI}
+        -DCOPIED_DEPENDENCIES=${COPIED_DEPENDENCIES}
+        -DCOPY_DEPENDENCIES=${COPY_DEPENDENCIES}
+        -DENABLE_SCRIPTING=${ENABLE_SCRIPTING}
+        -DGPU_PRIORITY_VAL=${GPU_PRIORITY_VAL}
+        -DBUILD_CAPTIONS=${BUILD_CAPTIONS}
+        -DCOMPILE_D3D12_HOOK=${COMPILE_D3D12_HOOK}
+        -DENABLE_BROWSER=OFF
+        -DCMAKE_PREFIX_PATH:PATH='${PREFIX_PATH_X86}'
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+        -DBUILD_FOR_DISTRIBUTION=${BUILD_FOR_DISTRIBUTION}
+        -DCURL_INCLUDE_DIR=${CURL_INCLUDE_DIR}
+        -DENABLE_VLC=false
+        -DVIRTUALCAM_GUID:STRING=${VIRTUALCAM_GUID}
+        -DOBS_VERSION='${OBS_VERSION}'
+        -DOBS_VERSION_OVERRIDE='${OBS_VERSION_OVERRIDE}'
+        -DCMAKE_MESSAGE_LOG_LEVEL=${CMAKE_MESSAGE_LOG_LEVEL}
+      RESULT_VARIABLE _process_result COMMAND_ERROR_IS_FATAL ANY)
+  endif()
 endif()

--- a/plugins/win-dshow/CMakeLists.txt
+++ b/plugins/win-dshow/CMakeLists.txt
@@ -194,7 +194,9 @@ source_group(
 
 set_target_properties(win-dshow PROPERTIES FOLDER "plugins/win-dshow")
 
-setup_plugin_target(win-dshow)
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  setup_plugin_target(win-dshow)
+endif()
 
 if(ENABLE_VIRTUALCAM AND VIRTUALCAM_AVAILABLE)
   target_sources(win-dshow PRIVATE tiny-nv12-scale.c tiny-nv12-scale.h shared-memory-queue.c shared-memory-queue.h
@@ -208,12 +210,12 @@ if(ENABLE_VIRTUALCAM AND VIRTUALCAM_AVAILABLE)
 
   target_sources(win-dshow PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/config/virtualcam-guid.h)
 
-  configure_file(virtualcam-install.bat.in "${CMAKE_CURRENT_BINARY_DIR}/virtualcam-install.bat")
-
-  configure_file(virtualcam-uninstall.bat.in "${CMAKE_CURRENT_BINARY_DIR}/virtualcam-uninstall.bat")
-
-  add_target_resource(win-dshow "${CMAKE_CURRENT_BINARY_DIR}/virtualcam-install.bat" "obs-plugins/win-dshow/")
-  add_target_resource(win-dshow "${CMAKE_CURRENT_BINARY_DIR}/virtualcam-uninstall.bat" "obs-plugins/win-dshow/")
+  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    configure_file(virtualcam-install.bat.in "${CMAKE_CURRENT_BINARY_DIR}/virtualcam-install.bat")
+    configure_file(virtualcam-uninstall.bat.in "${CMAKE_CURRENT_BINARY_DIR}/virtualcam-uninstall.bat")
+    add_target_resource(win-dshow "${CMAKE_CURRENT_BINARY_DIR}/virtualcam-install.bat" "obs-plugins/win-dshow/")
+    add_target_resource(win-dshow "${CMAKE_CURRENT_BINARY_DIR}/virtualcam-uninstall.bat" "obs-plugins/win-dshow/")
+  endif()
 
   add_subdirectory(virtualcam-module)
 endif()

--- a/plugins/win-dshow/virtualcam-module/CMakeLists.txt
+++ b/plugins/win-dshow/virtualcam-module/CMakeLists.txt
@@ -57,3 +57,11 @@ set_target_properties(obs-virtualcam-module PROPERTIES FOLDER "plugins/win-dshow
 set_target_properties(obs-virtualcam-module PROPERTIES OUTPUT_NAME "obs-virtualcam-module${_output_suffix}")
 
 add_target_resource(win-dshow "$<TARGET_FILE:obs-virtualcam-module>" "obs-plugins/win-dshow/")
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  add_custom_command(
+    TARGET obs-virtualcam-module
+    POST_BUILD
+    COMMAND "${CMAKE_COMMAND}" --build ${CMAKE_SOURCE_DIR}/build_x86 --config $<CONFIG> -t obs-virtualcam-module
+    COMMENT "Build 32-bit obs-virtualcam")
+endif()

--- a/slobs_CI/win-build.cmd
+++ b/slobs_CI/win-build.cmd
@@ -12,6 +12,7 @@ if defined ReleaseName (
 
     set InstallPath=packed_build
     set BUILD_DIRECTORY=build
+		set BUILD_DIRECTORY_X86=build_x86
 )
 
 call slobs_CI\win-install-dependency.cmd
@@ -21,9 +22,11 @@ cd "%MAIN_DIR%"
 if defined ENABLE_OBS_UI (
     set ENABLE_UI=true
     set PREFIX_PATH=%DEPS_DIR%;%QT_PATH%
+		set PREFIX_PATH_X86=%DEPS_DIR_X86%
 ) else (
     set ENABLE_UI=false
     set PREFIX_PATH=%DEPS_DIR%
+		set PREFIX_PATH_X86=%DEPS_DIR_X86%
 )
 
 cmake -H. ^
@@ -31,6 +34,7 @@ cmake -H. ^
          -G"%CmakeGenerator%" -A x64 ^
          -DCMAKE_SYSTEM_VERSION="10.0.18363.657" ^
          -DCMAKE_INSTALL_PREFIX="%CD%\%InstallPath%" ^
+         -DBUILD_DIRECTORY_X86=%BUILD_DIRECTORY_X86% ^
          -DVLCPath="%VLC_DIR%" ^
          -DCEF_ROOT_DIR="%CEFPATH%" ^
          -DUSE_UI_LOOP=false ^
@@ -60,6 +64,7 @@ cmake -H. ^
          -Dabsl_DIR="%GRPC_DIST%\lib\cmake\absl" ^
          -DgRPC_DIR="%GRPC_DIST%\lib\cmake\grpc" ^
          -DCMAKE_PREFIX_PATH:PATH=%PREFIX_PATH% ^
+         -DPREFIX_PATH_X86:PATH=%PREFIX_PATH_X86% ^
          -DCMAKE_BUILD_TYPE=%BuildConfig% ^
          -DBUILD_FOR_DISTRIBUTION=true ^
          -DCURL_INCLUDE_DIR=%DEPS_DIR%/ ^
@@ -72,6 +77,8 @@ del /q /s %CD%\%InstallPath%
 cmake --build %CD%\%BUILD_DIRECTORY% --config %BuildConfig% -v
 cmake -S . -B %CD%\%BUILD_DIRECTORY% -DCOPIED_DEPENDENCIES=OFF -DCOPY_DEPENDENCIES=ON
 cmake --build %CD%\%BUILD_DIRECTORY% --target install --config %BuildConfig% -v
+cmake --build "%CD%\%BUILD_DIRECTORY_X86%\plugins\win-dshow" --target install --config %BuildConfig% -v
 
 cmake --build %CD%\%BUILD_DIRECTORY% --target check_dependencies --config %BuildConfig% -v
 if %errorlevel% neq 0 exit /b %errorlevel%
+

--- a/slobs_CI/win-install-dependency.cmd
+++ b/slobs_CI/win-install-dependency.cmd
@@ -1,9 +1,14 @@
 
 set WORK_DIR=%CD%
 set SUBDIR=build\deps
+set SUBDIR_X86=build_x86\deps
 
 set DepsURL=https://obs-studio-deployment.s3-us-west-2.amazonaws.com/%WIN_DEPS_VERSION%.zip
 set DEPS_DIR=%CD%\%SUBDIR%\%WIN_DEPS_VERSION%
+
+set DepsURLX86=https://github.com/obsproject/obs-deps/releases/download/%WIN_DEPS_VERSION_X86%/windows-deps-%WIN_DEPS_VERSION_X86%-x86.zip
+set DEPS_FILENAME_X86=windows-deps-%WIN_DEPS_VERSION_X86%-x86
+set DEPS_DIR_X86=%CD%\%SUBDIR_X86%\%DEPS_FILENAME_X86%
 
 set VLCURL=https://obs-studio-deployment.s3-us-west-2.amazonaws.com/%VLC_VERSION%.zip
 set VLC_DIR=%CD%\%SUBDIR%\vlc
@@ -64,7 +69,7 @@ if exist webrtc_dist\ (
     7z x %WEBRTC_DIST%.7z -aoa -owebrtc_dist
 )
 
-if exist deps_bin\ (
+if exist %WIN_DEPS_VERSION%\ (
     echo "OBS binary dependencies already installed"
 ) else (
     if exist %WIN_DEPS_VERSION%.zip (curl -kLO %DepsURL% -f --retry 5 -z %WIN_DEPS_VERSION%.zip) else (curl -kLO %DepsURL% -f --retry 5 -C -)
@@ -104,6 +109,18 @@ if exist CEF\ (
 ) else (
     if exist %CefFileName%.zip (curl -kLO %CEFURL%/%CefFileName%.zip -f --retry 5 -z %CefFileName%.zip) else (curl -kLO %CEFURL%/%CefFileName%.zip -f --retry 5 -C -)
     7z x %CefFileName%.zip -aoa -o%CefFileName%
+)
+
+cd "%WORK_DIR%"
+
+mkdir %SUBDIR_X86%
+cd %SUBDIR_X86%
+
+if exist %WIN_DEPS_VERSION_X86%\ (
+    echo "OBS X86 binary dependencies already installed"
+) else (
+    if exist %DEPS_FILENAME_X86%.zip (curl -kLO %DepsURLX86% -f --retry 5 -z %DEPS_FILENAME_X86%.zip) else (curl -kLO %DepsURLX86% -f --retry 5 -C -)
+    7z x %DEPS_FILENAME_X86%.zip -aoa -o%DEPS_FILENAME_X86%
 )
 
 cd "%WORK_DIR%"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Previously we got the 32bit module from obs-studio but its GUID is different. Probably, it is more correct to have our own GUIDs instead of copying obs-studio ones. So this fix enables 32bit module compilation.

### Motivation and Context
In the current release version, Windows vcam does not work at all. 32bit module cannot be installed and used.

### How Has This Been Tested?


### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
