### PR TITLE
Paired encoders now use weak refs instead of raw pointers

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -693,6 +693,10 @@ void obs_encoder_shutdown(obs_encoder_t *encoder)
 	if (encoder->context.data) {
 		encoder->info.destroy(encoder->context.data);
 		encoder->context.data = NULL;
+		for (size_t i = 0; i < encoder->paired_encoders.num; i++) {
+			obs_weak_encoder_release(
+				encoder->paired_encoders.array[i]);
+		}
 		encoder->first_received = false;
 		encoder->offset_usec = 0;
 		encoder->start_ts = 0;


### PR DESCRIPTION
### Description
Backported upstream (OBS 32) weak paired-encoder lifetime handling to avoid shutdown use after free races.

### Motivation and Context
During stop/shutdown, a paired encoder can be destroyed while another encoder still reads fields such as `first_received`, `first_raw_ts`, or `start_ts`. Because at the moment we store paired encoders as raw pointers, this creates a use-after-free risk in both the normal encode path and the GPU encode thread.

### How Has This Been Tested?
Manually, Windows only.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) -->