### PR TITLE
 Fix null dereference crash in mp_media_next_video

### DIFF
--- a/shared/media-playback/media-playback/media.c
+++ b/shared/media-playback/media-playback/media.c
@@ -521,9 +521,13 @@ void mp_media_next_video(mp_media_t *m, bool preload)
 		enum video_range_type new_range;
 
 		if (!f || !f->width || !f->height) {
-			blog(LOG_ERROR,
-			     "MP: media frame is invalid ('%s': %" PRIu32 "x%" PRIu32 ")",
-			     m->path, f ? f->width : 0, f ? f->height : 0);
+			if (!m->bad_frame_logged) {
+				blog(LOG_WARNING,
+				     "MP: skipping invalid video frame ('%s': %dx%d)",
+				     m->path, f ? f->width : 0,
+				     f ? f->height : 0);
+				m->bad_frame_logged = true;
+			}
 			return;
 		}
 

--- a/shared/media-playback/media-playback/media.c
+++ b/shared/media-playback/media-playback/media.c
@@ -522,7 +522,7 @@ void mp_media_next_video(mp_media_t *m, bool preload)
 
 		if (!f || !f->width || !f->height) {
 			blog(LOG_ERROR,
-			     "MP: media frame is invalid ('%s': %" PRIu32 "x%" PRIu32 ")",
+			     "MP: media frame is invalid ('%s': %dx%d)",
 			     m->path, f ? f->width : 0, f ? f->height : 0);
 			return;
 		}

--- a/shared/media-playback/media-playback/media.c
+++ b/shared/media-playback/media-playback/media.c
@@ -498,18 +498,8 @@ void mp_media_next_video(mp_media_t *m, bool preload)
 	}
 
 	struct mp_decode *d = &m->v;
-	enum video_format new_format;
-	enum video_colorspace new_space;
-	enum video_range_type new_range;
-	AVFrame *f = d->frame;
 	struct obs_source_frame *frame;
 
-	if (!f->width || !f->height) {
-		blog(LOG_ERROR, "MP: media frame width or height are zero ('%s': %" PRIu32 "x%" PRIu32 ")", m->path,
-		     f->width, f->height);
-		return;
-	}
-	
 	if (m->video.index_eof < 0 || !m->enable_caching) {
 		if (!preload) {
 			if (!mp_media_can_play_frame(m, d)) {
@@ -522,6 +512,18 @@ void mp_media_next_video(mp_media_t *m, bool preload)
 				return;
 			}
 		} else if (!d->frame_ready) {
+			return;
+		}
+
+		AVFrame *f = d->frame;
+		enum video_format new_format;
+		enum video_colorspace new_space;
+		enum video_range_type new_range;
+
+		if (!f || !f->width || !f->height) {
+			blog(LOG_ERROR,
+			     "MP: media frame is invalid ('%s': %" PRIu32 "x%" PRIu32 ")",
+			     m->path, f ? f->width : 0, f ? f->height : 0);
 			return;
 		}
 

--- a/shared/media-playback/media-playback/media.h
+++ b/shared/media-playback/media-playback/media.h
@@ -120,6 +120,7 @@ struct mp_media {
 	bool seek_next_ts;
 	int64_t seek_pos;
 	int64_t volume;
+	bool bad_frame_logged;
 };
 
 typedef struct mp_media mp_media_t;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
 Fix null dereference crash in mp_media_next_video
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
**d->frame (an AVFrame*)** is only assigned inside **decode_packet** when a frame is successfully decoded. If decoding fails on the first attempt after a flush e.g. during a stinger transition reset when a seek/read error causes **m->eof** to be set before any frame is decoded  **d->frame** remains NULL while **d->frame_ready** is **false**.

  The existing **!d->frame_ready** guard would have caught this, but it was placed after **f->width** was already dereferenced, causing a null pointer crash in  **mp_media_next_video**.

  The fix moves **AVFrame *f = d->frame** and the **frame** validity check to after the readiness guards inside the non-caching block, where **f** is actually used.
  Since **d->frame_ready == true** is only set when **decode_packet** successfully assigns **d->frame**, the invariant **frame_ready → frame != NULL** ensures the check order is now correct. A defensive **!f** null check is also added to the frame validity assert.
  
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
