### PR TITLE
Mac: buffer more output frames to avoid audio input lag issue

### DIFF
--- a/libobs/media-io/audio-io.h
+++ b/libobs/media-io/audio-io.h
@@ -29,7 +29,13 @@ extern "C" {
 #define MAX_AUDIO_MIXES 6
 #define MAX_AUDIO_CHANNELS 8
 #define MAX_DEVICE_INPUT_CHANNELS 64
+#ifdef __APPLE__
+// Increase audio buffer to eliminate error: Source X is lagging (over by X ms) at max audio buffering. Restarting source audio.
+// Users have submitted logs where their audio restarts. Increasing buffer size resolved the issue locally
+#define AUDIO_OUTPUT_FRAMES 4096
+#else
 #define AUDIO_OUTPUT_FRAMES 1024
+#endif
 
 #define TOTAL_AUDIO_SIZE                                              \
 	(MAX_AUDIO_MIXES * MAX_AUDIO_CHANNELS * AUDIO_OUTPUT_FRAMES * \


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Aiming to increase audio buffer size on mac to address user reports of audio starting / stopping (which ballooned after Apple released MacOS 26). Looking at OBS audio docs for [obs_reset_audio2](https://docs.obsproject.com/reference-core#c.obs_reset_audio2) it didnt seem like a bad idea to try increasing the audio output frames.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
The goal is to eradicate these warning messages which indicates the buffer has been filled and audio will be restarted:
```
coreaudio_input_capture_63f7ec05-cafb-49af-aea8-c8240e1246be audio is lagging (over by 51.92 ms) at max audio buffering. Restarting source audio.
```

```
Source mac_screen_capture audio is lagging (over by 5.66 ms) at max audio buffering. Restarting source audio.
```

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Not  exactly sure why this bug decided to manifest for me but it was so profound- practically every tick my log would be full of this warning so there was no choice but to keep going until the warning stopped frankly. Verified my logs no longer have these warnings when I connect my audio devices on Streamlabs Desktop in debug/release builds.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
