### PR TITLE
mac-virtualcam: rename signal into activate/deactivate

### DIFF
--- a/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
+++ b/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
@@ -15,9 +15,8 @@ MODULE_EXPORT const char *obs_module_description(void)
 
 NSString *const OBSDalDestination = @"/Library/CoreMediaIO/Plug-Ins/DAL";
 
-// Can't use start because it will bug out OBS frontend thinking vcam is already activated.
-static const char *VIRTUAL_CAM_CONNECTED = "start";
-static const char *VIRTUAL_CAM_FAILED = "stop";
+static const char *VIRTUAL_CAM_CONNECTED = "activate"; // Indicates this plugin is now active.
+static const char *VIRTUAL_CAM_FAILED = "deactivate";
 
 static bool cmio_extension_supported()
 {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Fix issue in SLOBS frontend app where it displays a modal dialog because it thinks the mac-virtualcam has "started".
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Not a user facing bug. However, when I renamed the `VIRTUAL_CAM_CONNECTED` signal into "start" that triggers the issue on OBS frontend that makes it think virtual cam started which in turn causes a modal dialog to display when developer tries to close the app which introduces undesired delay in development.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Verified mac-virtualcam works in both SLD and SLOBS frontend. The "Start VirtualCam" button is no longer automatically selected. No more modal dialog shown when you try to exit the SLOBS frontend
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
