### PR TITLE
fix deadlock on fast init deinit of filters

### DIFF
--- a/plugins/nv-filters/nvidia-audiofx-filter.c
+++ b/plugins/nv-filters/nvidia-audiofx-filter.c
@@ -126,6 +126,9 @@ static void nvidia_audio_destroy(void *data)
 		return;
 
 	if (ng->nvidia_sdk_dir_found)
+		pthread_join(ng->nvafx_thread, NULL);
+
+	if (ng->nvidia_sdk_dir_found)
 		pthread_mutex_lock(&ng->nvafx_mutex);
 
 	for (size_t i = 0; i < ng->channels; i++) {
@@ -151,7 +154,6 @@ static void nvidia_audio_destroy(void *data)
 	bfree(ng->sdk_path);
 	bfree((void *)ng->fx);
 	if (ng->nvidia_sdk_dir_found) {
-		pthread_join(ng->nvafx_thread, NULL);
 		pthread_mutex_unlock(&ng->nvafx_mutex);
 		pthread_mutex_destroy(&ng->nvafx_mutex);
 	}

--- a/plugins/nv-filters/nvidia-audiofx-filter.c
+++ b/plugins/nv-filters/nvidia-audiofx-filter.c
@@ -125,11 +125,10 @@ static void nvidia_audio_destroy(void *data)
 	if (!ng)
 		return;
 
-	if (ng->nvidia_sdk_dir_found)
+	if (ng->nvidia_sdk_dir_found) {
 		pthread_join(ng->nvafx_thread, NULL);
-
-	if (ng->nvidia_sdk_dir_found)
 		pthread_mutex_lock(&ng->nvafx_mutex);
+	}
 
 	for (size_t i = 0; i < ng->channels; i++) {
 		if (ng->handle[0]) {


### PR DESCRIPTION
  **Summary**

  - Fix deadlock in nvidia_audio_destroy when NVIDIA audio filters are rapidly created and destroyed (e.g. during automated tests that iterate through all filter types)

  **Problem**

  nvidia_audio_destroy locks ng->nvafx_mutex and then calls pthread_join on the init thread. The init thread (nvidia_audio_initialize) also needs to acquire ng->nvafx_mutex as its first step. When deferred destruction
  runs before the init thread has acquired the mutex, this creates a deadlock:

  - Destroy thread: holds nvafx_mutex, waits on pthread_join
  - Init thread: waits on nvafx_mutex, never finishes

  This cascades to nvidia_afx_initializer_mutex (the global mutex shared across all NVIDIA audio filter instances), blocking initialization of any subsequent NVIDIA audio filters and stalling obs_wait_for_destroy_queue.

  **Fix**

  Move pthread_join before the mutex lock in nvidia_audio_destroy. The init thread runs to completion first (releasing all locks), then destroy safely locks the mutex for cleanup.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
