### PR TITLE
Protecting output batch size calculation

### DIFF
--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -2731,38 +2731,37 @@ static void reset_raw_output(obs_output_t *output)
 	pause_reset(&output->pause);
 }
 
-static const char *get_encoder_type_name(const obs_encoder_t *encoder)
-{
-	switch (encoder->info.type) {
-	case OBS_ENCODER_VIDEO:
-		return "video";
-	case OBS_ENCODER_AUDIO:
-		return "audio";
-	default:
-		return "unknown";
-	}
-}
-
-static bool log_invalid_encoder_timing(struct obs_output *output, obs_encoder_t *encoder, const char *reason,
-				       uint32_t fps_num, uint32_t fps_den, uint32_t frame_rate_divisor,
-				       uint32_t sample_rate, size_t frame_size)
-{
+static void set_fail_to_start_encoder_state(struct obs_output *output, obs_encoder_t *encoder) {
 	const char *last_error = obs_encoder_get_last_error(encoder);
-
-	blog(LOG_WARNING,
-	     "Output '%s': Cannot start data capture because encoder '%s' (%s) has invalid timing for "
-	     "interleaver batch size calculation (%s: fps_num=%" PRIu32 ", fps_den=%" PRIu32
-	     ", frame_rate_divisor=%" PRIu32 ", sample_rate=%" PRIu32 ", frame_size=%zu)",
-	     obs_output_get_name(output), obs_encoder_get_name(encoder), get_encoder_type_name(encoder), reason,
-	     fps_num, fps_den, frame_rate_divisor, sample_rate, frame_size);
-
 	obs_output_set_last_error(output,
 				  last_error && *last_error ? last_error : "Output encoder is not ready to start");
-	return false;
 }
 
-/* Validate encoder timing before data capture is hooked so malformed encoder state fails cleanly
- * instead of crashing during startup batch-size math. */
+static void log_invalid_video_encoder_params(struct obs_output *output, obs_encoder_t *video_encoder,
+					     const char *reason, uint32_t fps_num, uint32_t fps_den,
+					     uint32_t frame_rate_divisor)
+{
+	blog(LOG_WARNING,
+	     "Output '%s': Cannot start data capture because encoder '%s' (video) has invalid timing for "
+	     "interleaver batch size calculation (%s: fps_num=%" PRIu32 ", fps_den=%" PRIu32
+	     ", frame_rate_divisor=%" PRIu32 ")",
+	     obs_output_get_name(output), obs_encoder_get_name(video_encoder), reason, fps_num, fps_den,
+	     frame_rate_divisor);
+
+	set_fail_to_start_encoder_state(output, video_encoder);
+}
+
+static void log_invalid_audio_encoder_params(struct obs_output *output, obs_encoder_t *audio_encoder,
+					     const char *reason, uint32_t sample_rate, size_t frame_size)
+{
+	blog(LOG_WARNING,
+	     "Output '%s': Cannot start data capture because encoder '%s' (audio) has invalid timing for "
+	     "interleaver batch size calculation (%s: sample_rate=%" PRIu32 ", frame_size=%zu)",
+	     obs_output_get_name(output), obs_encoder_get_name(audio_encoder), reason, sample_rate, frame_size);
+
+	set_fail_to_start_encoder_state(output, audio_encoder);
+}
+
 static bool calculate_batch_size(struct obs_output *output, size_t *batch_size)
 {
 	struct obs_video_info ovi;
@@ -2776,27 +2775,31 @@ static bool calculate_batch_size(struct obs_output *output, size_t *batch_size)
 
 	/* Step 1: Calculate the largest interval between packets of any encoder. */
 	for (size_t i = 0; i < MAX_OUTPUT_VIDEO_ENCODERS; i++) {
-		obs_encoder_t *video = output->video_encoders[i];
+		obs_encoder_t *video_encoder = output->video_encoders[i];
 		uint32_t frame_rate_divisor;
 		uint64_t den;
 		uint64_t encoder_interval;
 
-		if (!video)
+		if (!video_encoder)
 			continue;
-
-		frame_rate_divisor = obs_encoder_get_frame_rate_divisor(video);
+		
+		frame_rate_divisor = obs_encoder_get_frame_rate_divisor(video_encoder);
+		// Here and in other places we validate encoder timing params before data capture is hooked so
+		// malformed encoder state fails cleanly instead of crashing during startup batch-size math.
 		if (!ovi.fps_num) {
 			da_free(intervals);
-			return log_invalid_encoder_timing(output, video, "video FPS numerator is zero", ovi.fps_num,
-							 ovi.fps_den, frame_rate_divisor, 0, 0);
+			log_invalid_video_encoder_params(output, video_encoder, "video FPS numerator is zero",
+											 ovi.fps_num, ovi.fps_den, frame_rate_divisor);
+			return false;
 		}
 
 		den = (uint64_t)ovi.fps_den * frame_rate_divisor;
 		encoder_interval = util_mul_div64(1000000000ULL, den, ovi.fps_num);
 		if (!encoder_interval) {
 			da_free(intervals);
-			return log_invalid_encoder_timing(output, video, "video encoder interval is zero",
-							 ovi.fps_num, ovi.fps_den, frame_rate_divisor, 0, 0);
+			log_invalid_video_encoder_params(output, video_encoder, "video encoder interval is zero",
+											 ovi.fps_num, ovi.fps_den, frame_rate_divisor);
+			return false;
 		}
 
 		da_push_back(intervals, &encoder_interval);
@@ -2817,20 +2820,23 @@ static bool calculate_batch_size(struct obs_output *output, size_t *batch_size)
 		frame_size = obs_encoder_get_frame_size(audio);
 		if (!sample_rate) {
 			da_free(intervals);
-			return log_invalid_encoder_timing(output, audio, "audio sample rate is zero", 0, 0, 0,
-							 sample_rate, frame_size);
+			log_invalid_audio_encoder_params(output, audio, "audio sample rate is zero", sample_rate,
+											 frame_size);
+			return false;
 		}
 		if (!frame_size) {
 			da_free(intervals);
-			return log_invalid_encoder_timing(output, audio, "audio frame size is zero", 0, 0, 0,
-							 sample_rate, frame_size);
+			log_invalid_audio_encoder_params(output, audio, "audio frame size is zero", sample_rate,
+											 frame_size);
+			return false;
 		}
 
 		encoder_interval = util_mul_div64(1000000000ULL, frame_size, sample_rate);
 		if (!encoder_interval) {
 			da_free(intervals);
-			return log_invalid_encoder_timing(output, audio, "audio encoder interval is zero", 0, 0, 0,
-							 sample_rate, frame_size);
+			log_invalid_audio_encoder_params(output, audio, "audio encoder interval is zero",
+											 sample_rate, frame_size);
+			return false;
 		}
 
 		da_push_back(intervals, &encoder_interval);
@@ -2878,11 +2884,11 @@ bool obs_output_begin_data_capture(obs_output_t *output, uint32_t flags)
 
 	size_t batch_size;
 	if (!calculate_batch_size(output, &batch_size)) {
-		/* Abort before activation so callers get a clean start failure instead of a partial capture state. */
+		// Abort before activation so callers get a clean start failure instead of a partial capture state.
 		return false;
 	}
 
-	/* Batch size is recomputed for each start, so overwrite the previous value instead of accumulating it. */
+	// Batch size is recomputed for each start, so overwrite the previous value instead of accumulating it.
 	output->interleaver_max_batch_size = batch_size;
 
 	os_atomic_set_bool(&output->data_active, true);

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -2731,34 +2731,108 @@ static void reset_raw_output(obs_output_t *output)
 	pause_reset(&output->pause);
 }
 
-static void calculate_batch_size(struct obs_output *output)
+static const char *get_encoder_type_name(const obs_encoder_t *encoder)
+{
+	switch (encoder->info.type) {
+	case OBS_ENCODER_VIDEO:
+		return "video";
+	case OBS_ENCODER_AUDIO:
+		return "audio";
+	default:
+		return "unknown";
+	}
+}
+
+static bool log_invalid_encoder_timing(struct obs_output *output, obs_encoder_t *encoder, const char *reason,
+				       uint32_t fps_num, uint32_t fps_den, uint32_t frame_rate_divisor,
+				       uint32_t sample_rate, size_t frame_size)
+{
+	const char *last_error = obs_encoder_get_last_error(encoder);
+
+	blog(LOG_WARNING,
+	     "Output '%s': Cannot start data capture because encoder '%s' (%s) has invalid timing for "
+	     "interleaver batch size calculation (%s: fps_num=%" PRIu32 ", fps_den=%" PRIu32
+	     ", frame_rate_divisor=%" PRIu32 ", sample_rate=%" PRIu32 ", frame_size=%zu)",
+	     obs_output_get_name(output), obs_encoder_get_name(encoder), get_encoder_type_name(encoder), reason,
+	     fps_num, fps_den, frame_rate_divisor, sample_rate, frame_size);
+
+	obs_output_set_last_error(output,
+				  last_error && *last_error ? last_error : "Output encoder is not ready to start");
+	return false;
+}
+
+/* Validate encoder timing before data capture is hooked so malformed encoder state fails cleanly
+ * instead of crashing during startup batch-size math. */
+static bool calculate_batch_size(struct obs_output *output, size_t *batch_size)
 {
 	struct obs_video_info ovi;
 	obs_get_video_info(&ovi);
 	DARRAY(uint64_t) intervals;
 	da_init(intervals);
 
+	*batch_size = 0;
+
 	uint64_t largest_interval = 0;
 
 	/* Step 1: Calculate the largest interval between packets of any encoder. */
 	for (size_t i = 0; i < MAX_OUTPUT_VIDEO_ENCODERS; i++) {
-		if (!output->video_encoders[i])
+		obs_encoder_t *video = output->video_encoders[i];
+		uint32_t frame_rate_divisor;
+		uint64_t den;
+		uint64_t encoder_interval;
+
+		if (!video)
 			continue;
 
-		uint32_t den = ovi.fps_den * obs_encoder_get_frame_rate_divisor(output->video_encoders[i]);
-		uint64_t encoder_interval = util_mul_div64(1000000000ULL, den, ovi.fps_num);
+		frame_rate_divisor = obs_encoder_get_frame_rate_divisor(video);
+		if (!ovi.fps_num) {
+			da_free(intervals);
+			return log_invalid_encoder_timing(output, video, "video FPS numerator is zero", ovi.fps_num,
+							 ovi.fps_den, frame_rate_divisor, 0, 0);
+		}
+
+		den = (uint64_t)ovi.fps_den * frame_rate_divisor;
+		encoder_interval = util_mul_div64(1000000000ULL, den, ovi.fps_num);
+		if (!encoder_interval) {
+			da_free(intervals);
+			return log_invalid_encoder_timing(output, video, "video encoder interval is zero",
+							 ovi.fps_num, ovi.fps_den, frame_rate_divisor, 0, 0);
+		}
+
 		da_push_back(intervals, &encoder_interval);
 
 		largest_interval = encoder_interval > largest_interval ? encoder_interval : largest_interval;
 	}
 
 	for (size_t i = 0; i < MAX_OUTPUT_AUDIO_ENCODERS; i++) {
-		if (!output->audio_encoders[i])
+		obs_encoder_t *audio = output->audio_encoders[i];
+		uint32_t sample_rate;
+		size_t frame_size;
+		uint64_t encoder_interval;
+
+		if (!audio)
 			continue;
 
-		uint32_t sample_rate = obs_encoder_get_sample_rate(output->audio_encoders[i]);
-		size_t frame_size = obs_encoder_get_frame_size(output->audio_encoders[i]);
-		uint64_t encoder_interval = util_mul_div64(1000000000ULL, frame_size, sample_rate);
+		sample_rate = obs_encoder_get_sample_rate(audio);
+		frame_size = obs_encoder_get_frame_size(audio);
+		if (!sample_rate) {
+			da_free(intervals);
+			return log_invalid_encoder_timing(output, audio, "audio sample rate is zero", 0, 0, 0,
+							 sample_rate, frame_size);
+		}
+		if (!frame_size) {
+			da_free(intervals);
+			return log_invalid_encoder_timing(output, audio, "audio frame size is zero", 0, 0, 0,
+							 sample_rate, frame_size);
+		}
+
+		encoder_interval = util_mul_div64(1000000000ULL, frame_size, sample_rate);
+		if (!encoder_interval) {
+			da_free(intervals);
+			return log_invalid_encoder_timing(output, audio, "audio encoder interval is zero", 0, 0, 0,
+							 sample_rate, frame_size);
+		}
+
 		da_push_back(intervals, &encoder_interval);
 
 		largest_interval = encoder_interval > largest_interval ? encoder_interval : largest_interval;
@@ -2769,13 +2843,14 @@ static void calculate_batch_size(struct obs_output *output)
 	 * divisible by all smaller ones. For example, 33.3... ms video (30 FPS) and 21.3... ms audio (48 kHz AAC). */
 	for (size_t i = 0; i < intervals.num; i++) {
 		uint64_t num = (largest_interval * 2) / intervals.array[i];
-		output->interleaver_max_batch_size += num;
+		*batch_size += num;
 	}
 
 	blog(LOG_DEBUG, "Maximum interleaver batch size for '%s' calculated to be %zu packets",
-	     obs_output_get_name(output), output->interleaver_max_batch_size);
+	     obs_output_get_name(output), *batch_size);
 
 	da_free(intervals);
+	return true;
 }
 
 bool obs_output_begin_data_capture(obs_output_t *output, uint32_t flags)
@@ -2801,10 +2876,17 @@ bool obs_output_begin_data_capture(obs_output_t *output, uint32_t flags)
 	if (flag_video(output) && flag_audio(output))
 		pair_encoders(output);
 
+	size_t batch_size;
+	if (!calculate_batch_size(output, &batch_size)) {
+		/* Abort before activation so callers get a clean start failure instead of a partial capture state. */
+		return false;
+	}
+
+	/* Batch size is recomputed for each start, so overwrite the previous value instead of accumulating it. */
+	output->interleaver_max_batch_size = batch_size;
+
 	os_atomic_set_bool(&output->data_active, true);
 	hook_data_capture(output);
-
-	calculate_batch_size(output);
 
 	if (flag_service(output))
 		obs_service_activate(output->service);

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -2731,7 +2731,7 @@ static void reset_raw_output(obs_output_t *output)
 	pause_reset(&output->pause);
 }
 
-static void set_fail_to_start_encoder_state(struct obs_output *output, obs_encoder_t *encoder) {
+static void set_fail_to_start_output_state(struct obs_output *output, obs_encoder_t *encoder) {
 	const char *last_error = obs_encoder_get_last_error(encoder);
 	obs_output_set_last_error(output,
 				  last_error && *last_error ? last_error : "Output encoder is not ready to start");
@@ -2748,7 +2748,7 @@ static void log_invalid_video_encoder_params(struct obs_output *output, obs_enco
 	     obs_output_get_name(output), obs_encoder_get_name(video_encoder), reason, fps_num, fps_den,
 	     frame_rate_divisor);
 
-	set_fail_to_start_encoder_state(output, video_encoder);
+	set_fail_to_start_output_state(output, video_encoder);
 }
 
 static void log_invalid_audio_encoder_params(struct obs_output *output, obs_encoder_t *audio_encoder,
@@ -2759,7 +2759,7 @@ static void log_invalid_audio_encoder_params(struct obs_output *output, obs_enco
 	     "interleaver batch size calculation (%s: sample_rate=%" PRIu32 ", frame_size=%zu)",
 	     obs_output_get_name(output), obs_encoder_get_name(audio_encoder), reason, sample_rate, frame_size);
 
-	set_fail_to_start_encoder_state(output, audio_encoder);
+	set_fail_to_start_output_state(output, audio_encoder);
 }
 
 static bool calculate_batch_size(struct obs_output *output, size_t *batch_size)

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -2808,25 +2808,25 @@ static bool calculate_batch_size(struct obs_output *output, size_t *batch_size)
 	}
 
 	for (size_t i = 0; i < MAX_OUTPUT_AUDIO_ENCODERS; i++) {
-		obs_encoder_t *audio = output->audio_encoders[i];
+		obs_encoder_t *audio_encoder = output->audio_encoders[i];
 		uint32_t sample_rate;
 		size_t frame_size;
 		uint64_t encoder_interval;
 
-		if (!audio)
+		if (!audio_encoder)
 			continue;
 
-		sample_rate = obs_encoder_get_sample_rate(audio);
-		frame_size = obs_encoder_get_frame_size(audio);
+		sample_rate = obs_encoder_get_sample_rate(audio_encoder);
+		frame_size = obs_encoder_get_frame_size(audio_encoder);
 		if (!sample_rate) {
 			da_free(intervals);
-			log_invalid_audio_encoder_params(output, audio, "audio sample rate is zero", sample_rate,
+			log_invalid_audio_encoder_params(output, audio_encoder, "audio sample rate is zero", sample_rate,
 											 frame_size);
 			return false;
 		}
 		if (!frame_size) {
 			da_free(intervals);
-			log_invalid_audio_encoder_params(output, audio, "audio frame size is zero", sample_rate,
+			log_invalid_audio_encoder_params(output, audio_encoder, "audio frame size is zero", sample_rate,
 											 frame_size);
 			return false;
 		}
@@ -2834,7 +2834,7 @@ static bool calculate_batch_size(struct obs_output *output, size_t *batch_size)
 		encoder_interval = util_mul_div64(1000000000ULL, frame_size, sample_rate);
 		if (!encoder_interval) {
 			da_free(intervals);
-			log_invalid_audio_encoder_params(output, audio, "audio encoder interval is zero",
+			log_invalid_audio_encoder_params(output, audio_encoder, "audio encoder interval is zero",
 											 sample_rate, frame_size);
 			return false;
 		}


### PR DESCRIPTION
### Description
This PR improves encoded output startup, so malformed encoder timing no longer crashes the process during interleaver setup.

### Motivation
Currently we have a crash in `calculate_batch_size()` which has origins in the front-end. Even though the crash was fixes by the migration  to the Factory API, I want to improve error handling in this chunk of code.


### Context
`calculate_batch_size()` walks every attached video and audio encoder, converts each encoder’s cadence into an interval, and then divides by those intervals to estimate how large the interleaver batch must be.

The problem is that this math assumed all attached encoders were already fully initialized and reporting valid timing. If an encoder was attached but not actually ready yet, libobs could see values like `fps_num == 0`, `sample_rate == 0`, `frame_size == 0`, or a computed interval of `0`.

That behavior is especially risky because it happens in the middle of startup, before the output is marked active and before callers get any structured error back. In other words, a bad encoder state in a single output could terminate the whole application instead of failing one output start attempt. 

### The fix
The fix changes batch-size calculation from a blind “compute and divide” step into a validated preflight step.

### How Has This Been Tested?
Manually, Windows only

### Types of changes
- Bug fix (non-breaking change which fixes an issue) -->