### PR TITLE
Fixes for OBS shutdown order

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1491,6 +1491,15 @@ void obs_shutdown(void)
 
 	obs_wait_for_destroy_queue();
 
+	// Destroy remaining runtime objects (outputs, encoders, displays, ...) while shared subsystems are still alive.
+	obs_free_data();
+
+	// Destroy shared subsystems after deferred destroy tasks have completed.
+	// `obs_free_data()` waits for the destroy queue before returning.
+	stop_video();
+	stop_audio();
+	stop_hotkeys();
+
 	for (size_t i = 0; i < obs->source_types.num; i++) {
 		struct obs_source_info *item = &obs->source_types.array[i];
 		if (item->type_data && item->free_type_data)
@@ -1522,10 +1531,6 @@ void obs_shutdown(void)
 	da_free(obs->filter_types);
 	da_free(obs->transition_types);
 
-	stop_video();
-	stop_audio();
-	stop_hotkeys();
-
 	module = obs->first_module;
 	while (module) {
 		struct obs_module *next = module->next;
@@ -1534,7 +1539,6 @@ void obs_shutdown(void)
 	}
 	obs->first_module = NULL;
 
-	obs_free_data();
 	obs_free_audio();
 	obs_free_video(true);
 	os_task_queue_destroy(obs->destruction_task_thread);


### PR DESCRIPTION
### Description
This change fixes libobs shutdown ordering so remaining runtime objects are destroyed before shared subsystems are torn down.

### Motivation and Context
`obs_shutdown()` was tearing down core shared subsystems too early:

```c
	// old code
	obs_wait_for_destroy_queue();

	...

	stop_video();
	stop_audio();
	stop_hotkeys();

	...

	obs_free_data();
```

Only in the end it did call `obs_free_data()`, which is the function that actually destroys the remaining live OBS runtime objects such as sources, outputs, encoders, services, and displays.

That ordering is unsafe because those objects still rely on the subsystems being alive while their destroy paths run.


### Why this is a bug
Several object families depend on shared libobs state during destruction:

- Sources can run destroy callbacks that use plugin-provided `info.destroy` handlers, hotkey unregister paths, audio-monitor cleanup, and graphics-context work.
- Displays require the graphics context during destroy.
- Outputs can still reference audio/video state while shutting down.
- Source destruction is partly deferred, and `obs_free_data()` waits for that destroy queue before returning.

With the old order, shutdown could begin tearing down audio, video, hotkeys, and modules before the objects that depend on them had actually been destroyed. That creates races and makes shutdown-time crashes much more likely.

### Why this fixes the issue

This makes shutdown follow the correct lifecycle:

- first destroy the objects that are still part of the OBS runtime graph
- then tear down the shared systems those objects depend on

That means source/output/display destruction still runs while the graphics context, audio/video state, hotkey system, registered type data, and module callbacks are all still available.

`obs_free_data()` already waits for deferred destroy tasks before returning, so once control moves past it, libobs is in a much safer state to shut subsystems down.

### How Has This Been Tested?
Manually, Windows only.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)