### PR TITLE
Update Virtual Camera system extension entitlement

### DIFF
--- a/plugins/mac-virtualcam/src/camera-extension/slobs-CMakeLists.cmake
+++ b/plugins/mac-virtualcam/src/camera-extension/slobs-CMakeLists.cmake
@@ -1,6 +1,22 @@
 cmake_minimum_required(VERSION 3.22...3.25)
 project(mac-camera-extension)
 
+# set_target_xcode_properties: Sets Xcode-specific target attributes
+function(set_target_xcode_properties target)
+  message(STATUS "[set_target_xcode_properties] Setting target properties for ${target}...")
+  set(options "")
+  set(oneValueArgs "")
+  set(multiValueArgs PROPERTIES)
+  cmake_parse_arguments(PARSE_ARGV 0 _STXP "${options}" "${oneValueArgs}" "${multiValueArgs}")
+
+  message(DEBUG "Setting Xcode properties for target ${target}...")
+
+  while(_STXP_PROPERTIES)
+    list(POP_FRONT _STXP_PROPERTIES key value)
+    set_property(TARGET ${target} PROPERTY XCODE_ATTRIBUTE_${key} "${value}")
+  endwhile()
+endfunction()
+
 foreach(_uuid IN ITEMS VIRTUALCAM_DEVICE_UUID VIRTUALCAM_SOURCE_UUID VIRTUALCAM_SINK_UUID)
   set(VALID_UUID FALSE)
   if(NOT ${_uuid})
@@ -36,12 +52,15 @@ set_target_properties(
              MACOSX_BUNDLE ON
              MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/cmake/macos/Info.plist.in"
              BUNDLE_EXTENSION systemextension
-             XCODE_PRODUCT_TYPE com.apple.product-type.system-extension
+             XCODE_PRODUCT_TYPE com.apple.product-type.system-extension)
+
+set_target_xcode_properties(
+  mac-camera-extension
+  PROPERTIES SWIFT_VERSION 5.0
              MACOSX_DEPLOYMENT_TARGET 13.0
              CODE_SIGN_ENTITLEMENTS "${CMAKE_CURRENT_SOURCE_DIR}/cmake/macos/entitlements.plist"
              PRODUCT_NAME com.streamlabs.slobs.mac-camera-extension
              PRODUCT_BUNDLE_IDENTIFIER com.streamlabs.slobs.mac-camera-extension
-             XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.streamlabs.slobs.mac-camera-extension"
              CURRENT_PROJECT_VERSION 1.0
              MARKETING_VERSION 1.0
              COPY_PHASE_STRIP NO
@@ -53,6 +72,4 @@ set_target_properties(
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_STYLE Automatic)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "Apple Development")
 set(CMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM $ENV{APPLE_TEAM_ID})
-# Use Swift version 5.0 by default
-set(CMAKE_XCODE_ATTRIBUTE_SWIFT_VERSION 5.0)
 # cmake-format: on

--- a/plugins/mac-virtualcam/src/camera-extension/slobs-CMakeLists.cmake
+++ b/plugins/mac-virtualcam/src/camera-extension/slobs-CMakeLists.cmake
@@ -41,7 +41,7 @@ set_target_properties(
              CODE_SIGN_ENTITLEMENTS "${CMAKE_CURRENT_SOURCE_DIR}/cmake/macos/entitlements.plist"
              PRODUCT_NAME com.streamlabs.slobs.mac-camera-extension
              PRODUCT_BUNDLE_IDENTIFIER com.streamlabs.slobs.mac-camera-extension
-             XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.streamlabs.slobs"
+             XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.streamlabs.slobs.mac-camera-extension"
              CURRENT_PROJECT_VERSION 1.0
              MARKETING_VERSION 1.0
              COPY_PHASE_STRIP NO

--- a/plugins/mac-virtualcam/src/obs-plugin/CMakeLists.txt
+++ b/plugins/mac-virtualcam/src/obs-plugin/CMakeLists.txt
@@ -5,9 +5,8 @@ add_library(OBS::virtualcam ALIAS mac-virtualcam)
 
 target_sources(mac-virtualcam PRIVATE Defines.h plugin-main.mm OBSDALMachServer.mm OBSDALMachServer.h)
 target_compile_options(mac-virtualcam PRIVATE -fmodules -fcxx-modules)
-if(DEFINED ENV{VIRTUALCAM_BYPASS_SYSTEM_CHECK}) # enable virtualcam dev outside of app bundle
-  target_compile_definitions(mac-virtualcam PRIVATE VIRTUALCAM_BYPASS_SYSTEM_CHECK)
-endif()
+# enable virtualcam dev outside of app bundle for slobs
+target_compile_definitions(mac-virtualcam PRIVATE VIRTUALCAM_BYPASS_SYSTEM_CHECK)
 target_link_libraries(mac-virtualcam PRIVATE OBS::mach-protocol OBS::libobs OBS::frontend-api)
 
 # cmake-format: off


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
* Enable `VIRTUALCAM_BYPASS_SYSTEM_CHECK` on the build agent to disable the OBS`OSSystemExtensionRequestDelegate`. Streamlabs Desktop.app does not use this it has to use its' own delegate due to Apple security restrictions.
* Update entitlements on the mac-camera-system extension

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Due to Apple security restrictions, Streamlabs Desktop.app is unable to directly utilize the OBS delegate directly. `obs64` dynamically loads the `mac-virtualcam` plugin which triggers `OSSystemExtensionErrorValidationFailed` error code during activation.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Created a code signed electron app build and verified I could properly install the system extension.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
