### PR TITLE
Ensure win-streamlabs-vst.exe is written to the correct folder

### DIFF
--- a/cmake/windows/helpers.cmake
+++ b/cmake/windows/helpers.cmake
@@ -29,6 +29,8 @@ function(set_target_properties_obs target)
   if(target_type STREQUAL EXECUTABLE)
     if(target STREQUAL obs-browser-helper)
       set(OBS_EXECUTABLE_DESTINATION "${OBS_PLUGIN_DESTINATION}")
+    elseif(target STREQUAL win-streamlabs-vst)
+      set(OBS_EXECUTABLE_DESTINATION "${OBS_PLUGIN_DESTINATION}")    
     elseif(target STREQUAL inject-helper OR target STREQUAL get-graphics-offsets)
       set(OBS_EXECUTABLE_DESTINATION "${OBS_DATA_DESTINATION}/obs-plugins/win-capture")
 

--- a/cmake/windows/helpers.cmake
+++ b/cmake/windows/helpers.cmake
@@ -30,7 +30,7 @@ function(set_target_properties_obs target)
     if(target STREQUAL obs-browser-helper)
       set(OBS_EXECUTABLE_DESTINATION "${OBS_PLUGIN_DESTINATION}")
     elseif(target STREQUAL win-streamlabs-vst)
-      set(OBS_EXECUTABLE_DESTINATION "${OBS_PLUGIN_DESTINATION}")    
+      set(OBS_EXECUTABLE_DESTINATION "${OBS_PLUGIN_DESTINATION}")
     elseif(target STREQUAL inject-helper OR target STREQUAL get-graphics-offsets)
       set(OBS_EXECUTABLE_DESTINATION "${OBS_DATA_DESTINATION}/obs-plugins/win-capture")
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
VST filters expect win-streamlabs-vst.exe to be in the same folder as the obs-vst plugin. Update cmake/windows/helpers.cmake to copy the executable to 'plugins' rather than 'bin'.

### Motivation and Context
Version 1.19 couldn't find the expected files.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the streamlabs branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
