### PR TITLE
Fix RTP stream shutdown crash

### DIFF
--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -792,10 +792,30 @@ static bool send_meta_data(struct rtmp_stream *stream)
 	size_t meta_data_size;
 	bool success = true;
 
+	// Obtaining temporary refs here to ensure that the code below will not crash during shutdown
+	// due to a possible data race on encoders
+	obs_encoder_t *vencoder = obs_encoder_get_ref(
+		obs_output_get_video_encoder(stream->output));
+	if (!vencoder) {
+		blog(LOG_WARNING, "send_meta_data - no video encoder");
+		return false;
+	}
+
+	obs_encoder_t *aencoder = obs_encoder_get_ref(
+		obs_output_get_audio_encoder(stream->output, 0));
+	if (!aencoder) {
+		blog(LOG_WARNING, "send_meta_data - no audio encoder");
+		obs_encoder_release(vencoder);
+		return false;
+	}
+
 	flv_meta_data(stream->output, &meta_data, &meta_data_size, false);
 	success = RTMP_Write(&stream->rtmp, (char *)meta_data,
 			     (int)meta_data_size, 0) >= 0;
 	bfree(meta_data);
+
+	obs_encoder_release(vencoder);
+	obs_encoder_release(aencoder);
 
 	return success;
 }


### PR DESCRIPTION
### Description
Fixing the following crash
```
EXCEPTION_ACCESS_VIOLATION_READ / 0x0
Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ / 0x0
```
```
obs-outputs    +0x3d81    encoder_video_codec (flv-mux.c:156)
obs-outputs    +0x3d81    build_flv_meta_data (flv-mux.c:216)
```

### Motivation and Context
The crash happens in RTP stream internals (flv mux, in this case) on shutdown during a reconnect attempt. There is a data race on encoders of an output, and while it tries to build meta data without any checks on encoder existence and/or locking any mutexes, some other thread resets them. There are clues in logs (see also Sentry reports):
```
   crash!
  "[000:00:15:29.331.776.100][4440][Info] [rtmp stream: 'main_stream_first'] Socket send buffer is 65536 bytes\n",
  "[000:00:15:29.331.515.500][4048][Debug] obs_encoder_get_codec: Null 'encoder' parameter\n",
  "[000:00:15:29.331.514.300][4048][Debug] obs_encoder_get_height: Null 'encoder' parameter\n",
  "[000:00:15:29.331.513.100][4048][Debug] obs_encoder_get_width: Null 'encoder' parameter\n",
  "[000:00:15:29.331.510.100][4048][Debug] obs_encoder_video: Null 'encoder' parameter\n",
  "[000:00:15:29.331.419.200][4048][Info] [rtmp stream: 'main_stream_first'] Connection to rtmps://push-rtmp-l11-sg01.tiktokcdn.com:443/game (43.152.140.130) successful\n",
  "[000:00:15:28.974.208.000][6820][Debug] signal received: stopping streaming\n",
```

In this case a good solution is to retain encoders and allow to finish building meta data, even though it will be discarded immediately.

### How Has This Been Tested?
Manually, Windows only.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 