### PR TITLE
Changed default bitrate from 2500 to 4500

### DIFF
--- a/plugins/mac-videotoolbox/encoder.c
+++ b/plugins/mac-videotoolbox/encoder.c
@@ -1525,10 +1525,10 @@ static void vt_defaults(obs_data_t *settings, void *data)
 						    "CBR");
 		}
 	}
-	obs_data_set_default_int(settings, "bitrate", 2500);
+	obs_data_set_default_int(settings, "bitrate", 4500);
 	obs_data_set_default_int(settings, "quality", 60);
 	obs_data_set_default_bool(settings, "limit_bitrate", false);
-	obs_data_set_default_int(settings, "max_bitrate", 2500);
+	obs_data_set_default_int(settings, "max_bitrate", 4500);
 	obs_data_set_default_double(settings, "max_bitrate_window", 1.5f);
 	obs_data_set_default_int(settings, "keyint_sec", 2);
 	obs_data_set_default_string(

--- a/plugins/obs-ffmpeg/obs-ffmpeg-av1.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-av1.c
@@ -261,7 +261,7 @@ static bool av1_encode(void *data, struct encoder_frame *frame,
 
 void av1_defaults(obs_data_t *settings)
 {
-	obs_data_set_default_int(settings, "bitrate", 2500);
+	obs_data_set_default_int(settings, "bitrate", 4500);
 	obs_data_set_default_int(settings, "keyint_sec", 0);
 	obs_data_set_default_int(settings, "cqp", 50);
 	obs_data_set_default_string(settings, "rate_control", "CBR");

--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -452,7 +452,7 @@ enum codec_type {
 
 static void nvenc_defaults_base(enum codec_type codec, obs_data_t *settings)
 {
-	obs_data_set_default_int(settings, "bitrate", 2500);
+	obs_data_set_default_int(settings, "bitrate", 4500);
 	obs_data_set_default_int(settings, "max_bitrate", 5000);
 	obs_data_set_default_int(settings, "keyint_sec", 0);
 	obs_data_set_default_int(settings, "cqp", 20);

--- a/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
@@ -926,7 +926,7 @@ static void vaapi_defaults_internal(obs_data_t *settings, enum codec_type codec)
 		obs_data_set_default_int(settings, "profile",
 					 FF_PROFILE_AV1_MAIN);
 	obs_data_set_default_int(settings, "level", FF_LEVEL_UNKNOWN);
-	obs_data_set_default_int(settings, "bitrate", 2500);
+	obs_data_set_default_int(settings, "bitrate", 4500);
 	obs_data_set_default_int(settings, "keyint_sec", 0);
 	obs_data_set_default_int(settings, "bf", 0);
 	obs_data_set_default_int(settings, "qp", 20);

--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -1162,7 +1162,7 @@ static void check_texture_encode_capability(obs_encoder_t *encoder,
 
 static void amf_defaults(obs_data_t *settings)
 {
-	obs_data_set_default_int(settings, "bitrate", 2500);
+	obs_data_set_default_int(settings, "bitrate", 4500);
 	obs_data_set_default_int(settings, "cqp", 20);
 	obs_data_set_default_string(settings, "rate_control", "CBR");
 	obs_data_set_default_string(settings, "preset", "quality");
@@ -2282,7 +2282,7 @@ try {
 
 static void amf_av1_defaults(obs_data_t *settings)
 {
-	obs_data_set_default_int(settings, "bitrate", 2500);
+	obs_data_set_default_int(settings, "bitrate", 4500);
 	obs_data_set_default_int(settings, "cqp", 20);
 	obs_data_set_default_string(settings, "rate_control", "CBR");
 	obs_data_set_default_string(settings, "preset", "quality");

--- a/plugins/obs-qsv11/obs-qsv11.c
+++ b/plugins/obs-qsv11/obs-qsv11.c
@@ -170,8 +170,8 @@ static void obs_qsv_defaults(obs_data_t *settings, int ver,
 			     enum qsv_codec codec)
 {
 	obs_data_set_default_string(settings, "target_usage", "TU4");
-	obs_data_set_default_int(settings, "bitrate", 2500);
-	obs_data_set_default_int(settings, "max_bitrate", 3000);
+	obs_data_set_default_int(settings, "bitrate", 4500);
+	obs_data_set_default_int(settings, "max_bitrate", 5000);
 	obs_data_set_default_string(settings, "profile",
 				    codec == QSV_CODEC_AVC ? "high" : "main");
 	obs_data_set_default_string(settings, "rate_control", "CBR");

--- a/plugins/obs-x264/obs-x264.c
+++ b/plugins/obs-x264/obs-x264.c
@@ -104,9 +104,9 @@ static void obs_x264_destroy(void *data)
 
 static void obs_x264_defaults(obs_data_t *settings)
 {
-	obs_data_set_default_int(settings, "bitrate", 2500);
+	obs_data_set_default_int(settings, "bitrate", 4500);
 	obs_data_set_default_bool(settings, "use_bufsize", false);
-	obs_data_set_default_int(settings, "buffer_size", 2500);
+	obs_data_set_default_int(settings, "buffer_size", 4500);
 	obs_data_set_default_int(settings, "keyint_sec", 0);
 	obs_data_set_default_int(settings, "crf", 23);
 #ifdef ENABLE_VFR


### PR DESCRIPTION
### Description
Changed default bitrate from 2500 to 4500

### Motivation and Context
This change is crucial for new users, because 2500 is too low for modern setups.

### How Has This Been Tested?
QA on Windows

### Types of changes
- Tweak (non-breaking change to improve existing functionality) -->
