### PR TITLE
Fix copy audio data crash

### DIFF
--- a/libobs/obs-audio-controls.c
+++ b/libobs/obs-audio-controls.c
@@ -888,7 +888,7 @@ int obs_volmeter_get_nr_channels(obs_volmeter_t *volmeter)
 		source = obs_weak_source_get_source(weak_source);
 
 	if (source)
-		source_nr_audio_channels = get_audio_channels(source->sample_info.speakers);
+		source_nr_audio_channels = get_audio_channels(source->input_sample_info.speakers);
 	else
 		source_nr_audio_channels = 0;
 

--- a/libobs/obs-audio.c
+++ b/libobs/obs-audio.c
@@ -497,10 +497,10 @@ bool audio_callback(void *param, uint64_t start_ts_in, uint64_t end_ts_in, uint6
 		    struct audio_data_mixes_outputs *mixes)
 {
 	struct obs_core_data *data = &obs->data;
-	struct obs_core_audio *audio = &obs->audio;
+	struct obs_core_audio *audio = param;
 	struct obs_source *source;
-	size_t sample_rate = audio_output_get_sample_rate(audio->audio);
-	size_t channels = audio_output_get_channels(audio->audio);
+	size_t sample_rate = audio->samples_per_sec;
+	size_t channels = audio->channels;
 	struct ts_info ts = {start_ts_in, end_ts_in};
 	size_t audio_size;
 	uint64_t min_ts;

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -841,7 +841,9 @@ struct obs_source {
 	DARRAY(struct audio_action) audio_actions;
 	DARRAY(struct source_audio_buf) audio_output_bufs;
 	float *audio_mix_buf[MAX_AUDIO_CHANNELS];
-	struct resample_info sample_info;
+	/* Source audio format on input, and main audio output format on resample. */
+	struct resample_info input_sample_info;
+	struct resample_info output_sample_info;
 	audio_resampler_t *resampler;
 	pthread_mutex_t audio_actions_mutex;
 	pthread_mutex_t audio_buf_mutex;

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -394,8 +394,8 @@ struct audio_monitor;
 
 struct obs_core_audio {
 	audio_t *audio;
-	// These 3 values are not present in the original OBS code. They serve as a main audio parameters cache, 
-	// allowing audio processing to finish the current iteration even if the global audio object has been destroyed.
+	/* These 3 values are not present in the original OBS code. They serve as a main audio parameters cache, 
+	 * allowing audio processing to finish the current iteration even if the global audio object has been destroyed. */
 	uint32_t samples_per_sec;
 	enum speaker_layout speakers;
 	size_t channels;

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -394,6 +394,11 @@ struct audio_monitor;
 
 struct obs_core_audio {
 	audio_t *audio;
+	// These 3 values are not present in the original OBS code. They serve as a main audio parameters cache, 
+	// allowing audio processing to finish the current iteration even if the global audio object has been destroyed.
+	uint32_t samples_per_sec;
+	enum speaker_layout speakers;
+	size_t channels;
 
 	DARRAY(struct obs_source *) render_order;
 	DARRAY(struct obs_source *) root_nodes;

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -1509,23 +1509,61 @@ static inline uint64_t uint64_diff(uint64_t ts1, uint64_t ts2)
 	return (ts1 < ts2) ? (ts2 - ts1) : (ts1 - ts2);
 }
 
-static inline size_t get_buf_placement(audio_t *audio, uint64_t offset)
+struct audio_output_config {
+	struct resample_info info;
+	size_t planes;
+	size_t blocksize;
+	size_t channels;
+};
+
+static bool get_audio_output_config(struct audio_output_config *config)
 {
-	uint32_t sample_rate = audio_output_get_sample_rate(audio);
+	const struct audio_output_info *obs_info;
+
+	memset(config, 0, sizeof(*config));
+
+	if (!obs)
+		return false;
+
+	pthread_mutex_lock(&obs->video.mixes_mutex);
+
+	if (!obs->audio.audio) {
+		pthread_mutex_unlock(&obs->video.mixes_mutex);
+		return false;
+	}
+
+	obs_info = audio_output_get_info(obs->audio.audio);
+	config->planes = audio_output_get_planes(obs->audio.audio);
+	config->blocksize = audio_output_get_block_size(obs->audio.audio);
+	config->channels = audio_output_get_channels(obs->audio.audio);
+	config->info.format = obs_info->format;
+	config->info.samples_per_sec = obs_info->samples_per_sec;
+	config->info.speakers = obs_info->speakers;
+
+	pthread_mutex_unlock(&obs->video.mixes_mutex);
+	return true;
+}
+
+static inline size_t get_buf_placement(uint32_t sample_rate, uint64_t offset)
+{
 	return (size_t)util_mul_div64(offset, sample_rate, 1000000000ULL);
 }
 
-static void source_output_audio_place(obs_source_t *source, const struct audio_data *in)
+static void source_output_audio_place(obs_source_t *source,
+				      const struct audio_data *in,
+				      const struct audio_output_config *config)
 {
-	audio_t *audio = obs->audio.audio;
 	size_t buf_placement;
-	size_t channels = audio_output_get_channels(audio);
+	size_t channels = config->channels;
 	size_t size = in->frames * sizeof(float);
 
 	if (!source->audio_ts || in->timestamp < source->audio_ts)
 		reset_audio_data(source, in->timestamp);
 
-	buf_placement = get_buf_placement(audio, in->timestamp - source->audio_ts) * sizeof(float);
+	buf_placement =
+		get_buf_placement(config->info.samples_per_sec,
+				  in->timestamp - source->audio_ts) *
+		sizeof(float);
 
 #if DEBUG_AUDIO == 1
 	blog(LOG_DEBUG, "frames: %lu, size: %lu, placement: %lu, base_ts: %llu, ts: %llu", (unsigned long)in->frames,
@@ -1546,10 +1584,11 @@ static void source_output_audio_place(obs_source_t *source, const struct audio_d
 	source->last_audio_input_buf_size = 0;
 }
 
-static inline void source_output_audio_push_back(obs_source_t *source, const struct audio_data *in)
+static inline void source_output_audio_push_back(obs_source_t *source,
+						 const struct audio_data *in,
+						 const struct audio_output_config *config)
 {
-	audio_t *audio = obs->audio.audio;
-	size_t channels = audio_output_get_channels(audio);
+	size_t channels = config->channels;
 	size_t size = in->frames * sizeof(float);
 
 	/* do not allow the circular buffers to become too big */
@@ -1580,9 +1619,11 @@ static inline bool source_muted(obs_source_t *source, uint64_t os_time)
 	       (source->push_to_talk_enabled && !push_to_talk_active);
 }
 
-static void source_output_audio_data(obs_source_t *source, const struct audio_data *data)
+static void source_output_audio_data(obs_source_t *source,
+				     const struct audio_data *data,
+				     const struct audio_output_config *config)
 {
-	size_t sample_rate = audio_output_get_sample_rate(obs->audio.audio);
+	size_t sample_rate = config->info.samples_per_sec;
 	struct audio_data in = *data;
 	uint64_t diff;
 	uint64_t os_time = os_gettime_ns();
@@ -1655,9 +1696,9 @@ static void source_output_audio_data(obs_source_t *source, const struct audio_da
 
 	if (source->monitoring_type != OBS_MONITORING_TYPE_MONITOR_ONLY) {
 		if (push_back && source->audio_ts)
-			source_output_audio_push_back(source, &in);
+			source_output_audio_push_back(source, &in, config);
 		else
-			source_output_audio_place(source, &in);
+			source_output_audio_place(source, &in, config);
 	}
 
 	pthread_mutex_unlock(&source->audio_buf_mutex);
@@ -3920,54 +3961,45 @@ static inline struct obs_audio_data *filter_async_audio(obs_source_t *source, st
 	return in;
 }
 
-static inline void reset_resampler(obs_source_t *source, const struct obs_source_audio *audio)
+static inline void reset_resampler(obs_source_t *source,
+				   const struct obs_source_audio *audio,
+				   const struct audio_output_config *config)
 {
-	const struct audio_output_info *obs_info;
-	struct resample_info output_info;
-
-	pthread_mutex_lock(&obs->video.mixes_mutex);
-	obs_info = audio_output_get_info(obs->audio.audio);
-
-	output_info.format = obs_info->format;
-	output_info.samples_per_sec = obs_info->samples_per_sec;
-	output_info.speakers = obs_info->speakers;
-	pthread_mutex_unlock(&obs->video.mixes_mutex);
-
-	source->sample_info.format = audio->format;
-	source->sample_info.samples_per_sec = audio->samples_per_sec;
-	source->sample_info.speakers = audio->speakers;
+	source->input_sample_info.format = audio->format;
+	source->input_sample_info.samples_per_sec = audio->samples_per_sec;
+	source->input_sample_info.speakers = audio->speakers;
+	source->output_sample_info = config->info;
 
 	audio_resampler_destroy(source->resampler);
 	source->resampler = NULL;
 	source->resample_offset = 0;
 
-	if (source->sample_info.samples_per_sec == output_info.samples_per_sec &&
-	    source->sample_info.format == output_info.format && source->sample_info.speakers == output_info.speakers) {
+	if (source->input_sample_info.samples_per_sec == source->output_sample_info.samples_per_sec &&
+	    source->input_sample_info.format == source->output_sample_info.format &&
+	    source->input_sample_info.speakers == source->output_sample_info.speakers) {
 		source->audio_failed = false;
 		return;
 	}
 
-	source->resampler = audio_resampler_create(&output_info, &source->sample_info);
+	source->resampler = audio_resampler_create(&source->output_sample_info,
+						   &source->input_sample_info);
 
 	source->audio_failed = source->resampler == NULL;
 	if (source->resampler == NULL)
 		blog(LOG_ERROR, "creation of resampler failed");
 }
 
-static void copy_audio_data(obs_source_t *source, const uint8_t *const data[], uint32_t frames, uint64_t ts)
+static void copy_audio_data(obs_source_t *source, const uint8_t *const data[],
+			    uint32_t frames, uint64_t ts,
+			    const struct audio_output_config *config)
 {
-	pthread_mutex_lock(&obs->video.mixes_mutex);
-	size_t planes = audio_output_get_planes(obs->audio.audio);
-	size_t blocksize = audio_output_get_block_size(obs->audio.audio);
-	pthread_mutex_unlock(&obs->video.mixes_mutex);
-
-	size_t size = (size_t)frames * blocksize;
+	size_t size = (size_t)frames * config->blocksize;
 	bool resize = source->audio_storage_size < size;
 
 	source->audio_data.frames = frames;
 	source->audio_data.timestamp = ts;
 
-	for (size_t i = 0; i < planes; i++) {
+	for (size_t i = 0; i < config->planes; i++) {
 		/* ensure audio storage capacity */
 		if (resize) {
 			bfree(source->audio_data.data[i]);
@@ -3983,11 +4015,10 @@ static void copy_audio_data(obs_source_t *source, const uint8_t *const data[], u
 }
 
 /* TODO: SSE optimization */
-static void downmix_to_mono_planar(struct obs_source *source, uint32_t frames)
+static void downmix_to_mono_planar(struct obs_source *source, uint32_t frames,
+				   const struct audio_output_config *config)
 {
-	pthread_mutex_lock(&obs->video.mixes_mutex);
-	size_t channels = audio_output_get_channels(obs->audio.audio);
-	pthread_mutex_unlock(&obs->video.mixes_mutex);
+	size_t channels = config->channels;
 	const float channels_i = 1.0f / (float)channels;
 	float **data = (float **)source->audio_data.data;
 
@@ -4035,14 +4066,20 @@ static void process_audio_balancing(struct obs_source *source, uint32_t frames, 
 }
 
 /* resamples/remixes new audio to the designated main audio output format */
-static void process_audio(obs_source_t *source, const struct obs_source_audio *audio)
+static void process_audio(obs_source_t *source,
+			  const struct obs_source_audio *audio,
+			  const struct audio_output_config *config)
 {
 	uint32_t frames = audio->frames;
-	bool mono_output;
+	bool mono_output = config->channels == 1;
 
-	if (source->sample_info.samples_per_sec != audio->samples_per_sec ||
-	    source->sample_info.format != audio->format || source->sample_info.speakers != audio->speakers)
-		reset_resampler(source, audio);
+	if (source->input_sample_info.samples_per_sec != audio->samples_per_sec ||
+	    source->input_sample_info.format != audio->format ||
+	    source->input_sample_info.speakers != audio->speakers ||
+	    source->output_sample_info.samples_per_sec != config->info.samples_per_sec ||
+	    source->output_sample_info.format != config->info.format ||
+	    source->output_sample_info.speakers != config->info.speakers)
+		reset_resampler(source, audio, config);
 
 	if (source->audio_failed)
 		return;
@@ -4058,27 +4095,27 @@ static void process_audio(obs_source_t *source, const struct obs_source_audio *a
 			return;
 		}
 
-		copy_audio_data(source, (const uint8_t *const *)output, frames, audio->timestamp);
+		copy_audio_data(source, (const uint8_t *const *)output, frames,
+				audio->timestamp, config);
 	} else {
-		copy_audio_data(source, audio->data, audio->frames, audio->timestamp);
+		copy_audio_data(source, audio->data, audio->frames,
+				audio->timestamp, config);
 	}
 
-	pthread_mutex_lock(&obs->video.mixes_mutex);
-	mono_output = audio_output_get_channels(obs->audio.audio) == 1;
-	pthread_mutex_unlock(&obs->video.mixes_mutex);
-
-	if (!mono_output && source->sample_info.speakers == SPEAKERS_STEREO &&
+	if (!mono_output &&
+	    source->input_sample_info.speakers == SPEAKERS_STEREO &&
 	    (source->balance > 0.51f || source->balance < 0.49f)) {
 		process_audio_balancing(source, frames, source->balance, OBS_BALANCE_TYPE_SINE_LAW);
 	}
 
 	if (!mono_output && (source->flags & OBS_SOURCE_FLAG_FORCE_MONO) != 0)
-		downmix_to_mono_planar(source, frames);
+		downmix_to_mono_planar(source, frames, config);
 }
 
 void obs_source_output_audio(obs_source_t *source, const struct obs_source_audio *audio_in)
 {
 	struct obs_audio_data *output;
+	struct audio_output_config config;
 
 	if (!obs_source_valid(source, "obs_source_output_audio"))
 		return;
@@ -4095,7 +4132,10 @@ void obs_source_output_audio(obs_source_t *source, const struct obs_source_audio
 	for (size_t i = channels; i < MAX_AUDIO_CHANNELS; i++)
 		audio.data[i] = NULL;
 
-	process_audio(source, &audio);
+	if (!get_audio_output_config(&config))
+		return;
+
+	process_audio(source, &audio, &config);
 
 	pthread_mutex_lock(&source->filter_mutex);
 	output = filter_async_audio(source, &source->audio_data);
@@ -4110,7 +4150,7 @@ void obs_source_output_audio(obs_source_t *source, const struct obs_source_audio
 		data.timestamp = output->timestamp;
 
 		pthread_mutex_lock(&source->audio_mutex);
-		source_output_audio_data(source, &data);
+		source_output_audio_data(source, &data, &config);
 		pthread_mutex_unlock(&source->audio_mutex);
 	}
 
@@ -5785,7 +5825,7 @@ enum speaker_layout obs_source_get_speaker_layout(obs_source_t *source)
 	if (!obs_source_valid(source, "obs_source_get_audio_channels"))
 		return SPEAKERS_UNKNOWN;
 
-	return source->sample_info.speakers;
+	return source->input_sample_info.speakers;
 }
 
 void obs_source_set_balance_value(obs_source_t *source, float balance)

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -1549,8 +1549,7 @@ static inline size_t get_buf_placement(uint32_t sample_rate, uint64_t offset)
 	return (size_t)util_mul_div64(offset, sample_rate, 1000000000ULL);
 }
 
-static void source_output_audio_place(obs_source_t *source,
-				      const struct audio_data *in,
+static void source_output_audio_place(obs_source_t *source, const struct audio_data *in,
 				      const struct audio_output_config *config)
 {
 	size_t buf_placement;
@@ -1561,9 +1560,7 @@ static void source_output_audio_place(obs_source_t *source,
 		reset_audio_data(source, in->timestamp);
 
 	buf_placement =
-		get_buf_placement(config->info.samples_per_sec,
-				  in->timestamp - source->audio_ts) *
-		sizeof(float);
+		get_buf_placement(config->info.samples_per_sec, in->timestamp - source->audio_ts) * sizeof(float);
 
 #if DEBUG_AUDIO == 1
 	blog(LOG_DEBUG, "frames: %lu, size: %lu, placement: %lu, base_ts: %llu, ts: %llu", (unsigned long)in->frames,
@@ -1584,8 +1581,7 @@ static void source_output_audio_place(obs_source_t *source,
 	source->last_audio_input_buf_size = 0;
 }
 
-static inline void source_output_audio_push_back(obs_source_t *source,
-						 const struct audio_data *in,
+static inline void source_output_audio_push_back(obs_source_t *source, const struct audio_data *in,
 						 const struct audio_output_config *config)
 {
 	size_t channels = config->channels;
@@ -1619,8 +1615,7 @@ static inline bool source_muted(obs_source_t *source, uint64_t os_time)
 	       (source->push_to_talk_enabled && !push_to_talk_active);
 }
 
-static void source_output_audio_data(obs_source_t *source,
-				     const struct audio_data *data,
+static void source_output_audio_data(obs_source_t *source, const struct audio_data *data,
 				     const struct audio_output_config *config)
 {
 	size_t sample_rate = config->info.samples_per_sec;
@@ -3961,8 +3956,7 @@ static inline struct obs_audio_data *filter_async_audio(obs_source_t *source, st
 	return in;
 }
 
-static inline void reset_resampler(obs_source_t *source,
-				   const struct obs_source_audio *audio,
+static inline void reset_resampler(obs_source_t *source, const struct obs_source_audio *audio,
 				   const struct audio_output_config *config)
 {
 	source->input_sample_info.format = audio->format;
@@ -3981,16 +3975,14 @@ static inline void reset_resampler(obs_source_t *source,
 		return;
 	}
 
-	source->resampler = audio_resampler_create(&source->output_sample_info,
-						   &source->input_sample_info);
+	source->resampler = audio_resampler_create(&source->output_sample_info, &source->input_sample_info);
 
 	source->audio_failed = source->resampler == NULL;
 	if (source->resampler == NULL)
 		blog(LOG_ERROR, "creation of resampler failed");
 }
 
-static void copy_audio_data(obs_source_t *source, const uint8_t *const data[],
-			    uint32_t frames, uint64_t ts,
+static void copy_audio_data(obs_source_t *source, const uint8_t *const data[], uint32_t frames, uint64_t ts,
 			    const struct audio_output_config *config)
 {
 	size_t size = (size_t)frames * config->blocksize;
@@ -4015,8 +4007,7 @@ static void copy_audio_data(obs_source_t *source, const uint8_t *const data[],
 }
 
 /* TODO: SSE optimization */
-static void downmix_to_mono_planar(struct obs_source *source, uint32_t frames,
-				   const struct audio_output_config *config)
+static void downmix_to_mono_planar(struct obs_source *source, uint32_t frames, const struct audio_output_config *config)
 {
 	size_t channels = config->channels;
 	const float channels_i = 1.0f / (float)channels;
@@ -4066,8 +4057,7 @@ static void process_audio_balancing(struct obs_source *source, uint32_t frames, 
 }
 
 /* resamples/remixes new audio to the designated main audio output format */
-static void process_audio(obs_source_t *source,
-			  const struct obs_source_audio *audio,
+static void process_audio(obs_source_t *source, const struct obs_source_audio *audio,
 			  const struct audio_output_config *config)
 {
 	uint32_t frames = audio->frames;
@@ -4095,15 +4085,12 @@ static void process_audio(obs_source_t *source,
 			return;
 		}
 
-		copy_audio_data(source, (const uint8_t *const *)output, frames,
-				audio->timestamp, config);
+		copy_audio_data(source, (const uint8_t *const *)output, frames, audio->timestamp, config);
 	} else {
-		copy_audio_data(source, audio->data, audio->frames,
-				audio->timestamp, config);
+		copy_audio_data(source, audio->data, audio->frames, audio->timestamp, config);
 	}
 
-	if (!mono_output &&
-	    source->input_sample_info.speakers == SPEAKERS_STEREO &&
+	if (!mono_output && source->input_sample_info.speakers == SPEAKERS_STEREO &&
 	    (source->balance > 0.51f || source->balance < 0.49f)) {
 		process_audio_balancing(source, frames, source->balance, OBS_BALANCE_TYPE_SINE_LAW);
 	}

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1771,13 +1771,13 @@ bool obs_reset_audio2(const struct obs_audio_info2 *oai)
 	int max_buffering_ms;
 	bool active = false;
 
-	/* don't allow changing of audio settings if active. */
 	if (!obs)
 		return false;
 
 	if (!oai)
 		return true;
 
+	/* don't allow changing of audio settings if active. */
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 	if (audio->audio)
 		active = audio_output_active(audio->audio);

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -982,50 +982,99 @@ static void obs_free_graphics(void)
 
 static void set_audio_thread(void *unused);
 
+// The old audio object is returned to allow the caller to finalize it properly.
+static audio_t *obs_clear_audio_output(void)
+{
+	audio_t *old_audio;
+
+	pthread_mutex_lock(&obs->video.mixes_mutex);
+	old_audio = obs->audio.audio;
+	obs->audio.audio = NULL;
+	pthread_mutex_unlock(&obs->video.mixes_mutex);
+
+	return old_audio;
+}
+
+static void obs_set_audio_output(audio_t *audio_output)
+{
+	pthread_mutex_lock(&obs->video.mixes_mutex);
+	obs->audio.audio = audio_output;
+	pthread_mutex_unlock(&obs->video.mixes_mutex);
+}
+
 static bool obs_init_audio(struct audio_output_info *ai)
 {
 	struct obs_core_audio *audio = &obs->audio;
+	audio_t *audio_output = NULL;
+	bool monitoring_mutex_initialized = false;
+	bool task_mutex_initialized = false;
 	int errorcode;
 
 	pthread_mutex_init_value(&audio->monitoring_mutex);
+	pthread_mutex_init_value(&audio->task_mutex);
 
 	if (pthread_mutex_init_recursive(&audio->monitoring_mutex) != 0)
-		return false;
+		goto fail;
+	monitoring_mutex_initialized = true;
 	if (pthread_mutex_init(&audio->task_mutex, NULL) != 0)
-		return false;
+		goto fail;
+	task_mutex_initialized = true;
 
 	struct obs_task_info audio_init = {.task = set_audio_thread};
 	deque_push_back(&audio->tasks, &audio_init, sizeof(audio_init));
 
 	audio->monitoring_device_name = bstrdup("Default");
 	audio->monitoring_device_id = bstrdup("default");
+	audio->samples_per_sec = ai->samples_per_sec;
+	audio->speakers = ai->speakers;
+	audio->channels = get_audio_channels(ai->speakers);
+	ai->input_param = audio;
 
-	errorcode = audio_output_open(&audio->audio, ai);
-	if (errorcode == AUDIO_OUTPUT_SUCCESS)
+	errorcode = audio_output_open(&audio_output, ai);
+	if (errorcode == AUDIO_OUTPUT_SUCCESS) {
+		obs_set_audio_output(audio_output);
 		return true;
-	else if (errorcode == AUDIO_OUTPUT_INVALIDPARAM)
+	} else if (errorcode == AUDIO_OUTPUT_INVALIDPARAM)
 		blog(LOG_ERROR, "Invalid audio parameters specified");
 	else
 		blog(LOG_ERROR, "Could not open audio output");
+
+fail:
+	bfree(audio->monitoring_device_name);
+	bfree(audio->monitoring_device_id);
+	audio->monitoring_device_name = NULL;
+	audio->monitoring_device_id = NULL;
+	deque_free(&audio->tasks);
+	audio->samples_per_sec = 0;
+	audio->speakers = SPEAKERS_UNKNOWN;
+	audio->channels = 0;
+
+	if (task_mutex_initialized) {
+		pthread_mutex_destroy(&audio->task_mutex);
+		pthread_mutex_init_value(&audio->task_mutex);
+	}
+	if (monitoring_mutex_initialized) {
+		pthread_mutex_destroy(&audio->monitoring_mutex);
+		pthread_mutex_init_value(&audio->monitoring_mutex);
+	}
 
 	return false;
 }
 
 static void stop_audio(void)
 {
-	struct obs_core_audio *audio = &obs->audio;
-
-	if (audio->audio) {
-		audio_output_close(audio->audio);
-		audio->audio = NULL;
-	}
+	audio_t *old_audio = obs_clear_audio_output();
+	if (old_audio)
+		audio_output_close(old_audio);
 }
 
 static void obs_free_audio(void)
 {
 	struct obs_core_audio *audio = &obs->audio;
-	if (audio->audio)
-		audio_output_close(audio->audio);
+	audio_t *old_audio = obs_clear_audio_output();
+
+	if (old_audio)
+		audio_output_close(old_audio);
 
 	deque_free(&audio->buffered_timestamps);
 	da_free(audio->render_order);
@@ -1718,27 +1767,35 @@ bool obs_reset_audio2(const struct obs_audio_info2 *oai)
 {
 	struct obs_core_audio *audio = &obs->audio;
 	struct audio_output_info ai;
+	int max_buffering_ticks;
+	int max_buffering_ms;
+	bool active = false;
 
 	/* don't allow changing of audio settings if active. */
-	if (!obs || (audio->audio && audio_output_active(audio->audio)))
+	if (!obs)
 		return false;
 
 	if (!oai)
 		return true;
 
 	pthread_mutex_lock(&obs->video.mixes_mutex);
+	if (audio->audio)
+		active = audio_output_active(audio->audio);
+	pthread_mutex_unlock(&obs->video.mixes_mutex);
+
+	if (active)
+		return false;
 
 	if (oai->max_buffering_ms) {
 		uint32_t max_frames = oai->max_buffering_ms * oai->samples_per_sec / SEC_TO_MSEC;
 		max_frames += (AUDIO_OUTPUT_FRAMES - 1);
-		audio->max_buffering_ticks = max_frames / AUDIO_OUTPUT_FRAMES;
+		max_buffering_ticks = (int)(max_frames / AUDIO_OUTPUT_FRAMES);
 	} else {
-		audio->max_buffering_ticks = 45;
+		max_buffering_ticks = 45;
 	}
-	audio->fixed_buffer = oai->fixed_buffering;
 
-	int max_buffering_ms =
-		audio->max_buffering_ticks * AUDIO_OUTPUT_FRAMES * SEC_TO_MSEC / (int)oai->samples_per_sec;
+	max_buffering_ms = max_buffering_ticks * AUDIO_OUTPUT_FRAMES *
+			   SEC_TO_MSEC / (int)oai->samples_per_sec;
 
 	ai.name = "Audio";
 	ai.samples_per_sec = oai->samples_per_sec;
@@ -1756,15 +1813,12 @@ bool obs_reset_audio2(const struct obs_audio_info2 *oai)
 	     (int)ai.samples_per_sec, (int)ai.speakers, max_buffering_ms,
 	     oai->fixed_buffering ? "fixed" : "dynamically increasing");
 
-	pthread_mutex_unlock(&obs->video.mixes_mutex);
-
 	obs_free_audio();
 
-	pthread_mutex_lock(&obs->video.mixes_mutex);
-	bool init_complited = obs_init_audio(&ai);
-	pthread_mutex_unlock(&obs->video.mixes_mutex);
+	audio->max_buffering_ticks = max_buffering_ticks;
+	audio->fixed_buffer = oai->fixed_buffering;
 
-	return init_complited;
+	return obs_init_audio(&ai);
 }
 
 bool obs_reset_audio(const struct obs_audio_info *oai)


### PR DESCRIPTION
### Description
This PR fixes a data race crash with the following stack trace:
```
obs          +0x5a3e1 copy_audio_data (obs-source.c:4264)
obs          +0x5ac36 process_audio (obs-source.c:4371)
w32-pthreads +0x04ab6 pthread_mutex_lock (pthread_mutex_lock.c:98)
ntdll        +0x1cca3 RtlAllocateHeap
obs-ffmpeg   +0x109b2 get_audio (obs-ffmpeg-source.c:281)
obs-ffmpeg   +0x28984 mp_media_next_audio (media.c:499)
obs-ffmpeg   +0x28984 mp_media_thread (media.c:1072)
w32-pthreads +0x087a0 pthread_setspecific (pthread_setspecific.c:159)
obs-ffmpeg   +0x2922d mp_media_thread_start (media.c:1180)
w32-pthreads +0x01460 ptw32_threadStart (ptw32_threadStart.c:225)
ucrtbase     +0x037af thread_start<T>
KERNEL32.DLL +0x2e8d6 BaseThreadInitThunk
ntdll        +0x8c40b RtlUserThreadStart
```

This change improves the async source-audio path in libobs by snapshotting the current audio-output settings once per frame and using that immutable config throughout processing.

### Motivation and Context
The observed failure was `EXCEPTION_ACCESS_VIOLATION_READ / 0x38`, which matched the code reading fields from the global `obs->audio.audio` output object while async audio was still being processed.

Before this change, the async audio path repeatedly read live audio-output state from the global `obs->audio.audio` pointer in multiple helpers:
- `copy_audio_data()` queried planes and block size
- `downmix_to_mono_planar()` queried channel count
- `source_output_audio_data()` and related buffer-placement code depended on the current output sample rate
- `reset_resampler()` used the current output format to decide whether to rebuild the resampler

That created two related problems:
1. **Late audio during reset/shutdown could dereference a dead or null audio output**
   - If `obs->audio.audio` was cleared or torn down while an async source thread was still inside audio processing, the next helper that queried it could crash.

2. **There was still a check-then-use race even when `mixes_mutex` was used**
   - The old code sometimes read output state under `obs->video.mixes_mutex`, unlocked, and then continued processing based on that live object.
   - That means the pointer could change between separate reads, or the code could keep using data derived from an output object that was no longer current.


### The fix 🛠️
This patch introduces a small object, `audio_output_config`, in `obs-source.c`.

It contains only the output settings the async path actually needs for one frame:
- output format / sample rate / speaker layout
- plane count
- block size
- channel count

A new helper, `get_audio_output_config()`, copies those values under `obs->video.mixes_mutex` and returns them by value. If libobs is already shutting down or `obs->audio.audio` is unavailable, it returns `false`.

That config is then used through the whole async source-audio path instead of re-reading `obs->audio.audio` later. This means one async frame is processed against one consistent set of output settings.

The patch also makes the resampler state explicit in `obs-internal.h`:
- `input_sample_info`
- `output_sample_info`

### How Has This Been Tested?
Manually, Windows only.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)