### PR TITLE
update obs-browser plugin & fix Xcode 16.3 compile error

### DIFF
--- a/plugins/mac-capture/mac-sck-audio-capture.m
+++ b/plugins/mac-capture/mac-sck-audio-capture.m
@@ -187,7 +187,7 @@ API_AVAILABLE(macos(13.0)) static void *sck_audio_capture_create(obs_data_t *set
     sc->audio_capture_type = (unsigned int) obs_data_get_int(settings, "type");
 
     os_sem_init(&sc->shareable_content_available, 1);
-    screen_capture_build_content_list(sc, sc->capture_type == ScreenCaptureAudioDesktopStream);
+    screen_capture_build_content_list(sc, sc->audio_capture_type == ScreenCaptureAudioDesktopStream);
 
     sc->capture_delegate = [[ScreenCaptureDelegate alloc] init];
     sc->capture_delegate.sc = sc;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
* Upgrade macos obs-browser (obs64 helper -> OBS Helper renamed) for browser source CEF
* fix compile error on xcode 16.3, invalid enum comparison

### Motivation and Context
* Stabilize Browser source(s). Fix CEF instability

### How Has This Been Tested?
* Launch SLOBS (macos) with a Browser source in scene. Resolves a 100% crash issue I found

### Types of changes
* Will need to update OSN macos cmake script to account for OBS Helper rename

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
