### PR TITLE
obs_video_info: add a parent_ovi pointer

### DIFF
--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -1505,6 +1505,7 @@ int OBSBasic::ResetVideo()
 	ovi.adapter = config_get_uint(App()->GetUserConfig(), "Video", "AdapterIdx");
 	ovi.gpu_conversion = true;
 	ovi.scale_type = GetScaleType(activeConfiguration);
+	ovi.parent_ovi = NULL;
 
 	if (ovi.base_width < 32 || ovi.base_height < 32) {
 		ovi.base_width = 1920;

--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -274,6 +274,8 @@ static void maybe_set_up_gpu_rescale(struct obs_encoder *encoder)
 	ovi->scale_type = encoder->gpu_scale_type;
 
 	ovi->gpu_conversion = true;
+	// Source items will be unaware of this new ovi* since it doesn't match their cached ptr. So we will set the parent ovi*
+	ovi->parent_ovi = current_mix->ovi;
 
 	mix = obs_create_video_mix(ovi);
 	if (!mix)

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -1086,9 +1086,13 @@ static void scene_video_render(void *data, gs_effect_t *effect)
 	gs_blend_state_push();
 	gs_reset_blend_state();
 
+	// Determine if there is another obs_video_info this scene item can render into
+	struct obs_video_info *parent_ovi =
+		obs_get_video_rendering_canvas() != NULL ? obs_get_video_rendering_canvas()->parent_ovi : NULL;
+
 	item = scene->first_item;
 	while (item) {
-		if (obs_get_video_rendering_canvas() != item->canvas &&
+		if ((parent_ovi == item->canvas || obs_get_video_rendering_canvas() == item->canvas) &&
 		    item->canvas != NULL) {
 			item = item->next;
 			continue;

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1967,6 +1967,7 @@ struct obs_video_info *obs_create_video_info()
 	ovi->scale_type = OBS_SCALE_BILINEAR;
 	ovi->adapter = 0;
 	ovi->gpu_conversion = true;
+	ovi->parent_ovi = NULL;
 
 	return ovi;
 }

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -224,6 +224,7 @@ struct obs_video_info {
 	enum video_range_type range;      /**< YUV range (if YUV) */
 
 	enum obs_scale_type scale_type; /**< How to scale if scaling */
+	void* parent_ovi;               /**< Pointer to the source obs_video_info this was copied from */
 };
 
 /**


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Within `maybe_set_up_gpu_rescale` we are creating a new video_mix and effectively trying to assign it a copy of the current `obs_video_info`. However, the `item->canvas` pointer within `scene_video_render` has no idea it needs to render to this new canvas required by the video encoder. Adding a `parent_ovi*` field so we can associate the current `ovi*` with the new `ovi*` created for the video encoder. Now the scene items know they need to render to the current ovi as well as any duplicates created for the video encoders. Now during `receive_video`, the encoder is no longer being given all black pixels (empty frame).
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Resolves black screen rendering for all resolutions during Twitch enhanced broadcasting.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
