### PR TITLE
Crash fix: improved video reset cleanup and WinRT capture release

### DIFF
--- a/libobs-winrt/winrt-capture.cpp
+++ b/libobs-winrt/winrt-capture.cpp
@@ -198,12 +198,16 @@ static struct winrt_capture *capture_list;
 static void winrt_capture_device_loss_release(void *data)
 {
 	winrt_capture *capture = static_cast<winrt_capture *>(data);
+	if (!capture)
+		return;
+
 	capture->active = FALSE;
 
 	capture->frame_arrived.revoke();
 
 	try {
-		capture->frame_pool.Close();
+		if (capture->frame_pool)
+			capture->frame_pool.Close();
 	} catch (winrt::hresult_error &err) {
 		blog(LOG_ERROR, "Direct3D11CaptureFramePool::Close (0x%08X): %s", err.code().value,
 		     winrt::to_string(err.message()).c_str());
@@ -212,7 +216,8 @@ static void winrt_capture_device_loss_release(void *data)
 	}
 
 	try {
-		capture->session.Close();
+		if (capture->session)
+			capture->session.Close();
 	} catch (winrt::hresult_error &err) {
 		blog(LOG_ERROR, "GraphicsCaptureSession::Close (0x%08X): %s", err.code().value,
 		     winrt::to_string(err.message()).c_str());
@@ -280,6 +285,12 @@ winrt_capture_create_item(IGraphicsCaptureItemInterop *const interop_factory, HW
 static void winrt_capture_device_loss_rebuild(void *device_void, void *data)
 {
 	winrt_capture *capture = static_cast<winrt_capture *>(data);
+	capture->active = FALSE;
+
+	if (capture->window && !IsWindow(capture->window)) {
+		blog(LOG_WARNING, "Skipping WinRT capture rebuild for invalid window %p", capture->window);
+		return;
+	}
 
 	auto activation_factory =
 		winrt::get_activation_factory<winrt::Windows::Graphics::Capture::GraphicsCaptureItem>();

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -728,9 +728,6 @@ static int obs_init_video()
 			return OBS_VIDEO_FAIL;
 	}
 
-	blog(LOG_INFO, "[VIDEO_CANVAS] wait obs_graphics_thread to stop");
-	pthread_join(video->video_thread, NULL);
-
 	// OBS canvases
 	/* Reset main canvas mix first so it remains first in the rendering order. */
 	if (!obs_canvas_reset_video_internal(obs->data.main_canvas, obs->video.canvases.array[0]))
@@ -803,6 +800,15 @@ static void stop_video(void)
 	for (size_t i = 0, num = obs->video.mixes.num; i < num; i++)
 		video_output_stop(obs->video.mixes.array[i]->video);
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
+
+	struct obs_core_video *video = &obs->video;
+	void *thread_retval;
+
+	if (video->thread_initialized) {
+		blog(LOG_INFO, "[VIDEO_CANVAS] wait obs_graphics_thread to stop");
+		pthread_join(video->video_thread, &thread_retval);
+		video->thread_initialized = false;
+	}
 }
 
 static void obs_free_render_textures(struct obs_core_video_mix *video)
@@ -1633,6 +1639,7 @@ int obs_deactivate_video_info()
 	}
 
 	blog(LOG_DEBUG, "[VIDEO_CANVAS] About to stop and reset video");
+	obs_wait_for_destroy_queue();
 	stop_video();
 	obs_free_video(false);
 	blog(LOG_DEBUG, "[VIDEO_CANVAS] Video stopped and ready too init");
@@ -3896,6 +3903,24 @@ static void task_wait_callback(void *param)
 	os_event_signal(info->event);
 }
 
+static bool wait_for_task_queue(enum obs_task_type type)
+{
+	struct task_wait_info info = {0};
+
+	if (!obs)
+		return false;
+
+	if ((type == OBS_TASK_GRAPHICS && !obs->video.thread_initialized) ||
+	    (type == OBS_TASK_AUDIO && !obs->audio.audio))
+		return false;
+
+	os_event_init(&info.event, OS_EVENT_TYPE_AUTO);
+	obs_queue_task(type, task_wait_callback, &info, false);
+	os_event_wait(info.event);
+	os_event_destroy(info.event);
+	return true;
+}
+
 THREAD_LOCAL bool is_graphics_thread = false;
 THREAD_LOCAL bool is_audio_thread = false;
 
@@ -3969,21 +3994,29 @@ void obs_queue_task(enum obs_task_type type, obs_task_t task, void *param, bool 
 
 bool obs_wait_for_destroy_queue(void)
 {
-	struct task_wait_info info = {0};
-
-	if (!obs->video.thread_initialized || !obs->audio.audio)
+	if (!obs)
 		return false;
 
-	/* allow video and audio threads time to release objects */
-	os_event_init(&info.event, OS_EVENT_TYPE_AUTO);
-	obs_queue_task(OBS_TASK_GRAPHICS, task_wait_callback, &info, false);
-	os_event_wait(info.event);
-	obs_queue_task(OBS_TASK_AUDIO, task_wait_callback, &info, false);
-	os_event_wait(info.event);
-	os_event_destroy(info.event);
+	bool tasks_processed = false;
+	bool destroy_tasks_processed;
 
-	/* wait for destroy task queue */
-	return os_task_queue_wait(obs->destruction_task_thread);
+	wait_for_task_queue(OBS_TASK_GRAPHICS);
+	wait_for_task_queue(OBS_TASK_AUDIO);
+
+	do {
+		destroy_tasks_processed = os_task_queue_wait(obs->destruction_task_thread);
+		tasks_processed |= destroy_tasks_processed;
+
+		/*
+		 * Some destroy callbacks defer their actual graphics teardown to the
+		 * graphics thread. Flush that queue after each destroy batch so reset
+		 * does not drop stale cleanup tasks.
+		 */
+		wait_for_task_queue(OBS_TASK_GRAPHICS);
+		wait_for_task_queue(OBS_TASK_AUDIO);
+	} while (destroy_tasks_processed);
+
+	return tasks_processed;
 }
 
 static void set_ui_thread(void *unused)

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -4007,11 +4007,8 @@ bool obs_wait_for_destroy_queue(void)
 		destroy_tasks_processed = os_task_queue_wait(obs->destruction_task_thread);
 		tasks_processed |= destroy_tasks_processed;
 
-		/*
-		 * Some destroy callbacks defer their actual graphics teardown to the
-		 * graphics thread. Flush that queue after each destroy batch so reset
-		 * does not drop stale cleanup tasks.
-		 */
+		// Some destroy callbacks defer their actual cleanup, so we need to wait
+		// while deinitialization completes to not get zombie objects.
 		wait_for_task_queue(OBS_TASK_GRAPHICS);
 		wait_for_task_queue(OBS_TASK_AUDIO);
 	} while (destroy_tasks_processed);


### PR DESCRIPTION
## Description

This change fixes a data race crash during `Video::RemoveVideoContext` and WinRT capture cleanup.

With the following stack trace:
```
libobs-winrt +0x0188c winrt::impl::consume_Windows_Foundation_IClosable<T>::Close (Windows.Foundation.h:382)
obs          +0xc084c os_sleepto_ns (platform-windows.c:443)
obs          +0x67e9a video_sleep (obs-video.c:950)
libobs-winrt +0x016cb winrt_capture_device_loss_release (winrt-capture.cpp:261)
obs          +0x69095 obs_graphics_thread_loop (obs-video.c:1264)
ucrtbase     +0x174ef _acrt_getptd
libobs-winrt +0x03b39 winrt_capture_thread_stop (winrt-capture.cpp:730)
obs          +0x692b9 uninit_winrt_state (obs-video.c:1156)
obs          +0x692b9 obs_graphics_thread (obs-video.c:1324)
w32-pthreads +0x01460 ptw32_threadStart (ptw32_threadStart.c:225)
ucrtbase     +0x037af thread_start<T>
KERNEL32.DLL +0x2e8d6 BaseThreadInitThunk
ntdll        +0x8c48b RtlUserThreadStart
```

> Note: the stack trace seems to be damaged, but still useful.

### Root cause

The crash was caused by two related problems:
1. Video cleanup could free/reset graphics-thread-owned state before the old graphics thread had fully stopped.
2. WinRT capture teardown assumed `frame_pool` and `session` were always initialized, which is not true after a failed or partial rebuild.

### Details
1. `Video::RemoveVideoContext` goes through `osn-video.cpp` into `obs_remove_video_info`, which first calls `obs_deactivate_video_info`.
2. During that reset, we stop the `main_mix` first in `stop_video`, and the graphics thread exits as soon as `main_mix` is stopped in `obs_graphics_thread_loop`. Upstream (OBS 32) waits for all mixes instead.
3. Window-capture destruction is not instant. `wc_destroy()` queues `wc_actual_destroy()` onto the graphics task queue in `window-capture.c`,` obs_queue_task()` just appends it (see `obs.c`).
4. The reset path then frees the graphics task deque without processing it in `obs_free_video`. So a queued `wc_actual_destroy()` can be lost.
5. If that happens, the stale WinRT capture object stays in static `capture_list` in `winrt-capture.cpp`. On the first reset, `winrt_capture_thread_stop` calls `winrt_capture_device_loss_release`, which nulls `frame_pool` and `session`.
6. After reinit, that same stale capture is still around because the source never ran `wc_actual_destroy()`, and the plugin still holds `libobs-winrt` loaded from `wc_create()`. The new graphics thread calls `winrt_capture_thread_start()`, rebuild hits stale `HWND`, and we get the exact message from our log: 
```
"[000:00:45:34.475.858.300][6532][Error] CreateForWindow (0x80070057)\n",
```
in `winrt_capture_create_item()`.
7. On the next `RemoveVideoContext`, `winrt_capture_thread_stop()` releases the same stale capture again. `winrt_capture_device_loss_release()` does `capture->frame_pool.Close()` and `capture->session.Close()` with no null guard, so a null COM wrapper crashes exactly in `IClosable::Close`, which matches the stack.


## Changes
- Moved graphics thread synchronization into video stop/teardown instead of deferring the join until re-init
- Flush deferred destroy work before `obs_free_video(false)`
- Add a task-queue barrier helper to synchronously drain graphics/audio task queues.
- Rework destroy-queue waiting so it keeps flushing destroy work and any follow-up graphics/audio work until the system is stable.
- Made `winrt_capture_device_loss_release()`  safe for partial initialization
- Guarded `frame_pool.Close()` and `session.Close()` so they are only called when the corresponding objects exist
- Marked captures inactive before rebuild and skip rebuild entirely if the stored window handle is no longer valid


### How Has This Been Tested?
Manually, Windows only.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

