### PR TITLE
Game capture tweaks

### DIFF
--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -2384,7 +2384,7 @@ static void game_capture_tick(void *data, float seconds)
 		if (gc->capturing) {
 			obs_data_t *settings =
 				obs_source_get_settings(gc->source);
-			if (obs_data_get_bool(settings, COMPAT_INFO_VISIBLE)) {
+			if (is_compat_info_visible(gc)) {
 				set_compat_info_visible(gc, false);
 			}
 			obs_data_release(settings);
@@ -2969,13 +2969,14 @@ static bool window_changed_callback(obs_properties_t *ppts, obs_property_t *p,
 
 	if (!compat) {
 		modified = obs_property_visible(p_warn) || modified;
-		obs_property_set_visible(p_warn, false);
+		//set a default msg, will be set as visible or not in game_capture_tick
+		obs_property_set_description(p_warn,
+					     "Attempting to hook process...");
 		return modified;
 	}
 
-	obs_property_set_long_description(p_warn, compat->message);
+	obs_property_set_description(p_warn, compat->message);
 	obs_property_text_set_info_type(p_warn, compat->severity);
-	obs_property_set_visible(p_warn, true);
 
 	compat_result_free(compat);
 
@@ -3065,29 +3066,26 @@ static obs_properties_t *game_capture_properties(void *data)
 	obs_property_list_add_int(p, TEXT_MATCH_CLASS, WINDOW_PRIORITY_CLASS);
 	obs_property_list_add_int(p, TEXT_MATCH_EXE, WINDOW_PRIORITY_EXE);
 
-	p = obs_properties_add_text(ppts, SETTINGS_COMPAT_INFO, NULL,
-				    OBS_TEXT_INFO);
-	obs_property_set_enabled(p, false);
-
-	if (audio_capture_available()) {
-		p = obs_properties_add_bool(ppts, SETTING_CAPTURE_AUDIO,
-					    TEXT_CAPTURE_AUDIO);
-		obs_property_set_long_description(p, TEXT_CAPTURE_AUDIO_TT);
-	}
-
 	p = obs_properties_add_text(ppts, SETTINGS_COMPAT_INFO,
 				    "Specified window is not a game",
 				    OBS_TEXT_INFO);
 	obs_property_text_set_info_type(p, OBS_TEXT_INFO_ERROR);
-	obs_property_set_visible(p, false);
+	obs_property_set_enabled(p, false);
 	if (data) {
 		struct game_capture *gc = data;
 		obs_data_t *settings = obs_source_get_settings(gc->source);
 		obs_property_set_visible(
 			p, obs_data_get_bool(settings, COMPAT_INFO_VISIBLE));
 		obs_data_release(settings);
+	} else {
+		obs_property_set_visible(p, false);
 	}
-	obs_property_set_modified_callback(p, status_message_changed_callback);
+
+	if (audio_capture_available()) {
+		p = obs_properties_add_bool(ppts, SETTING_CAPTURE_AUDIO,
+					    TEXT_CAPTURE_AUDIO);
+		obs_property_set_long_description(p, TEXT_CAPTURE_AUDIO_TT);
+	}
 
 	obs_properties_add_bool(ppts, SETTING_COMPATIBILITY,
 				TEXT_SLI_COMPATIBILITY);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Asana ticket: https://app.asana.com/1/1083097041131/project/1207748235152481/task/1208003854874152?focus=true

-When an unsupported window is selected for game capture, a blank screen is shown. Previously there was a stock image with a text banner, but it was intentionally removed based on user feedback (PR 586). 
-Error information was being set, but the field used wasn't displayed so I updated to the correct field so an error message displays on the Settings page. There is still no indication in the editor. 
-Only set visibility of compat_info in game_capture_tick (aside from getting properties) since it is called multiple times per second and will pick up any changes quickly.
-Updated the order of the settings displayed because the error info was created in 2 different places and would display midway down the settings, it now displays below the drop lists.
-Removed a callback function from the compat_info property because it was redundant.

### Motivation and Context
Asana ticket based on a user issue.

### How Has This Been Tested?
Manually tested.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ x] My code is not on the streamlabs branch.
- [x ] The code has been tested.
- [x ] All commit messages are properly formatted and commits squashed where appropriate.
- [x ] I have included updates to all appropriate documentation.
