### PR TITLE
obs-nvenc: destroy NVENC resources before session cleanup

### DIFF
--- a/plugins/obs-nvenc/nvenc-cuda.c
+++ b/plugins/obs-nvenc/nvenc-cuda.c
@@ -187,11 +187,15 @@ bool cuda_init_surfaces(struct nvenc_data *enc)
 static void cuda_surface_free(struct nvenc_data *enc, struct nv_cuda_surface *nvsurf)
 {
 	if (nvsurf->res) {
-		if (nvsurf->mapped_res) {
+		if (enc->session && nvsurf->mapped_res) {
 			nv.nvEncUnmapInputResource(enc->session, nvsurf->mapped_res);
+			nvsurf->mapped_res = NULL;
 		}
-		nv.nvEncUnregisterResource(enc->session, nvsurf->res);
+		if (enc->session)
+			nv.nvEncUnregisterResource(enc->session, nvsurf->res);
+		nvsurf->res = NULL;
 		cu->cuArrayDestroy(nvsurf->tex);
+		nvsurf->tex = NULL;
 	}
 }
 

--- a/plugins/obs-nvenc/nvenc-d3d11.c
+++ b/plugins/obs-nvenc/nvenc-d3d11.c
@@ -152,11 +152,15 @@ static void d3d11_texture_free(struct nvenc_data *enc, struct nv_texture *nvtex)
 {
 
 	if (nvtex->res) {
-		if (nvtex->mapped_res) {
+		if (enc->session && nvtex->mapped_res) {
 			nv.nvEncUnmapInputResource(enc->session, nvtex->mapped_res);
+			nvtex->mapped_res = NULL;
 		}
-		nv.nvEncUnregisterResource(enc->session, nvtex->res);
+		if (enc->session)
+			nv.nvEncUnregisterResource(enc->session, nvtex->res);
+		nvtex->res = NULL;
 		nvtex->tex->lpVtbl->Release(nvtex->tex);
+		nvtex->tex = NULL;
 	}
 }
 

--- a/plugins/obs-nvenc/nvenc.c
+++ b/plugins/obs-nvenc/nvenc.c
@@ -960,18 +960,12 @@ static void nvenc_destroy(void *data)
 {
 	struct nvenc_data *enc = data;
 
-	if (enc->encode_started) {
+	if (enc->session && enc->encode_started) {
 		NV_ENC_PIC_PARAMS params = {NV_ENC_PIC_PARAMS_VER};
 		params.encodePicFlags = NV_ENC_PIC_FLAG_EOS;
 		nv.nvEncEncodePicture(enc->session, &params);
 		get_encoded_packet(enc, true);
 	}
-
-	for (size_t i = 0; i < enc->bitstreams.num; i++) {
-		nv_bitstream_free(enc, &enc->bitstreams.array[i]);
-	}
-	if (enc->session)
-		nv.nvEncDestroyEncoder(enc->session);
 
 #ifdef _WIN32
 	d3d11_free_textures(enc);
@@ -980,6 +974,16 @@ static void nvenc_destroy(void *data)
 	cuda_opengl_free(enc);
 #endif
 	cuda_free_surfaces(enc);
+
+	for (size_t i = 0; i < enc->bitstreams.num; i++) {
+		nv_bitstream_free(enc, &enc->bitstreams.array[i]);
+	}
+
+	if (enc->session) {
+		nv.nvEncDestroyEncoder(enc->session);
+		enc->session = NULL;
+	}
+
 	cuda_ctx_free(enc);
 
 	bfree(enc->header);
@@ -1228,6 +1232,11 @@ bool nvenc_encode_base(struct nvenc_data *enc, struct nv_bitstream *bs, void *pi
 	/* Add ROI map if enabled */
 	if (obs_encoder_has_roi(enc->encoder))
 		add_roi(enc, &params);
+
+	if (!enc->session) {
+		NV_FAIL("nvenc session is not available");
+		return false;
+	}
 
 	NVENCSTATUS err = nv.nvEncEncodePicture(enc->session, &params);
 	if (err != NV_ENC_SUCCESS && err != NV_ENC_ERR_NEED_MORE_INPUT) {


### PR DESCRIPTION
### Description
This PR fixes NVENC teardown ordering and adds checks to prevent NVENC API calls with an invalid/destroyed session handle.

### Problem
At the moment, destroy sequence calls `nvEncDestroyEncoder` before releasing all NVENC-created input resources (registered textures/surfaces).
That violates the NVENC API contract and can lead to invalid session usage during cleanup.

See for details in `nvenc.c` function `nvenc_destroy()`.

```c++
static void nvenc_destroy(void *data)
{
...
	// Destroys the encoder session
	if (enc->session)
		nv.nvEncDestroyEncoder(enc->session);

#ifdef _WIN32
	d3d11_free_textures(enc);
	d3d11_free(enc);
#else
	cuda_opengl_free(enc);
#endif
	cuda_free_surfaces(enc);
	cuda_ctx_free(enc);
...
```
Inside `d3d11_free_textures`:
```c++
static void d3d11_texture_free(struct nvenc_data *enc, struct nv_texture *nvtex)
{
	if (nvtex->res) {
...
		// BOOM! Use of already destroyed session
		nv.nvEncUnregisterResource(enc->session, nvtex->res);
		nvtex->tex->lpVtbl->Release(nvtex->tex);
	}
}

void d3d11_free_textures(struct nvenc_data *enc)
{
	for (size_t i = 0; i < enc->textures.num; i++) {
		d3d11_texture_free(enc, &enc->textures.array[i]);
	}
}
```

Inside `cuda_free_surfaces`:
```c++
static void cuda_surface_free(struct nvenc_data *enc, struct nv_cuda_surface *nvsurf)
{
	if (nvsurf->res) {
...
		// BOOM again!
		nv.nvEncUnregisterResource(enc->session, nvsurf->res);
		cu->cuArrayDestroy(nvsurf->tex);
	}
}

void cuda_free_surfaces(struct nvenc_data *enc)
{
...
	for (size_t i = 0; i < enc->surfaces.num; i++) {
		cuda_surface_free(enc, &enc->surfaces.array[i]);
	}
...
}
```

### How Has This Been Tested?
Manually, Windows only.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 