### PR TITLE
cherry-pick mac-avcapture fixes from upstream obs-31 branch

### DIFF
--- a/plugins/mac-avcapture/plugin-main.m
+++ b/plugins/mac-avcapture/plugin-main.m
@@ -20,8 +20,8 @@ static void *av_capture_create(obs_data_t *settings, obs_source_t *source)
     capture_data->isFastPath = false;
     capture_data->settings = settings;
     capture_data->source = source;
-    capture_data->videoFrame = bmalloc(sizeof(OBSAVCaptureVideoFrame));
-    capture_data->audioFrame = bmalloc(sizeof(OBSAVCaptureAudioFrame));
+    capture_data->videoFrame = bzalloc(sizeof(OBSAVCaptureVideoFrame));
+    capture_data->audioFrame = bzalloc(sizeof(OBSAVCaptureAudioFrame));
 
     OBSAVCapture *capture = [[OBSAVCapture alloc] initWithCaptureInfo:capture_data];
 

--- a/plugins/mac-capture/mac-audio.c
+++ b/plugins/mac-capture/mac-audio.c
@@ -1140,7 +1140,7 @@ static obs_properties_t *coreaudio_properties(bool input, void *data)
 	obs_property_set_modified_callback2(property, coreaudio_downmix_changed,
 					    ca);
 
-	if (ca != NULL) {
+	if (ca != NULL && ca->au_initialized) {
 		uint32_t channels = get_audio_channels(ca->speakers);
 		ensure_output_channels_visible(props, ca, channels);
 

--- a/plugins/mac-capture/mac-sck-audio-capture.m
+++ b/plugins/mac-capture/mac-sck-audio-capture.m
@@ -13,9 +13,7 @@ API_AVAILABLE(macos(13.0)) static void destroy_audio_screen_stream(struct screen
                 MACCAP_ERR("destroy_audio_screen_stream: Failed to stop stream with error %s\n",
                            [[error localizedFailureReason] cStringUsingEncoding:NSUTF8StringEncoding]);
             }
-            os_event_signal(sc->disp_finished);
         }];
-        os_event_wait(sc->disp_finished);
     }
 
     if (sc->stream_properties) {
@@ -28,7 +26,6 @@ API_AVAILABLE(macos(13.0)) static void destroy_audio_screen_stream(struct screen
         sc->disp = NULL;
     }
 
-    os_event_destroy(sc->disp_finished);
     os_event_destroy(sc->stream_start_completed);
 }
 
@@ -152,7 +149,6 @@ API_AVAILABLE(macos(13.0)) static bool init_audio_screen_stream(struct screen_ca
         sc->disp = NULL;
         return !did_add_output;
     }
-    os_event_init(&sc->disp_finished, OS_EVENT_TYPE_MANUAL);
     os_event_init(&sc->stream_start_completed, OS_EVENT_TYPE_MANUAL);
 
     __block BOOL did_stream_start = false;

--- a/plugins/mac-capture/mac-sck-common.h
+++ b/plugins/mac-capture/mac-sck-common.h
@@ -52,7 +52,6 @@ struct API_AVAILABLE(macos(12.5)) screen_capture {
     SCShareableContent *shareable_content;
     ScreenCaptureDelegate *capture_delegate;
 
-    os_event_t *disp_finished;
     os_event_t *stream_start_completed;
     os_sem_t *shareable_content_available;
     IOSurfaceRef current, prev;

--- a/plugins/mac-capture/mac-sck-video-capture.m
+++ b/plugins/mac-capture/mac-sck-video-capture.m
@@ -9,9 +9,7 @@ API_AVAILABLE(macos(12.5)) static void destroy_screen_stream(struct screen_captu
                 MACCAP_ERR("destroy_screen_stream: Failed to stop stream with error %s\n",
                            [[error localizedFailureReason] cStringUsingEncoding:NSUTF8StringEncoding]);
             }
-            os_event_signal(sc->disp_finished);
         }];
-        os_event_wait(sc->disp_finished);
     }
 
     if (sc->stream_properties) {
@@ -41,7 +39,6 @@ API_AVAILABLE(macos(12.5)) static void destroy_screen_stream(struct screen_captu
         sc->disp = NULL;
     }
 
-    os_event_destroy(sc->disp_finished);
     os_event_destroy(sc->stream_start_completed);
 }
 
@@ -110,7 +107,6 @@ API_AVAILABLE(macos(12.5)) static bool init_screen_stream(struct screen_capture 
                 MACCAP_ERR("init_screen_stream: Invalid target display ID:  %u\n", sc->display);
                 os_sem_post(sc->shareable_content_available);
                 sc->disp = NULL;
-                os_event_init(&sc->disp_finished, OS_EVENT_TYPE_MANUAL);
                 os_event_init(&sc->stream_start_completed, OS_EVENT_TYPE_MANUAL);
                 return true;
             }
@@ -152,7 +148,6 @@ API_AVAILABLE(macos(12.5)) static bool init_screen_stream(struct screen_capture 
                 MACCAP_ERR("init_screen_stream: Invalid target window ID:  %u\n", sc->window);
                 os_sem_post(sc->shareable_content_available);
                 sc->disp = NULL;
-                os_event_init(&sc->disp_finished, OS_EVENT_TYPE_MANUAL);
                 os_event_init(&sc->stream_start_completed, OS_EVENT_TYPE_MANUAL);
                 return true;
             } else {
@@ -172,7 +167,6 @@ API_AVAILABLE(macos(12.5)) static bool init_screen_stream(struct screen_capture 
                 MACCAP_ERR("init_screen_stream: Invalid target display ID:  %u\n", sc->display);
                 os_sem_post(sc->shareable_content_available);
                 sc->disp = NULL;
-                os_event_init(&sc->disp_finished, OS_EVENT_TYPE_MANUAL);
                 os_event_init(&sc->stream_start_completed, OS_EVENT_TYPE_MANUAL);
                 return true;
             }
@@ -217,7 +211,6 @@ API_AVAILABLE(macos(12.5)) static bool init_screen_stream(struct screen_capture 
         if (sc->capture_type != ScreenCaptureWindowStream) {
             sc->disp = NULL;
             [content_filter release];
-            os_event_init(&sc->disp_finished, OS_EVENT_TYPE_MANUAL);
             os_event_init(&sc->stream_start_completed, OS_EVENT_TYPE_MANUAL);
             return true;
         }
@@ -250,7 +243,6 @@ API_AVAILABLE(macos(12.5)) static bool init_screen_stream(struct screen_capture 
             return !did_add_output;
         }
     }
-    os_event_init(&sc->disp_finished, OS_EVENT_TYPE_MANUAL);
     os_event_init(&sc->stream_start_completed, OS_EVENT_TYPE_MANUAL);
 
     __block BOOL did_stream_start = NO;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Bringing over mac-avcapture fixes from obs-31 branch. Currently, we have about 4 reports of choppy audio with capture cards that I cannot repro with Elgato 4K X. Thought it prudent to check obs-31 and bring over any improvements.
 
* mac-avcapture: Prevent race condition in source init/deinit
* mac-avcapture: Clear memory when creating frame struct
* mac-sck-audio-capture: Remove disp_finished event
* mac-capture: Don't read channels for disconnected audio device
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Wanted to bring over mac-audio fixes from obs-31 branch so I do not overlap the upstream branch or redo effort
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Test avcapture plugin in Desktop
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
