### PR TITLE
bump mac-audio thread priority

### DIFF
--- a/plugins/mac-capture/mac-audio.c
+++ b/plugins/mac-capture/mac-audio.c
@@ -526,12 +526,21 @@ static void coreaudio_begin_reconnect(struct coreaudio_data *ca)
 	// It is better to set the 'reconnecting' status here to avoid desynchronization.
 	// If the thread creation fails, something is broken anyway.
 	ca->reconnecting = true;
-	ret = pthread_create(&ca->reconnect_thread, NULL, reconnect_thread, ca);
+
+	pthread_attr_t attr;
+	pthread_attr_init(&attr);
+
+	// Set QoS class for high-priority real-time work
+	// USER_INTERACTIVE is the highest reasonable QoS for audio
+	pthread_attr_set_qos_class_np(&attr, QOS_CLASS_USER_INTERACTIVE, 0);
+	ret = pthread_create(&ca->reconnect_thread, &attr, reconnect_thread,
+			     ca);
 	if (ret != 0)
 		blog(LOG_WARNING,
 		     "[coreaudio_begin_reconnect] failed to "
 		     "create thread, error code: %d",
 		     ret);
+	pthread_attr_destroy(&attr);
 }
 
 static OSStatus


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Update mac-audio to use QOS_CLASS_USER_INTERACTIVE → Best for low-latency UI/audio.

<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Attempting to resolve mac-coreaudio customer supports reporting choppy audio on macos tahoe etc. Looking at their scenes they are using loaded templates which can spawn upwards of 280+ threads (I see same number on Windows-SLD for this one popular template). So we will attempt to bump audio priority which appears to align with Apple recommendation for important UI/audio threads

OBS already sets this attribute on the video thread so there is already an established precedent elsewhere in code
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Streamed for over an hour using the Waves animated template with audio/video being input from an Elgato 4K X capture card with lots of other apps opened

Verified I did not see this warning in node_obs logs:
```
coreaudio_input_capture_63f7ec05-cafb-49af-aea8-c8240e1246be audio is lagging (over by 51.92 ms) at max audio buffering. Restarting source audio.
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
