### PR TITLE
update path to ffmpeg for the mac build agent

### DIFF
--- a/.github/scripts/.build.zsh
+++ b/.github/scripts/.build.zsh
@@ -136,6 +136,7 @@ build() {
       log_group "Build/Install preset ${product_name}..."
       # Run the install target to construct a packed_build that will be consumed by obs-studio-node.
       cmake --build --target install --preset macos
+      ditto UI/${config}/OBS.app OBS.app
       exit 0 # Do not execute the steps below. streamlabs/obs-studio uses the cmake install target.
 
       log_group "Building ${product_name}..."

--- a/.github/scripts/.build.zsh
+++ b/.github/scripts/.build.zsh
@@ -136,8 +136,6 @@ build() {
       log_group "Build/Install preset ${product_name}..."
       # Run the install target to construct a packed_build that will be consumed by obs-studio-node.
       cmake --build --target install --preset macos
-      log_group "Copy OBS.app ${product_name}..."
-      cp -Rv build_macos/UI/${config}/OBS.app OBS.app
       exit 0 # Do not execute the steps below. streamlabs/obs-studio uses the cmake install target.
 
       log_group "Building ${product_name}..."

--- a/.github/scripts/.build.zsh
+++ b/.github/scripts/.build.zsh
@@ -137,7 +137,7 @@ build() {
       # Run the install target to construct a packed_build that will be consumed by obs-studio-node.
       cmake --build --target install --preset macos
       log_group "Copy OBS.app ${product_name}..."
-      cp -v build_macos/UI/${config}/OBS.app OBS.app
+      cp -Rv build_macos/UI/${config}/OBS.app OBS.app
       exit 0 # Do not execute the steps below. streamlabs/obs-studio uses the cmake install target.
 
       log_group "Building ${product_name}..."

--- a/.github/scripts/.build.zsh
+++ b/.github/scripts/.build.zsh
@@ -136,6 +136,7 @@ build() {
       log_group "Build/Install preset ${product_name}..."
       # Run the install target to construct a packed_build that will be consumed by obs-studio-node.
       cmake --build --target install --preset macos
+      log_group "Copy OBS.app ${product_name}..."
       ditto build_macos/UI/${config}/OBS.app OBS.app
       exit 0 # Do not execute the steps below. streamlabs/obs-studio uses the cmake install target.
 

--- a/.github/scripts/.build.zsh
+++ b/.github/scripts/.build.zsh
@@ -136,7 +136,7 @@ build() {
       log_group "Build/Install preset ${product_name}..."
       # Run the install target to construct a packed_build that will be consumed by obs-studio-node.
       cmake --build --target install --preset macos
-      ditto UI/${config}/OBS.app OBS.app
+      ditto build_macos/UI/${config}/OBS.app OBS.app
       exit 0 # Do not execute the steps below. streamlabs/obs-studio uses the cmake install target.
 
       log_group "Building ${product_name}..."

--- a/.github/scripts/.build.zsh
+++ b/.github/scripts/.build.zsh
@@ -137,7 +137,7 @@ build() {
       # Run the install target to construct a packed_build that will be consumed by obs-studio-node.
       cmake --build --target install --preset macos
       log_group "Copy OBS.app ${product_name}..."
-      ditto build_macos/UI/${config}/OBS.app OBS.app
+      cp -v build_macos/UI/${config}/OBS.app OBS.app
       exit 0 # Do not execute the steps below. streamlabs/obs-studio uses the cmake install target.
 
       log_group "Building ${product_name}..."

--- a/CI/macos/fix_deps_paths.sh
+++ b/CI/macos/fix_deps_paths.sh
@@ -1,16 +1,13 @@
 #!/bin/bash
-
+# Usage: <full path to the source file> <destination path>
 # Check if a file path is passed as an argument
 if [ -z "$1" ]; then
     echo "Usage: $0 <path_to_binary>"
     exit 1
 fi
 
-FINAL_PATH=$1
-INSTALL_PREFIX=$2
-SOURCE_FILE=$3
-
-BINARY_PATH="$INSTALL_PREFIX/$FINAL_PATH"
+SOURCE_FILE=$1
+BINARY_PATH=$2
 
 if [ ! -e "$BINARY_PATH" ]; then
   echo "fix_deps_paths.sh: creating the path: $BINARY_PATH."

--- a/CI/macos/fix_deps_paths.sh
+++ b/CI/macos/fix_deps_paths.sh
@@ -6,11 +6,8 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-FINAL_PATH=$1
-INSTALL_PREFIX=$2
-SOURCE_FILE=$3
-
-BINARY_PATH="$INSTALL_PREFIX/$FINAL_PATH"
+BINARY_PATH=$1
+SOURCE_FILE=$2
 
 if [ ! -e "$BINARY_PATH" ]; then
   echo "fix_deps_paths.sh: creating the path: $BINARY_PATH."

--- a/CI/macos/fix_deps_paths.sh
+++ b/CI/macos/fix_deps_paths.sh
@@ -6,8 +6,21 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-BINARY_PATH=$1
+FINAL_PATH=$1
+INSTALL_PREFIX=$2
+SOURCE_FILE=$3
 
+BINARY_PATH="$INSTALL_PREFIX/$FINAL_PATH"
+
+if [ ! -e "$BINARY_PATH" ]; then
+  echo "fix_deps_paths.sh: creating the path: $BINARY_PATH."
+  mkdir -p "$BINARY_PATH"
+fi
+
+cp -v "$SOURCE_FILE" "$BINARY_PATH" 
+
+filename=$(basename "$SOURCE_FILE")
+BINARY_PATH="$BINARY_PATH/$filename"
 # Use otool to get the list of linked libraries
 LIB_PATHS=$(otool -L "$BINARY_PATH" | grep "obs-deps" | awk '{print $1}')
 

--- a/CI/macos/fix_deps_paths.sh
+++ b/CI/macos/fix_deps_paths.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# Usage: <full path to the source file> <destination path>
+
 # Check if a file path is passed as an argument
 if [ -z "$1" ]; then
-    echo "Usage: $0 <path_to_binary>"
+    echo "Usage: $0 <path_to_binary> <destination path>"
     exit 1
 fi
 

--- a/CI/macos/fix_deps_paths.sh
+++ b/CI/macos/fix_deps_paths.sh
@@ -6,8 +6,11 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-BINARY_PATH=$1
-SOURCE_FILE=$2
+FINAL_PATH=$1
+INSTALL_PREFIX=$2
+SOURCE_FILE=$3
+
+BINARY_PATH="$INSTALL_PREFIX/$FINAL_PATH"
 
 if [ ! -e "$BINARY_PATH" ]; then
   echo "fix_deps_paths.sh: creating the path: $BINARY_PATH."

--- a/cmake/macos/helpers.cmake
+++ b/cmake/macos/helpers.cmake
@@ -63,7 +63,7 @@ function(set_target_properties_obs target)
       # cmake-format: off
       set_target_xcode_properties(
         ${target}
-        PROPERTIES PRODUCT_BUNDLE_IDENTIFIER com.streamlabs.slobs
+        PROPERTIES PRODUCT_BUNDLE_IDENTIFIER com.obsproject.obs-studio
                    PRODUCT_NAME OBS
                    ASSETCATALOG_COMPILER_APPICON_NAME AppIcon
                    CURRENT_PROJECT_VERSION ${OBS_BUILD_NUMBER}

--- a/cmake/macos/helpers.cmake
+++ b/cmake/macos/helpers.cmake
@@ -405,7 +405,7 @@ function(target_install_ffmpeg_and_ffprobe target)
       install(
         CODE "
         message(\"Running fix_deps_paths.sh on ${FINAL_FFMPEG_PATH}\")
-        execute_process(COMMAND bash \"${CMAKE_SOURCE_DIR}/CI/macos/fix_deps_paths.sh\" \"${ffmpeg_path}\" \"${FINAL_FFMPEG_PATH}\")
+        execute_process(COMMAND bash \"${CMAKE_SOURCE_DIR}/CI/macos/fix_deps_paths.sh\" \"${ffmpeg_path}\" \"${destination}\")
       ")
     else()
       message(WARNING "ffmpeg not found at ${ffmpeg_path}")
@@ -418,7 +418,7 @@ function(target_install_ffmpeg_and_ffprobe target)
       install(
         CODE "
         message(\"Running fix_deps_paths.sh on ${FINAL_FFPROBE_PATH}\")
-        execute_process(COMMAND bash \"${CMAKE_SOURCE_DIR}/CI/macos/fix_deps_paths.sh\" \"${ffprobe_path}\" \"${FINAL_FFPROBE_PATH}\")
+        execute_process(COMMAND bash \"${CMAKE_SOURCE_DIR}/CI/macos/fix_deps_paths.sh\" \"${ffprobe_path}\" \"${destination}\")
       ")
     else()
       message(WARNING "ffprobe not found at ${ffprobe_path}")

--- a/cmake/macos/helpers.cmake
+++ b/cmake/macos/helpers.cmake
@@ -407,7 +407,7 @@ function(target_install_ffmpeg_and_ffprobe target)
       install(
         CODE "
         message(\"Running fix_deps_paths.sh on ${FINAL_FFMPEG_PATH}\")
-        execute_process(COMMAND bash \"${CMAKE_SOURCE_DIR}/CI/macos/fix_deps_paths.sh\" \"${destination}\" \"${CMAKE_INSTALL_PREFIX}\" \"${ffmpeg_path}\")
+        execute_process(COMMAND bash \"${CMAKE_SOURCE_DIR}/CI/macos/fix_deps_paths.sh\" \"${FINAL_FFMPEG_PATH}\" \"${ffmpeg_path}\")
       ")
     else()
       message(WARNING "ffmpeg not found at ${ffmpeg_path}")
@@ -420,7 +420,7 @@ function(target_install_ffmpeg_and_ffprobe target)
       install(
         CODE "
         message(\"Running fix_deps_paths.sh on ${FINAL_FFPROBE_PATH}\")
-        execute_process(COMMAND bash \"${CMAKE_SOURCE_DIR}/CI/macos/fix_deps_paths.sh\" \"${destination}\" \"${CMAKE_INSTALL_PREFIX}\" \"${ffprobe_path}\")
+        execute_process(COMMAND bash \"${CMAKE_SOURCE_DIR}/CI/macos/fix_deps_paths.sh\" \"${FINAL_FFPROBE_PATH}\" \"${ffprobe_path}\")
       ")
     else()
       message(WARNING "ffprobe not found at ${ffprobe_path}")

--- a/cmake/macos/helpers.cmake
+++ b/cmake/macos/helpers.cmake
@@ -407,7 +407,7 @@ function(target_install_ffmpeg_and_ffprobe target)
       install(
         CODE "
         message(\"Running fix_deps_paths.sh on ${FINAL_FFMPEG_PATH}\")
-        execute_process(COMMAND bash \"${CMAKE_SOURCE_DIR}/CI/macos/fix_deps_paths.sh\" \"${FINAL_FFMPEG_PATH}\" \"${ffmpeg_path}\")
+        execute_process(COMMAND bash \"${CMAKE_SOURCE_DIR}/CI/macos/fix_deps_paths.sh\" \"${destination}\" \"${CMAKE_INSTALL_PREFIX}\" \"${ffmpeg_path}\")
       ")
     else()
       message(WARNING "ffmpeg not found at ${ffmpeg_path}")
@@ -420,7 +420,7 @@ function(target_install_ffmpeg_and_ffprobe target)
       install(
         CODE "
         message(\"Running fix_deps_paths.sh on ${FINAL_FFPROBE_PATH}\")
-        execute_process(COMMAND bash \"${CMAKE_SOURCE_DIR}/CI/macos/fix_deps_paths.sh\" \"${FINAL_FFPROBE_PATH}\" \"${ffprobe_path}\")
+        execute_process(COMMAND bash \"${CMAKE_SOURCE_DIR}/CI/macos/fix_deps_paths.sh\" \"${destination}\" \"${CMAKE_INSTALL_PREFIX}\" \"${ffprobe_path}\")
       ")
     else()
       message(WARNING "ffprobe not found at ${ffprobe_path}")

--- a/cmake/macos/helpers.cmake
+++ b/cmake/macos/helpers.cmake
@@ -394,20 +394,18 @@ function(target_install_ffmpeg_and_ffprobe target)
     get_filename_component(ffmpeg_bin_dir "${FFmpeg_INCLUDE_DIRS}/../bin" REALPATH)
     set(ffmpeg_path "${ffmpeg_bin_dir}/ffmpeg")
     set(ffprobe_path "${ffmpeg_bin_dir}/ffprobe")
-    set(destination "OBS.app/Contents/Frameworks")
+    set(destination "${CMAKE_INSTALL_PREFIX}/OBS.app/Contents/Frameworks")
     set(FINAL_FFMPEG_PATH "${destination}/ffmpeg")
     set(FINAL_FFPROBE_PATH "${destination}/ffprobe")
-    message(STATUS "FINAL_FFMPEG_PATH ${FINAL_FFMPEG_PATH}")
-    message(STATUS "FINAL_FFPROBE_PATH ${FINAL_FFPROBE_PATH}")
 
     # Install ffmpeg
     if(EXISTS "${ffmpeg_path}")
-      message(STATUS "Found ffmpeg at ${ffmpeg_path}. Will install to ${destination}")
+      message(STATUS "Found ffmpeg at ${ffmpeg_path}.")
       # Run the fix_deps_paths.sh script at install time with the full absolute path
       install(
         CODE "
         message(\"Running fix_deps_paths.sh on ${FINAL_FFMPEG_PATH}\")
-        execute_process(COMMAND bash \"${CMAKE_SOURCE_DIR}/CI/macos/fix_deps_paths.sh\" \"${destination}\" \"${CMAKE_INSTALL_PREFIX}\" \"${ffmpeg_path}\")
+        execute_process(COMMAND bash \"${CMAKE_SOURCE_DIR}/CI/macos/fix_deps_paths.sh\" \"${ffmpeg_path}\" \"${FINAL_FFMPEG_PATH}\")
       ")
     else()
       message(WARNING "ffmpeg not found at ${ffmpeg_path}")
@@ -420,7 +418,7 @@ function(target_install_ffmpeg_and_ffprobe target)
       install(
         CODE "
         message(\"Running fix_deps_paths.sh on ${FINAL_FFPROBE_PATH}\")
-        execute_process(COMMAND bash \"${CMAKE_SOURCE_DIR}/CI/macos/fix_deps_paths.sh\" \"${destination}\" \"${CMAKE_INSTALL_PREFIX}\" \"${ffprobe_path}\")
+        execute_process(COMMAND bash \"${CMAKE_SOURCE_DIR}/CI/macos/fix_deps_paths.sh\" \"${ffprobe_path}\" \"${FINAL_FFPROBE_PATH}\")
       ")
     else()
       message(WARNING "ffprobe not found at ${ffprobe_path}")

--- a/cmake/macos/helpers.cmake
+++ b/cmake/macos/helpers.cmake
@@ -63,7 +63,7 @@ function(set_target_properties_obs target)
       # cmake-format: off
       set_target_xcode_properties(
         ${target}
-        PROPERTIES PRODUCT_BUNDLE_IDENTIFIER com.obsproject.obs-studio
+        PROPERTIES PRODUCT_BUNDLE_IDENTIFIER com.streamlabs.slobs
                    PRODUCT_NAME OBS
                    ASSETCATALOG_COMPILER_APPICON_NAME AppIcon
                    CURRENT_PROJECT_VERSION ${OBS_BUILD_NUMBER}
@@ -113,7 +113,7 @@ function(set_target_properties_obs target)
           TARGET ${target}
           POST_BUILD
           COMMAND "${CMAKE_COMMAND}" -E copy_if_different "$<TARGET_FILE:${executable}>"
-          "$<TARGET_BUNDLE_CONTENT_DIR:${target}>/MacOS/"
+                  "$<TARGET_BUNDLE_CONTENT_DIR:${target}>/MacOS/"
           COMMENT "Copy ${executable} to application bundle")
       endforeach()
 
@@ -168,7 +168,7 @@ function(set_target_properties_obs target)
           TARGET ${target}
           POST_BUILD
           COMMAND "${CMAKE_COMMAND}" -E copy_directory "$<TARGET_BUNDLE_DIR:obs-dal-plugin>"
-          "$<TARGET_BUNDLE_CONTENT_DIR:${target}>/Resources/$<TARGET_BUNDLE_DIR_NAME:obs-dal-plugin>"
+                  "$<TARGET_BUNDLE_CONTENT_DIR:${target}>/Resources/$<TARGET_BUNDLE_DIR_NAME:obs-dal-plugin>"
           COMMENT "Add OBS DAL plugin to application bundle")
       endif()
 
@@ -177,7 +177,7 @@ function(set_target_properties_obs target)
           TARGET ${target}
           POST_BUILD
           COMMAND "${CMAKE_COMMAND}" -E copy_if_different "$<TARGET_FILE_DIR:obspython>/obspython.py"
-          "$<TARGET_BUNDLE_CONTENT_DIR:${target}>/Resources"
+                  "$<TARGET_BUNDLE_CONTENT_DIR:${target}>/Resources"
           COMMENT "Add OBS::python import module")
       endif()
 
@@ -365,8 +365,7 @@ endmacro()
 
 # target_export: Helper function to export target as CMake package
 function(target_export target)
-  # Exclude CMake package from 'ALL' target
-  # set(exclude_variant EXCLUDE_FROM_ALL)
+  # Exclude CMake package from 'ALL' target set(exclude_variant EXCLUDE_FROM_ALL)
   set(exclude_variant "")
   _target_export(${target})
 endfunction()
@@ -380,7 +379,7 @@ function(target_install_resources target)
 
     foreach(data_file IN LISTS data_files)
       cmake_path(RELATIVE_PATH data_file BASE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/data/" OUTPUT_VARIABLE
-        relative_path)
+                 relative_path)
       cmake_path(GET relative_path PARENT_PATH relative_path)
       target_sources(${target} PRIVATE "${data_file}")
       set_property(SOURCE "${data_file}" PROPERTY MACOSX_PACKAGE_LOCATION "Resources/${relative_path}")
@@ -395,23 +394,20 @@ function(target_install_ffmpeg_and_ffprobe target)
     get_filename_component(ffmpeg_bin_dir "${FFmpeg_INCLUDE_DIRS}/../bin" REALPATH)
     set(ffmpeg_path "${ffmpeg_bin_dir}/ffmpeg")
     set(ffprobe_path "${ffmpeg_bin_dir}/ffprobe")
-    set(destination "${CMAKE_INSTALL_PREFIX}/OBS.app/Contents/Frameworks")
+    set(destination "OBS.app/Contents/Frameworks")
     set(FINAL_FFMPEG_PATH "${destination}/ffmpeg")
     set(FINAL_FFPROBE_PATH "${destination}/ffprobe")
+    message(STATUS "FINAL_FFMPEG_PATH ${FINAL_FFMPEG_PATH}")
+    message(STATUS "FINAL_FFPROBE_PATH ${FINAL_FFPROBE_PATH}")
 
     # Install ffmpeg
     if(EXISTS "${ffmpeg_path}")
-      message(STATUS "Found ffmpeg at ${ffmpeg_path}")
-      install(
-        FILES "${ffmpeg_path}"
-        DESTINATION "${destination}"
-        PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-      )
-
+      message(STATUS "Found ffmpeg at ${ffmpeg_path}. Will install to ${destination}")
       # Run the fix_deps_paths.sh script at install time with the full absolute path
-      install(CODE "
+      install(
+        CODE "
         message(\"Running fix_deps_paths.sh on ${FINAL_FFMPEG_PATH}\")
-        execute_process(COMMAND bash \"${CMAKE_SOURCE_DIR}/CI/macos/fix_deps_paths.sh\" \"${FINAL_FFMPEG_PATH}\")
+        execute_process(COMMAND bash \"${CMAKE_SOURCE_DIR}/CI/macos/fix_deps_paths.sh\" \"${destination}\" \"${CMAKE_INSTALL_PREFIX}\" \"${ffmpeg_path}\")
       ")
     else()
       message(WARNING "ffmpeg not found at ${ffmpeg_path}")
@@ -420,23 +416,17 @@ function(target_install_ffmpeg_and_ffprobe target)
     # Install ffprobe
     if(EXISTS "${ffprobe_path}")
       message(STATUS "Found ffprobe at ${ffprobe_path}")
-      install(
-        FILES "${ffprobe_path}"
-        DESTINATION "${destination}"
-        PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-      )
-
       # Run the fix_deps_paths.sh script for ffprobe with the full absolute path
-      install(CODE "
+      install(
+        CODE "
         message(\"Running fix_deps_paths.sh on ${FINAL_FFPROBE_PATH}\")
-        execute_process(COMMAND bash \"${CMAKE_SOURCE_DIR}/CI/macos/fix_deps_paths.sh\" \"${FINAL_FFPROBE_PATH}\")
+        execute_process(COMMAND bash \"${CMAKE_SOURCE_DIR}/CI/macos/fix_deps_paths.sh\" \"${destination}\" \"${CMAKE_INSTALL_PREFIX}\" \"${ffprobe_path}\")
       ")
     else()
       message(WARNING "ffprobe not found at ${ffprobe_path}")
     endif()
   endif()
 endfunction()
-
 
 # target_add_resource: Helper function to add a specific resource to a bundle
 function(target_add_resource target resource)
@@ -532,7 +522,7 @@ function(_bundle_dependencies target)
     cmake_path(RELATIVE_PATH plugin_path BASE_DIRECTORY "${plugin_stem_dir}" OUTPUT_VARIABLE plugin_file_name)
     target_sources(${target} PRIVATE "${plugin}")
     set_source_files_properties("${plugin}" PROPERTIES MACOSX_PACKAGE_LOCATION "plugins/${plugin_file_name}"
-      XCODE_FILE_ATTRIBUTES "CodeSignOnCopy")
+                                                       XCODE_FILE_ATTRIBUTES "CodeSignOnCopy")
     source_group("Qt plugins" FILES "${plugin}")
   endforeach()
 


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Update script to work both locally and on build agent to copy ffmpeg/ffprobe. 

### Motivation and Context
Looking at the logs, this bug has been here for awhile where the build agent failed to copy ffmpeg/ffprobe. Locally it worked- but it would fail only on the build agent (but the build could still happily finish).

### How Has This Been Tested?
* Verified I could still record
* ffmpeg/ffprobe now present in the final artifact built by build machine

### Types of changes
* build agent was using the wrong path (packed_build was inserted twice): `/Users/runner/work/obs-studio/obs-studio/build_macos/packed_build/packed_build/OBS.app/Contents/Frameworks/ffmpeg`. This fix works because it uses a `relative` path. 
* run cp command during install() to copy over the artifacts

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
