### PR TITLE
Fixed crash on audio processing

### DIFF
--- a/libobs/obs-audio.c
+++ b/libobs/obs-audio.c
@@ -89,6 +89,9 @@ static void mix_audio(struct audio_data_mixes_outputs *mixes,
 								    canvas_idx,
 								    mix_idx,
 								    ch);
+				if (!aud) {
+					continue;
+				}
 				register float *end;
 
 				mix += start_point;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Fixed crash which happened during application major state change, like enabling dual output mode or importing scenes from OBS

### Motivation and Context
`get_source_audio_output_buf` might return a null pointer if specified indexes are out of range, so this simple error handling helps to avoid rare crashes.

### How Has This Been Tested?
- by QA, Windows only

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
