### PR TITLE
fix macOS Screen capture

### DIFF
--- a/plugins/mac-capture/mac-sck-video-capture.m
+++ b/plugins/mac-capture/mac-sck-video-capture.m
@@ -697,7 +697,7 @@ enum gs_color_space sck_video_capture_get_color_space(void *data, size_t count,
 
 API_AVAILABLE(macos(12.5))
 struct obs_source_info sck_video_capture_info = {
-    .id = "screen_capture",
+    .id = "mac_screen_capture",
     .type = OBS_SOURCE_TYPE_INPUT,
     .get_name = sck_video_capture_getname,
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
* Transferring (or rather restore?) this [pull request](https://github.com/streamlabs/obs-studio/pull/600). This file (`plugins/mac-capture/mac-screen-capture.m`) was renamed in obs-30.2 so we need to reapply the rename


### Motivation and Context
Resolves a support issue for 1.19.2

### How Has This Been Tested?
I verified the functionality appears to match 1.17.2 now

<img width="595" height="484" alt="image" src="https://github.com/user-attachments/assets/07f5e70a-8ad1-44da-b67c-9b41b3714f27" />


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
