### PR TITLE
Improved synchronization in stop_gpu_encode (crash fix)

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -3876,13 +3876,15 @@ void stop_gpu_encode(obs_encoder_t *encoder)
 		video->gpu_want_destroy_thread = true;
 	pthread_mutex_unlock(&video->gpu_encoder_mutex);
 
+	// Ensure that all texture encode work has completed before teardown.
+	os_event_wait(video->gpu_encode_inactive);
+
 	obs_enter_graphics();
 	if (video->gpu_want_destroy_thread) {
 		blog(LOG_INFO,
 		     "stop_gpu_encode - gpu_want_destroy_thread: 1 '%s' (%s) (%p)",
 		     obs_encoder_get_name(encoder), obs_encoder_get_id(encoder),
 		     encoder);
-		os_event_wait(video->gpu_encode_inactive);
 		stop_gpu_encoding_thread(video);
 		free_gpu_encoding(video);
 	}


### PR DESCRIPTION
### Description
This PR fixes a race condition in video encoder shutdown that can lead to crashes during recording/stream stop.

Stacktrace:
```
nvEncodeAPI64 +0x244be <unknown>
nvEncodeAPI64 +0x483d5 <unknown>
nvEncodeAPI64 +0x49bb2 <unknown>
nvEncodeAPI64 +0x6a531 <unknown>
obs-nvenc     +0x09357 nvenc_encode_base (nvenc.c:1232)
```

### How it happens
When stopping a GPU texture encoder, cleanup could proceed while the GPU encode thread was still encoding with a previously snapshotted encoder pointer.

Code paths: 🔀
1) GPU thread snapshots encoder list
```c++
		for (size_t i = 0; i < video->gpu_encoders.num; i++) {
			obs_encoder_t *encoder = obs_encoder_get_ref(
				video->gpu_encoders.array[i]);
			if (encoder)
				da_push_back(encoders, &encoder);
		}
```
and uses encoder->context.data later
```c++
				success = encoder->info.encode_texture2(
					encoder->context.data, &tex,
					encoder->cur_pts, lock_key, &next_key,
					&pkt, &received);
```

2) At the same time, stop/shutdown path calls `stop_gpu_encode()` then `obs_encoder_shutdown()`.
See `remove_connection` function in `obs-encoder.c` for the reference.

3) `obs_encoder_shutdown` calls  `encoder->info.destroy(encoder->context.data);` making encoder partially destroyed.
4) While the `gpu_encode_thread` holds a valid strong reference to the encoder, the encoder is now in an invalid state.

### The Fix 🏆
Added an unconditional GPU inactivity fence in stop_gpu_encode() after encoder removal.
This guarantees cleanup does not continue until the active GPU encode iteration has finished.
The event semantics already exists:
Reset at iteration start:
`obs-video-gpu-encode.c:56`
Signal at iteration end:
`obs-video-gpu-encode.c:224`

### What has changed? 🔄
Previously we waited for an encoder to stop any processing only if wanted to destroy the thread
```
if (video->gpu_want_destroy_thread) {
```

But there might be multiple encoders served by a single thread. Moreover, the thread might be reused if a new encoder was assigned to that thread. So, now we wait unconditionally.

### How Has This Been Tested?
Manually, Windows only.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)