### PR TITLE
update to accept optional ARCH param + rename virtual camera

### DIFF
--- a/plugins/mac-virtualcam/src/camera-extension/OBSCameraProviderSource.swift
+++ b/plugins/mac-virtualcam/src/camera-extension/OBSCameraProviderSource.swift
@@ -19,7 +19,7 @@ class OBSCameraProviderSource: NSObject, CMIOExtensionProviderSource {
 
         provider = CMIOExtensionProvider(source: self, clientQueue: clientQueue)
         deviceSource = OBSCameraDeviceSource(
-            localizedName: "OBS Virtual Camera",
+            localizedName: "Streamlabs Virtual Camera",
             deviceUUID: deviceUUID,
             sourceUUID: sourceUUID,
             sinkUUID: sinkUUID)

--- a/plugins/mac-virtualcam/src/camera-extension/build-slobs-cameraextension.sh
+++ b/plugins/mac-virtualcam/src/camera-extension/build-slobs-cameraextension.sh
@@ -8,8 +8,14 @@ cp CMakeLists.txt backup-CMakeLists.txt
 # Copy over the slobs version to build the project.
 cp slobs-CMakeLists.cmake CMakeLists.txt
 
+cmake_args=()
+
+if [ $# -ge 1 ]; then
+  cmake_args+=(-DCMAKE_OSX_ARCHITECTURES="$1")
+done
+
 # Build the project using the custom SLOBS build.
-cmake --preset macos
+cmake --preset macos "${cmake_args[@]}"
 cmake --build build_macos --preset macos
 cp backup-CMakeLists.txt CMakeLists.txt
 rm backup-CMakeLists.txt

--- a/plugins/mac-virtualcam/src/camera-extension/build-slobs-cameraextension.sh
+++ b/plugins/mac-virtualcam/src/camera-extension/build-slobs-cameraextension.sh
@@ -1,4 +1,24 @@
 # Use custom SLOBS CmakeLists.txt file which directly builds the SystemExtension (instead of the default CMakeLists.txt file)
+function display_usage {
+  echo "Usage: $(basename "$0") [OPTIONS]"
+  echo ""
+  echo "Description: This script builds the camera extension for slobs."
+  echo ""
+  echo "Options:"
+  echo "  -h, --help        Display this help message and exit."
+  echo "  arm64             set CMAKE_OSX_ARCHITECTURES to arm64"
+  echo "  x86_64            set CMAKE_OSX_ARCHITECTURES to x86_64"
+  echo ""
+  echo "Examples:"
+  echo "  $(basename "$0") arm64"
+  echo "  $(basename "$0") x86_64"
+  echo ""
+  exit 0
+}
+
+if [[ ( "$1" == "--help" ) || ( "$1" == "-h" ) ]]; then
+  display_usage
+fi
 
 cp -v ../../../../CMakePresets.json ./  # copy this file locally. We need to reuse the VIRTUALCAM_UUIDs
 
@@ -12,7 +32,7 @@ cmake_args=()
 
 if [ $# -ge 1 ]; then
   cmake_args+=(-DCMAKE_OSX_ARCHITECTURES="$1")
-done
+fi
 
 # Build the project using the custom SLOBS build.
 cmake --preset macos "${cmake_args[@]}"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
* Update build script to accept an optional ARCH parameter so we can build for arm64 or x86_64 locally (non-issue on build agent but makes dev easier)
* Rename OBS Virtual Camera -> Streamlabs Virtual Camera
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Enables the camera extension to switch ARCH on-the-fly at build time.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Verified the resulting executable could be either arm64 or x86_64 depending upon the argument
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
