### PR TITLE
Fix dshow init crash

### DIFF
--- a/plugins/win-dshow/win-dshow-encoder.cpp
+++ b/plugins/win-dshow/win-dshow-encoder.cpp
@@ -53,7 +53,7 @@ static const char *GetC353EncoderName(void *)
 	return obs_module_text("Encoder.C353");
 }
 
-static inline void FindDevice(DeviceId &id, const wchar_t *name)
+static bool FindDevice(DeviceId &id, const wchar_t *name)
 {
 	vector<DeviceId> devices;
 	DShow::VideoEncoder::EnumEncoders(devices);
@@ -61,9 +61,10 @@ static inline void FindDevice(DeviceId &id, const wchar_t *name)
 	for (const DeviceId &device : devices) {
 		if (device.name.find(name) != string::npos) {
 			id = device;
-			break;
+			return true;
 		}
 	}
+	return false;
 }
 
 /*
@@ -81,7 +82,10 @@ inline bool DShowEncoder::Update(obs_data_t *settings)
 	DStr deviceName;
 	DeviceId id;
 
-	FindDevice(id, device);
+	if (!FindDevice(id, device) || id.name.empty()) {
+		blog(LOG_WARNING, "win-dshow-encoder: device '%ls' not found", device);
+		return false;
+	}
 
 	video_t *video = obs_encoder_video(context);
 	const struct video_output_info *voi = video_output_get_info(video);
@@ -102,13 +106,24 @@ inline bool DShowEncoder::Update(obs_data_t *settings)
 		width = 1280;
 		height = 720;
 	}
+	uint32_t fps_num;
+	uint32_t fps_den;
 
-	int keyint = keyint_sec * voi->fps_num / voi->fps_den;
+	if (voi) {
+		fps_num = voi->fps_num;
+		fps_den = voi->fps_den;
+	} else {
+		blog(LOG_ERROR, "win-dshow-encoder: video output info is null, using default 30 fps");
+		fps_num = 30;
+		fps_den = 1;
+	}
 
-	frameInterval = voi->fps_den * 10000000 / voi->fps_num;
+	int keyint = keyint_sec * fps_num / fps_den;
 
-	config.fpsNumerator = voi->fps_num;
-	config.fpsDenominator = voi->fps_den;
+	frameInterval = fps_den * 10000000LL / fps_num;
+
+	config.fpsNumerator = fps_num;
+	config.fpsDenominator = fps_den;
 	config.bitrate = bitrate;
 	config.keyframeInterval = keyint;
 	config.cx = width;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
