### PR TITLE
explicitly set Team ID so entitlements can be installed manually (for mac-virtualcam installation)

### DIFF
--- a/plugins/mac-virtualcam/src/camera-extension/cmake/macos/slobs-entitlements.plist
+++ b/plugins/mac-virtualcam/src/camera-extension/cmake/macos/slobs-entitlements.plist
@@ -1,0 +1,12 @@
+<!--?xml version="1.0" encoding="UTF-8"?-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>com.apple.security.app-sandbox</key>
+        <true/>
+        <key>com.apple.security.application-groups</key>
+        <array>
+            <string>UT675MBB9Q.com.streamlabs.slobs</string>
+        </array>
+    </dict>
+</plist>

--- a/plugins/mac-virtualcam/src/camera-extension/slobs-CMakeLists.cmake
+++ b/plugins/mac-virtualcam/src/camera-extension/slobs-CMakeLists.cmake
@@ -58,18 +58,19 @@ set_target_xcode_properties(
   mac-camera-extension
   PROPERTIES SWIFT_VERSION 5.0
              MACOSX_DEPLOYMENT_TARGET 13.0
-             CODE_SIGN_ENTITLEMENTS "${CMAKE_CURRENT_SOURCE_DIR}/cmake/macos/entitlements.plist"
+             CODE_SIGN_ENTITLEMENTS "${CMAKE_CURRENT_SOURCE_DIR}/cmake/macos/slobs-entitlements.plist"
              PRODUCT_NAME com.streamlabs.slobs.mac-camera-extension
              PRODUCT_BUNDLE_IDENTIFIER com.streamlabs.slobs.mac-camera-extension
              CURRENT_PROJECT_VERSION 1.0
              MARKETING_VERSION 1.0
              COPY_PHASE_STRIP NO
              GENERATE_INFOPLIST_FILE YES
+             INFOPLIST_KEY_CFBundleDisplayName "Streamlabs Virtual Camera"
+             INFOPLIST_KEY_CFBundleIdentifier "com.streamlabs.slobs.mac-camera-extension"
              INFOPLIST_KEY_NSHumanReadableCopyright "(c) 2022-${CURRENT_YEAR} Sebastian Beckmann, Patrick Heyer"
              INFOPLIST_KEY_NSSystemExtensionUsageDescription "This Camera Extension enables virtual camera functionality in Streamlabs Desktop.")
 
 # Switch to automatic codesigning via valid team ID
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_STYLE Automatic)
-set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "Apple Development")
 set(CMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM $ENV{APPLE_TEAM_ID})
 # cmake-format: on


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
* set Team ID so we can setup app groups, etc properly when codesign is run outside of xcode (entitlement fix)
* set display name "Streamlabs Virtual Camera" for users 
<img width="445" height="158" alt="image" src="https://github.com/user-attachments/assets/c9af87ab-ca35-4915-b82d-0d9075e48861" />

* no need to explicitly state "Apple Development" in the cmake file that builds the xcodeproj so removing that line

### Motivation and Context
This change is required if `codesign` is run manually outside of xcode (which is currently the case in Streamlabs Desktop where we run codesign manually). we will hardcode the Team ID since desktop doesn't auto-replace the special xcode variables.

### How Has This Been Tested?
Tested locally and verified code sign works by running codesign against the binary again

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
