### PR TITLE
libobs/audio-io: restore AUDIO_OUTPUT_FRAMES & set GPU vars on SLOBS frontend

### DIFF
--- a/frontend/utility/system-info-macos.mm
+++ b/frontend/utility/system-info-macos.mm
@@ -46,6 +46,8 @@ namespace {
         gpu.model = capabilities.cpu.name.value_or("Unknown");
         gpu.vendor_id = 0x106b;  // Always Apple
         gpu.device_id = 0;       // Always 0 for Apple Silicon
+        gpu.dedicated_video_memory = 0; // There really isn't dedicated video mem on Apple
+        gpu.shared_system_memory = [[NSProcessInfo processInfo] physicalMemory];
 
         std::vector<GoLiveApi::Gpu> gpus;
         gpus.push_back(std::move(gpu));

--- a/libobs/media-io/audio-io.h
+++ b/libobs/media-io/audio-io.h
@@ -29,13 +29,7 @@ extern "C" {
 #define MAX_AUDIO_MIXES 6
 #define MAX_AUDIO_CHANNELS 8
 #define MAX_DEVICE_INPUT_CHANNELS 64
-#ifdef __APPLE__
-// Increase audio buffer to eliminate error: Source X is lagging (over by X ms) at max audio buffering. Restarting source audio.
-// Users have submitted logs where their audio restarts. Increasing buffer size resolved the issue locally
-#define AUDIO_OUTPUT_FRAMES 4096
-#else
 #define AUDIO_OUTPUT_FRAMES 1024
-#endif
 
 #define TOTAL_AUDIO_SIZE (MAX_AUDIO_MIXES * MAX_AUDIO_CHANNELS * AUDIO_OUTPUT_FRAMES * sizeof(float))
 


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Reverts `AUDIO_OUTPUT_FRAMES` buffer increase. On SLOBS backend when using enhanced broadcasting on Apple Silicon it appears to cause issues. Also, properly initialize GPU struct. Previously, uninitialized data was being sent inside the `go_live_config` data.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Enable enhanced broadcasting for mac now that obs-31.2 has been merged.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
In SLD, I click on the "Enable Enhanced Broadcasting" checkbox. Start a stream and make sure I see my scene on Twitch. I also verified enhanced broadcasting worked on "SLOBS" frontend.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
