### PR TITLE
fix audio cleanup

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1167,12 +1167,24 @@ static void obs_main_view_free(struct obs_view *view)
 			blog(LOG_INFO, "\t%d " #type "(s) were remaining", unfreed); \
 	} while (false)
 
-static void obs_free_data(void)
+static void obs_free_runtime_objects(void)
 {
 	blog(LOG_INFO, "Freeing OBS context data");
 
 	struct obs_core_data *data = &obs->data;
 	data->valid = false;
+
+	FREE_OBS_LINKED_LIST(output);
+	FREE_OBS_LINKED_LIST(encoder);
+	FREE_OBS_LINKED_LIST(display);
+	FREE_OBS_LINKED_LIST(service);
+
+	os_task_queue_wait(obs->destruction_task_thread);
+}
+
+static void obs_free_data(void)
+{
+	struct obs_core_data *data = &obs->data;
 
 	/* Free main canvas */
 	obs_canvas_release(data->main_canvas);
@@ -1182,11 +1194,6 @@ static void obs_free_data(void)
 	obs_main_view_free(&data->stream_view);
 	obs_view_remove(&data->record_view);
 	obs_main_view_free(&data->record_view);
-
-	FREE_OBS_LINKED_LIST(output);
-	FREE_OBS_LINKED_LIST(encoder);
-	FREE_OBS_LINKED_LIST(display);
-	FREE_OBS_LINKED_LIST(service);
 
 	FREE_OBS_HASH_TABLE(hh, &data->public_sources, source);
 	FREE_OBS_HASH_TABLE(hh_uuid, &data->sources, source);
@@ -1540,14 +1547,17 @@ void obs_shutdown(void)
 
 	obs_wait_for_destroy_queue();
 
-	// Destroy remaining runtime objects (outputs, encoders, displays, ...) while shared subsystems are still alive.
-	obs_free_data();
+	// Free outputs, encoders, displays, services while audio/video subsystems are still alive (they may need the pipeline during destruction).
+	obs_free_runtime_objects();
 
-	// Destroy shared subsystems after deferred destroy tasks have completed.
-	// `obs_free_data()` waits for the destroy queue before returning.
+	// Stop audio/video/hotkey threads after runtime objects are freed
+	// but before sources and mutexes they access are destroyed.
 	stop_video();
 	stop_audio();
 	stop_hotkeys();
+
+	// Free sources, canvases, views, and mutexes now that the audio/video threads are no longer running.
+	obs_free_data();
 
 	for (size_t i = 0; i < obs->source_types.num; i++) {
 		struct obs_source_info *item = &obs->source_types.array[i];


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
  The crash: pthread_mutex_unlock on an already-destroyed audio_sources_mutex in the audio thread during shutdown.

  Root cause:  obs_free_data() before stop_audio(). This destroys data->audio_sources_mutex and frees all sources while the audio thread is still running audio_callback(), which uses both.

  The fix: Split obs_free_data() into two functions:
  - obs_free_runtime_objects() — frees outputs, encoders, displays, services. Called first, while audio/video threads are still alive (these objects may need the pipeline during destruction).
  - obs_free_data() — frees sources, canvases, views, and destroys mutexes. Called after stop_video()/stop_audio() so the threads are no longer accessing them.

  The new shutdown order in obs_shutdown():
  1. obs_free_runtime_objects() — free outputs/encoders (subsystems alive)
  2. stop_video() / stop_audio() / stop_hotkeys() — stop threads
  3. obs_free_data() — free sources/mutexes (threads stopped)
  
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
