### PR TITLE
Remove flags from registry call

### DIFF
--- a/plugins/win-dshow/dshow-plugin.cpp
+++ b/plugins/win-dshow/dshow-plugin.cpp
@@ -28,7 +28,6 @@ static bool vcam_installed(bool b64)
 	StringCbPrintf(temp, sizeof(temp), L"CLSID\\%s", cls_str);
 
 	DWORD flags = KEY_READ;
-	flags |= b64 ? KEY_WOW64_64KEY : KEY_WOW64_32KEY;
 
 	LSTATUS status = RegOpenKeyExW(HKEY_CLASSES_ROOT, temp, 0, flags, &key);
 	if (status != ERROR_SUCCESS) {


### PR DESCRIPTION
win-dshow queries the registry to find whether obs-virtualcam-module is installed, and that registry call was failing. Removing the KEY_WOW64_64KEY/KEY_WOW64_32KEY flag from RegOpenKeyExW fixes that issue as it's only expecting an access value (i.e. KEY_READ).
