### PR TITLE
Ffmpeg mux freez fix

### DIFF
--- a/libobs/util/pipe-posix.c
+++ b/libobs/util/pipe-posix.c
@@ -140,7 +140,11 @@ os_process_pipe_t *os_process_pipe_create2(const os_process_args_t *args,
 					   const char *type)
 {
 	char **argv = os_process_args_get_argv(args);
-	return os_process_pipe_create_internal(argv[0], argv, type);
+	const char *internal_type = type;
+	if (type && (type[0] == 'f' || type[0] == 'm')) {
+		internal_type = (type[0] == 'f') ? "r" : "w";
+	}
+	return os_process_pipe_create_internal(argv[0], argv, internal_type);
 }
 
 int os_process_pipe_destroy(os_process_pipe_t *pp)

--- a/libobs/util/pipe-windows.c
+++ b/libobs/util/pipe-windows.c
@@ -266,7 +266,7 @@ os_process_pipe_t *os_process_pipe_create(const char *cmd_line,
 
 	success = !!SetHandleInformation(read_pipe ? input : output,
 					 HANDLE_FLAG_INHERIT, false);
-	if (!success) {
+	if (!success && !is_named_pipe) {
 		goto error;
 	}
 

--- a/libobs/util/pipe-windows.c
+++ b/libobs/util/pipe-windows.c
@@ -68,8 +68,7 @@ bool os_process_pipe_signal_shutdown(os_process_pipe_t *pp)
 	}
 
 	if (!SetEvent(pp->shutdown_event)) {
-		blog(LOG_ERROR, "Failed to signal shutdown event: %lu",
-		     GetLastError());
+		blog(LOG_ERROR, "Failed to signal shutdown event: %lu", GetLastError());
 		return false;
 	}
 	return true;
@@ -92,12 +91,9 @@ static bool create_data_event(os_process_pipe_t *pp, DWORD pid)
 	char event_name[64];
 	snprintf(event_name, sizeof(event_name), "FFmpegMuxData_%lu", pid);
 
-	pp->data_event = CreateEventA(/*lpEventAttributes*/ NULL,
-				      /*bManualReset    */ FALSE,
-				      /*bInitialState   */ FALSE, event_name);
+	pp->data_event = CreateEventA(NULL, FALSE, FALSE, event_name);
 	if (!pp->data_event) {
-		blog(LOG_ERROR, "Failed to create data event '%s': %lu",
-		     event_name, GetLastError());
+		blog(LOG_ERROR, "Failed to create data event '%s': %lu", event_name, GetLastError());
 		return false;
 	}
 	return true;
@@ -109,8 +105,7 @@ bool os_process_pipe_signal_data(os_process_pipe_t *pp)
 		return false;
 
 	if (!SetEvent(pp->data_event)) {
-		blog(LOG_ERROR, "Failed to signal data event: %lu",
-		     GetLastError());
+		blog(LOG_ERROR, "Failed to signal data event: %lu", GetLastError());
 		return false;
 	}
 	return true;
@@ -131,13 +126,13 @@ static bool create_data_pipe(os_process_pipe_t *pp, DWORD pid)
 
 	pp->handle = CreateNamedPipeA(
 		pipe_name, PIPE_ACCESS_OUTBOUND | FILE_FLAG_FIRST_PIPE_INSTANCE,
-		PIPE_TYPE_BYTE | /* byte stream                                         */
-			PIPE_WAIT, /* blocking mode                                       */
-		1, /* max instances                                       */
-		64 * 1024, /* out-buf size                                        */
-		0, /* in-buf size  (unused)                               */
+		PIPE_TYPE_BYTE |
+			PIPE_WAIT,
+		1,
+		64 * 1024,
+		0, 
 		0,
-		NULL); /* default timeout / security                          */
+		NULL);
 
 	if (pp->handle == INVALID_HANDLE_VALUE) {
 		blog(LOG_ERROR, "CreateNamedPipe '%s' failed: %lu", pipe_name,
@@ -145,12 +140,10 @@ static bool create_data_pipe(os_process_pipe_t *pp, DWORD pid)
 		return false;
 	}
 
-	/* Block until child connects; harmless because child launches immediately */
-	BOOL ok = ConnectNamedPipe(pp->handle, NULL) ||
-		  GetLastError() == ERROR_PIPE_CONNECTED;
+	// Block until child connects; harmless because child launches immediately
+	BOOL ok = ConnectNamedPipe(pp->handle, NULL) || GetLastError() == ERROR_PIPE_CONNECTED;
 	if (!ok) {
-		blog(LOG_ERROR, "ConnectNamedPipe '%s' failed: %lu", pipe_name,
-		     GetLastError());
+		blog(LOG_ERROR, "ConnectNamedPipe '%s' failed: %lu", pipe_name, GetLastError());
 		CloseHandle(pp->handle);
 		pp->handle = NULL;
 		return false;

--- a/libobs/util/pipe-windows.c
+++ b/libobs/util/pipe-windows.c
@@ -233,7 +233,7 @@ os_process_pipe_t *os_process_pipe_create(const char *cmd_line,
 	bool read_pipe;
 	bool is_named_pipe = false;
 	HANDLE process;
-	HANDLE output;
+	HANDLE output = NULL;
 	HANDLE input = NULL;
 	HANDLE err_input, err_output;
 	bool success;

--- a/libobs/util/pipe-windows.c
+++ b/libobs/util/pipe-windows.c
@@ -27,6 +27,9 @@ struct os_process_pipe {
 	HANDLE handle;
 	HANDLE handle_err;
 	HANDLE process;
+	// extended ipc
+	HANDLE shutdown_event;
+	HANDLE data_event;
 };
 
 static bool create_pipe(HANDLE *input, HANDLE *output)
@@ -40,6 +43,118 @@ static bool create_pipe(HANDLE *input, HANDLE *output)
 		return false;
 	}
 
+	return true;
+}
+
+static bool create_shutdown_event(os_process_pipe_t *pp, DWORD pid)
+{
+	char event_name[64];
+	snprintf(event_name, sizeof(event_name), "FFmpegMuxShutdown_%lu", pid);
+
+	pp->shutdown_event = CreateEventA(NULL, TRUE, FALSE, event_name);
+	if (!pp->shutdown_event) {
+		blog(LOG_ERROR, "Failed to create shutdown event '%s': %lu",
+		     event_name, GetLastError());
+		return false;
+	}
+	return true;
+}
+
+bool os_process_pipe_signal_shutdown(os_process_pipe_t *pp)
+{
+	if (!pp || !pp->shutdown_event) {
+		blog(LOG_WARNING, "Cannot signal shutdown: No shutdown event");
+		return false;
+	}
+
+	if (!SetEvent(pp->shutdown_event)) {
+		blog(LOG_ERROR, "Failed to signal shutdown event: %lu",
+		     GetLastError());
+		return false;
+	}
+	return true;
+}
+
+void os_process_pipe_cleanup_shutdown_event(os_process_pipe_t *pp)
+{
+	if (pp && pp->shutdown_event) {
+		CloseHandle(pp->shutdown_event);
+		pp->shutdown_event = NULL;
+	}
+}
+static inline void build_pipe_name(char *buf, size_t len, DWORD pid)
+{
+	snprintf(buf, len, "\\\\.\\pipe\\FFmpegMuxPipe_%lu", pid);
+}
+
+static bool create_data_event(os_process_pipe_t *pp, DWORD pid)
+{
+	char event_name[64];
+	snprintf(event_name, sizeof(event_name), "FFmpegMuxData_%lu", pid);
+
+	pp->data_event = CreateEventA(/*lpEventAttributes*/ NULL,
+				      /*bManualReset    */ FALSE,
+				      /*bInitialState   */ FALSE, event_name);
+	if (!pp->data_event) {
+		blog(LOG_ERROR, "Failed to create data event '%s': %lu",
+		     event_name, GetLastError());
+		return false;
+	}
+	return true;
+}
+
+bool os_process_pipe_signal_data(os_process_pipe_t *pp)
+{
+	if (!pp || !pp->data_event)
+		return false;
+
+	if (!SetEvent(pp->data_event)) {
+		blog(LOG_ERROR, "Failed to signal data event: %lu",
+		     GetLastError());
+		return false;
+	}
+	return true;
+}
+
+void os_process_pipe_cleanup_data_event(os_process_pipe_t *pp)
+{
+	if (pp && pp->data_event) {
+		CloseHandle(pp->data_event);
+		pp->data_event = NULL;
+	}
+}
+
+static bool create_data_pipe(os_process_pipe_t *pp, DWORD pid)
+{
+	char pipe_name[64];
+	build_pipe_name(pipe_name, sizeof(pipe_name), pid);
+
+	pp->handle = CreateNamedPipeA(
+		pipe_name, PIPE_ACCESS_OUTBOUND | FILE_FLAG_FIRST_PIPE_INSTANCE,
+		PIPE_TYPE_BYTE | /* byte stream                                         */
+			PIPE_WAIT, /* blocking mode                                       */
+		1, /* max instances                                       */
+		64 * 1024, /* out-buf size                                        */
+		0, /* in-buf size  (unused)                               */
+		0,
+		NULL); /* default timeout / security                          */
+
+	if (pp->handle == INVALID_HANDLE_VALUE) {
+		blog(LOG_ERROR, "CreateNamedPipe '%s' failed: %lu", pipe_name,
+		     GetLastError());
+		return false;
+	}
+
+	/* Block until child connects; harmless because child launches immediately */
+	BOOL ok = ConnectNamedPipe(pp->handle, NULL) ||
+		  GetLastError() == ERROR_PIPE_CONNECTED;
+	if (!ok) {
+		blog(LOG_ERROR, "ConnectNamedPipe '%s' failed: %lu", pipe_name,
+		     GetLastError());
+		CloseHandle(pp->handle);
+		pp->handle = NULL;
+		return false;
+	}
 	return true;
 }
 
@@ -123,27 +238,38 @@ os_process_pipe_t *os_process_pipe_create(const char *cmd_line,
 {
 	os_process_pipe_t *pp = NULL;
 	bool read_pipe;
+	bool is_named_pipe = false;
 	HANDLE process;
 	HANDLE output;
+	HANDLE input = NULL;
 	HANDLE err_input, err_output;
-	HANDLE input;
 	bool success;
 
 	if (!cmd_line || !type) {
 		return NULL;
 	}
-	if (*type != 'r' && *type != 'w') {
+
+	if (*type == 'f' || *type == 'm') {
+		is_named_pipe = true;
+	} else if (*type != 'r' && *type != 'w') {
 		return NULL;
 	}
-	if (!create_pipe(&input, &output)) {
-		return NULL;
+
+	read_pipe = (*type == 'r' || *type == 'f');
+
+	if (!is_named_pipe || read_pipe) {
+		if (!create_pipe(&input, &output)) {
+			return NULL;
+		}
 	}
 
 	if (!create_pipe(&err_input, &err_output)) {
+		if (input)
+			CloseHandle(input);
+		if (output)
+			CloseHandle(output);
 		return NULL;
 	}
-
-	read_pipe = *type == 'r';
 
 	success = !!SetHandleInformation(read_pipe ? input : output,
 					 HANDLE_FLAG_INHERIT, false);
@@ -169,14 +295,50 @@ os_process_pipe_t *os_process_pipe_create(const char *cmd_line,
 	pp->read_pipe = read_pipe;
 	pp->process = process;
 	pp->handle_err = err_input;
+	pp->shutdown_event = NULL;
+	pp->data_event = NULL;
 
-	CloseHandle(read_pipe ? output : input);
+	DWORD pid = GetProcessId(process);
+	if (!pid || !create_shutdown_event(pp, pid)) {
+		os_process_pipe_destroy(pp);
+		pp = NULL;
+		goto error;
+	}
+
+	if (!create_data_event(pp, pid)) {
+		os_process_pipe_destroy(pp);
+		pp = NULL;
+		goto error;
+	}
+
+	if (is_named_pipe) {
+		if (!create_data_pipe(pp, pid)) {
+			os_process_pipe_destroy(pp);
+			pp = NULL;
+			goto error;
+		}
+	}
+
+	if (read_pipe) {
+		if (output)
+			CloseHandle(output);
+	} else {
+		if (input)
+			CloseHandle(input);
+	}
 	CloseHandle(err_output);
+
 	return pp;
 
 error:
-	CloseHandle(output);
-	CloseHandle(input);
+	if (output)
+		CloseHandle(output);
+	if (input)
+		CloseHandle(input);
+	if (err_input)
+		CloseHandle(err_input);
+	if (err_output)
+		CloseHandle(err_output);
 	return NULL;
 }
 
@@ -250,14 +412,18 @@ int os_process_pipe_destroy(os_process_pipe_t *pp)
 	if (pp) {
 		DWORD code;
 
-		CloseHandle(pp->handle);
-		CloseHandle(pp->handle_err);
+		os_process_pipe_signal_shutdown(pp);
 
 		WaitForSingleObject(pp->process, INFINITE);
 		if (GetExitCodeProcess(pp->process, &code))
 			ret = (int)code;
 
+		CloseHandle(pp->handle);
+		CloseHandle(pp->handle_err);
+
 		CloseHandle(pp->process);
+		os_process_pipe_cleanup_shutdown_event(pp);
+		os_process_pipe_cleanup_data_event(pp);
 		bfree(pp);
 	}
 
@@ -320,6 +486,7 @@ size_t os_process_pipe_write(os_process_pipe_t *pp, const uint8_t *data,
 	success =
 		!!WriteFile(pp->handle, data, (DWORD)len, &bytes_written, NULL);
 	if (success && bytes_written) {
+		os_process_pipe_signal_data(pp);
 		return bytes_written;
 	}
 

--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -151,6 +151,7 @@ struct ffmpeg_mux {
 	struct io_buffer io;
 };
 
+#ifdef _WIN32
 struct pipe_sync_info {
 	HANDLE shutdown_event;
 	HANDLE data_event;
@@ -158,6 +159,7 @@ struct pipe_sync_info {
 };
 
 static struct pipe_sync_info psi = {0};
+#endif // _WIN32
 
 #define SRT_PROTO "srt"
 #define UDP_PROTO "udp"
@@ -257,7 +259,7 @@ static void ffmpeg_mux_free(struct ffmpeg_mux *ffm)
 
 	memset(ffm, 0, sizeof(*ffm));
 }
-
+#ifdef _WIN32
 static inline void build_pipe_name(char *buf, size_t len, DWORD pid)
 {
 	snprintf(buf, len, "\\\\.\\pipe\\FFmpegMuxPipe_%lu", pid);
@@ -322,6 +324,7 @@ static void cleanup_pipe_sync_info(struct pipe_sync_info *psi)
 		CloseHandle(psi->data_event);
 	memset(psi, 0, sizeof(*psi));
 }
+#endif // _WIN32
 
 static bool get_opt_str(int *p_argc, char ***p_argv, char **str,
 			const char *opt)
@@ -729,6 +732,7 @@ static void ffmpeg_mux_header(struct ffmpeg_mux *ffm, uint8_t *data,
 
 static size_t safe_read(void *vdata, size_t size)
 {
+#ifdef _WIN32
 	static struct pipe_sync_info psi = {0};
 	static bool ready = false;
 
@@ -757,11 +761,42 @@ static size_t safe_read(void *vdata, size_t size)
 			dst += got;
 			remain -= got;
 		} else {
-			fprintf(stderr, "safe_read: Wait failed: %lu\n", GetLastError());
+			fprintf(stderr, "safe_read: Wait failed: %lu\n",
+				GetLastError());
 			return 0;
 		}
 	}
 	return size;
+#else
+	uint8_t *dst = vdata;
+	size_t remain = size;
+
+	if (!pipe) {
+		// Assume stdin is used for input, as set up by os_process_pipe_create2
+		ssize_t got = read(STDIN_FILENO, dst, remain);
+		if (got <= 0) {
+			fprintf(stderr,
+				"safe_read: Failed to read from stdin: %s\n",
+				strerror(errno));
+			return 0;
+		}
+		return (size_t)got;
+	}
+
+	size_t total_read = 0;
+	while (remain) {
+		size_t got = os_process_pipe_read(pipe, dst, remain);
+		if (got == 0) {
+			fprintf(stderr,
+				"safe_read: Pipe read failed or closed\n");
+			return total_read;
+		}
+		dst += got;
+		remain -= got;
+		total_read += got;
+	}
+	return total_read;
+#endif
 }
 
 static bool ffmpeg_mux_get_header(struct ffmpeg_mux *ffm)
@@ -1404,9 +1439,10 @@ int main(int argc, char *argv[])
 	ffmpeg_mux_free(&ffm);
 	resize_buf_free(&rb);
 	resize_buf_free(&rb_filename);
-	cleanup_pipe_sync_info(&psi);
 
 #ifdef _WIN32
+	cleanup_pipe_sync_info(&psi);
+
 	for (int i = 0; i < argc; i++)
 		free(argv[i]);
 	free(argv);

--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -768,34 +768,19 @@ static size_t safe_read(void *vdata, size_t size)
 	}
 	return size;
 #else
-	uint8_t *dst = vdata;
-	size_t remain = size;
+	uint8_t *data = vdata;
+	size_t total = size;
 
-	if (!pipe) {
-		// Assume stdin is used for input, as set up by os_process_pipe_create2
-		ssize_t got = read(STDIN_FILENO, dst, remain);
-		if (got <= 0) {
-			fprintf(stderr,
-				"safe_read: Failed to read from stdin: %s\n",
-				strerror(errno));
+	while (size > 0) {
+		size_t in_size = fread(data, 1, size, stdin);
+		if (in_size == 0)
 			return 0;
-		}
-		return (size_t)got;
+
+		size -= in_size;
+		data += in_size;
 	}
 
-	size_t total_read = 0;
-	while (remain) {
-		size_t got = os_process_pipe_read(pipe, dst, remain);
-		if (got == 0) {
-			fprintf(stderr,
-				"safe_read: Pipe read failed or closed\n");
-			return total_read;
-		}
-		dst += got;
-		remain -= got;
-		total_read += got;
-	}
-	return total_read;
+	return total;
 #endif
 }
 

--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -270,7 +270,6 @@ static bool init_pipe_sync_info(struct pipe_sync_info *psi)
 	DWORD pid = GetCurrentProcessId();
 	char name[64];
 
-	/* shutdown event */
 	snprintf(name, sizeof(name), "FFmpegMuxShutdown_%lu", pid);
 	psi->shutdown_event = OpenEventA(SYNCHRONIZE, FALSE, name);
 	if (!psi->shutdown_event) {
@@ -279,7 +278,6 @@ static bool init_pipe_sync_info(struct pipe_sync_info *psi)
 		return false;
 	}
 
-	/* data event */
 	snprintf(name, sizeof(name), "FFmpegMuxData_%lu", pid);
 	psi->data_event = OpenEventA(SYNCHRONIZE, FALSE, name);
 	if (!psi->data_event) {
@@ -289,10 +287,8 @@ static bool init_pipe_sync_info(struct pipe_sync_info *psi)
 		return false;
 	}
 
-	/* named-pipe client */
 	build_pipe_name(name, sizeof(name), pid);
 
-	/* Wait until server side exists (should be instantaneous) */
 	if (!WaitNamedPipeA(name, NMPWAIT_WAIT_FOREVER)) {
 		fprintf(stderr, "WaitNamedPipe '%s' failed: %lu\n", name,
 			GetLastError());

--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -151,6 +151,14 @@ struct ffmpeg_mux {
 	struct io_buffer io;
 };
 
+struct pipe_sync_info {
+	HANDLE shutdown_event;
+	HANDLE data_event;
+	HANDLE pipe;
+};
+
+static struct pipe_sync_info psi = {0};
+
 #define SRT_PROTO "srt"
 #define UDP_PROTO "udp"
 #define TCP_PROTO "tcp"
@@ -248,6 +256,71 @@ static void ffmpeg_mux_free(struct ffmpeg_mux *ffm)
 	av_packet_free(&ffm->packet);
 
 	memset(ffm, 0, sizeof(*ffm));
+}
+
+static inline void build_pipe_name(char *buf, size_t len, DWORD pid)
+{
+	snprintf(buf, len, "\\\\.\\pipe\\FFmpegMuxPipe_%lu", pid);
+}
+
+static bool init_pipe_sync_info(struct pipe_sync_info *psi)
+{
+	DWORD pid = GetCurrentProcessId();
+	char name[64];
+
+	/* shutdown event */
+	snprintf(name, sizeof(name), "FFmpegMuxShutdown_%lu", pid);
+	psi->shutdown_event = OpenEventA(SYNCHRONIZE, FALSE, name);
+	if (!psi->shutdown_event) {
+		fprintf(stderr, "OpenEvent '%s' failed: %lu\n", name,
+			GetLastError());
+		return false;
+	}
+
+	/* data event */
+	snprintf(name, sizeof(name), "FFmpegMuxData_%lu", pid);
+	psi->data_event = OpenEventA(SYNCHRONIZE, FALSE, name);
+	if (!psi->data_event) {
+		fprintf(stderr, "OpenEvent '%s' failed: %lu\n", name,
+			GetLastError());
+		CloseHandle(psi->shutdown_event);
+		return false;
+	}
+
+	/* named-pipe client */
+	build_pipe_name(name, sizeof(name), pid);
+
+	/* Wait until server side exists (should be instantaneous) */
+	if (!WaitNamedPipeA(name, NMPWAIT_WAIT_FOREVER)) {
+		fprintf(stderr, "WaitNamedPipe '%s' failed: %lu\n", name,
+			GetLastError());
+		CloseHandle(psi->shutdown_event);
+		CloseHandle(psi->data_event);
+		return false;
+	}
+
+	psi->pipe = CreateFileA(name, GENERIC_READ, 0, NULL, OPEN_EXISTING,
+				FILE_ATTRIBUTE_NORMAL, NULL);
+	if (psi->pipe == INVALID_HANDLE_VALUE) {
+		fprintf(stderr, "CreateFile '%s' failed: %lu\n", name,
+			GetLastError());
+		CloseHandle(psi->shutdown_event);
+		CloseHandle(psi->data_event);
+		return false;
+	}
+
+	return true;
+}
+
+static void cleanup_pipe_sync_info(struct pipe_sync_info *psi)
+{
+	if (psi->pipe && psi->pipe != INVALID_HANDLE_VALUE)
+		CloseHandle(psi->pipe);
+	if (psi->shutdown_event)
+		CloseHandle(psi->shutdown_event);
+	if (psi->data_event)
+		CloseHandle(psi->data_event);
+	memset(psi, 0, sizeof(*psi));
 }
 
 static bool get_opt_str(int *p_argc, char ***p_argv, char **str,
@@ -656,19 +729,39 @@ static void ffmpeg_mux_header(struct ffmpeg_mux *ffm, uint8_t *data,
 
 static size_t safe_read(void *vdata, size_t size)
 {
-	uint8_t *data = vdata;
-	size_t total = size;
+	static struct pipe_sync_info psi = {0};
+	static bool ready = false;
 
-	while (size > 0) {
-		size_t in_size = fread(data, 1, size, stdin);
-		if (in_size == 0)
+	if (!ready) {
+		if (!init_pipe_sync_info(&psi))
 			return 0;
-
-		size -= in_size;
-		data += in_size;
+		ready = true;
 	}
 
-	return total;
+	uint8_t *dst = vdata;
+	size_t remain = size;
+	HANDLE h[2] = {psi.shutdown_event, psi.data_event};
+
+	while (remain) {
+		DWORD wr = WaitForMultipleObjects(2, h, FALSE, INFINITE);
+
+		if (wr == WAIT_OBJECT_0) // shutdown
+			return 0;
+
+		if (wr == WAIT_OBJECT_0 + 1) { // data available
+			DWORD want = (DWORD)remain, got = 0;
+			if (!ReadFile(psi.pipe, dst, want, &got, NULL) ||
+			    got == 0)
+				return 0;
+
+			dst += got;
+			remain -= got;
+		} else {
+			fprintf(stderr, "safe_read: Wait failed: %lu\n", GetLastError());
+			return 0;
+		}
+	}
+	return size;
 }
 
 static bool ffmpeg_mux_get_header(struct ffmpeg_mux *ffm)
@@ -1311,6 +1404,7 @@ int main(int argc, char *argv[])
 	ffmpeg_mux_free(&ffm);
 	resize_buf_free(&rb);
 	resize_buf_free(&rb_filename);
+	cleanup_pipe_sync_info(&psi);
 
 #ifdef _WIN32
 	for (int i = 0; i < argc; i++)

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -340,7 +340,7 @@ void start_pipe(struct ffmpeg_muxer *stream, const char *path)
 {
 	os_process_args_t *args = NULL;
 	build_command_line(stream, &args, path);
-	stream->pipe = os_process_pipe_create2(args, "w");
+	stream->pipe = os_process_pipe_create2(args, "m");
 	os_process_args_destroy(args);
 }
 


### PR DESCRIPTION
### Description
fixed re submit of https://github.com/streamlabs/obs-studio/pull/651
had issue with error handling on win11


Replace use of stdin to communicated with ffmpeg mux process. with named pipe and windows events. 
 
### Motivation and Context
fread in mux process could get stuck waiting for more data even after obs process already called CloseHandle on it. 
 
obs stuck in  os_process_pipe_destroy waiting with WaitForSingleObject for mux process to close 
```
 	ntdll.dll!NtWaitForSingleObject()	Unknown	Symbols loaded.
 	KernelBase.dll!00007ffa75fc8a9e()	Unknown	No symbols loaded.
 	obs.dll!os_process_pipe_destroy(os_process_pipe * pp) Line 257	C	Symbols loaded.
 	obs-ffmpeg.dll!deactivate(ffmpeg_muxer * stream, int code) Line 514	C	Symbols loaded.
 	obs.dll!send_interleaved(obs_output * output) Line 1793	C	Symbols loaded.
>	obs.dll!interleave_packets(void * data, encoder_packet * packet) Line 2325	C	Symbols loaded.
 	[Inline Frame] obs.dll!send_packet(obs_encoder *) Line 1372	C	Symbols loaded.
 	obs.dll!send_off_encoder_packet(obs_encoder * encoder, bool success, bool received, encoder_packet * pkt) Line 1429	C	Symbols loaded.
 	obs.dll!gpu_encode_thread(void * data) Line 172	C	Symbols loaded.
 	w32-pthreads.dll!ptw32_threadStart(void * vthreadParms) Line 225	C	Symbols loaded.
 	ucrtbase.dll!00007ffa75ec1bb2()	Unknown	No symbols loaded.
 	kernel32.dll!00007ffa77157374()	Unknown	No symbols loaded.
 	ntdll.dll!RtlUserThreadStart()	Unknown	Symbols loaded.
``` 
and mux process stuck inside fread. 
```
ntdll.dll!NtReadFile()	Unknown	Symbols loaded.
 	KernelBase.dll!ReadFile()	Unknown	Symbols loaded.
 	ucrtbase.dll!_read_nolock()	Unknown	Symbols loaded.
 	ucrtbase.dll!_read()	Unknown	Symbols loaded.
 	ucrtbase.dll!common_refill_and_read_nolock<char>()	Unknown	Symbols loaded.
 	ucrtbase.dll!_fread_nolock_s()	Unknown	Symbols loaded.
 	ucrtbase.dll!fread_s()	Unknown	Symbols loaded.
 	ucrtbase.dll!fread()	Unknown	Symbols loaded.
>	obs-ffmpeg-mux.exe!safe_read(void * vdata, unsigned __int64 size) Line 675	C	Symbols loaded.
 	obs-ffmpeg-mux.exe!wmain(int argc, wchar_t * * argv_w) Line 1313	C	Symbols loaded.
 	[Inline Frame] obs-ffmpeg-mux.exe!invoke_main() Line 90	C++	Symbols loaded.
 	obs-ffmpeg-mux.exe!__scrt_common_main_seh() Line 288	C++	Symbols loaded.
 	kernel32.dll!00007ffa77157374()	Unknown	No symbols loaded.
 	ntdll.dll!RtlUserThreadStart()	Unknown	Symbols loaded.
``` 	

fread should return with eof error as parent process already called CloseHandle a moment before. And it should initiate shutdown sequence.
For most users it works fine, but in some rare condition fread get stuck ignoring stdin being closed.  

### How Has This Been Tested?
Start/Stop recording in local SLD build.
 
### Types of changes
- Bug fix (non-breaking change which fixes an issue) 
- Tweak (non-breaking change to improve existing functionality) 
 
### Checklist:
- [x] My code has been run through [clang-format]
- [x] I have read the [**contributing** document]
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
