### PR TITLE
update slobs to build on macOS Tahoe dev env

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -52,7 +52,8 @@
       "inherits": ["macos"],
       "warnings": {"dev": true, "deprecated": true},
       "cacheVariables": {
-        "CMAKE_COMPILE_WARNING_AS_ERROR": true
+        "CMAKE_COMPILE_WARNING_AS_ERROR": true,
+        "ENABLE_CCACHE": true
       }
     },
     {
@@ -124,7 +125,11 @@
       "inherits": "linux-x86_64",
       "cacheVariables": {
         "ENABLE_RELEASE_BUILD": true,
-        "ENABLE_BROWSER": true
+        "ENABLE_BROWSER": true,
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_COMPILE_WARNING_AS_ERROR": true,
+        "CMAKE_COLOR_DIAGNOSTICS": true,
+        "ENABLE_CCACHE": true
       }
     },
     {
@@ -157,8 +162,7 @@
       "inherits": ["windows-x64"],
       "warnings": {"dev": true, "deprecated": true},
       "cacheVariables": {
-        "CMAKE_COMPILE_WARNING_AS_ERROR": true,
-        "ENABLE_CCACHE": false
+        "CMAKE_COMPILE_WARNING_AS_ERROR": true
       }
     }
   ],

--- a/buildspec.json
+++ b/buildspec.json
@@ -12,17 +12,15 @@
             }
         },
         "qt6": {
-            "version": "2024-09-10v4",
+            "version": "2025-08-23",
             "baseUrl": "https://obs-studio-deployment.s3-us-west-2.amazonaws.com",
             "label": "Pre-Built Qt6",
             "hashes": {
-                "macos-x86_64": "82118c65905ba373849c56682d8a0da3e7d4f83a9c22be5a3dfef29a20a7e152",
-                "macos-arm64": "72460fbc0875b75c9d605454434d9fcfc23a47cc23b3592215047fa6a555a222",
-                "macos-universal": "b53ec9b86c95e0883d7ba920cf87a5f86c00db4da36fe9316e375e2c1e61149b",
-                "windows-x64": "b91f0d0ea2ebbbd006a5a1a0bf82a0ffaec24282cfe75a095c3a4ba4b47f7714"
+                "macos-universal": "990f11638b80a4509e14e8c315f6e4caa0861e37fcd3113a256fbff835ffca29",
+                "windows-x64": "c62e82483bc7c0bf199e8ac3220c66a85a6e8a0cd69a05b6d44f873b830e415f"
             },
             "debugSymbols": {
-                "windows-x64": "7400a4d195e16d0220d43c1cc296c6ff288118826b34ac4c74a1e069c9b1ea68"
+                "windows-x64": "aae88a17e0211cb37db6a8602f2e20d69255be1f9700c699008ca5adbce1dde2"
             }
         },
         "cef": {

--- a/cmake/common/ccache.cmake
+++ b/cmake/common/ccache.cmake
@@ -11,7 +11,7 @@ endif()
 if(CCACHE_PROGRAM)
   message(DEBUG "Trying to find ccache on build host - done")
   message(DEBUG "Ccache found as ${CCACHE_PROGRAM}")
-  option(ENABLE_CCACHE "Enable compiler acceleration with ccache" ON)
+  option(ENABLE_CCACHE "Enable compiler acceleration with ccache" OFF)
 
   if(ENABLE_CCACHE)
     set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")

--- a/cmake/macos/defaults.cmake
+++ b/cmake/macos/defaults.cmake
@@ -40,6 +40,8 @@ set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
 # Use common bundle-relative RPATH for installed targets
 set(CMAKE_INSTALL_RPATH "@executable_path/../Frameworks")
+# Ignore any dependent packages installed via Homebrew
+list(APPEND CMAKE_IGNORE_PREFIX_PATH "/opt/homebrew" "/usr/local")
 
 # Used for library exports only (obs-frontend-api)
 set(OBS_LIBRARY_DESTINATION "lib")


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Enable slobs to compile on macos 26 / Xcode 26 by cherry-picking commits from upstream
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Updated to macOS 26 to check for issues with Desktop (since many users already upgraded). Unfortunately, this sacked my dev env due to many changes within `macosSDK26`. These are issues already resolved only on obs `master` branch so we will cherry-pick only what is needed for now:
* Disable ccache on local dev env. fixes compile issue with clang++ detecting multiple deployment targets
* Upgrade Qt to fix [issue](https://bugreports.qt.io/browse/QTBUG-137687) with Apple GL being removed
* cherry-pick a change to prevent the build from grabbing homebrew libs instead of the local obs-deps (now for ex, devs can have a local Qt installed via homebrew without it conflicting with obs)

Unresolved xcode 26 bug-
`builtin-validationUtility Framework .../OBS.app/Contents/Frameworks/Chromium Embedded Framework.framework did not contain an Info.plist `
* Not sure why xcode 26 thinks the pre-built CEF framework `ver 5060` lacks an Info.plist (because it does seem to have it when I check) and the previous Xcode versions worked with this just fine. luckily this is the last step in the build process after OBS.app is already built so we can still manually run the OBS.app externally and manually attach the debugger if we need to run SLOBS backend directly. Very awkward (looks like updating to CEF to a more [recent ver ](https://github.com/obsproject/obs-studio/commit/480f514abbbe4878b81161d8ce2b73aa970a02cd) will fix). For now I can live w/o fixing this maybe?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Verified I can build slobs via `cmake`. Checked Desktop
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
