### PR TITLE
Fix video mix canvas identity

### DIFF
--- a/libobs/media-io/audio-io.c
+++ b/libobs/media-io/audio-io.c
@@ -146,7 +146,7 @@ static void do_audio_output(struct audio_output *audio, size_t mix_idx,
 
 		struct obs_encoder *encoder = input->param;
 		if (encoder && encoder->video &&
-		    encoder->video->ovi != obs_get_audio_rendering_canvas()) {
+		    encoder->video->canvas_ovi != obs_get_audio_rendering_canvas()) {
 			continue;
 		}
 		float(*buf)[AUDIO_OUTPUT_FRAMES] =

--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -241,8 +241,12 @@ static void maybe_set_up_gpu_rescale(struct obs_encoder *encoder)
 		const struct video_output_info *voi = video_output_get_info(current->video);
 		if (current_mix->view != current->view)
 			continue;
+		if (current_mix->canvas_ovi != current->canvas_ovi)
+			continue;
+		if (current_mix->rendering_mode != current->rendering_mode)
+			continue;
 
-		if (current->ovi->scale_type != encoder->gpu_scale_type)
+		if (current->ovi.scale_type != encoder->gpu_scale_type)
 			continue;
 
 		if (voi->width != width || voi->height != height)
@@ -262,26 +266,27 @@ static void maybe_set_up_gpu_rescale(struct obs_encoder *encoder)
 	if (!create_mix)
 		return;
 
-	struct obs_video_info *ovi = bzalloc(sizeof(struct obs_video_info));
-	*ovi = *current_mix->ovi;
+	struct obs_video_info ovi = current_mix->ovi;
 
-	ovi->output_format = format;
-	ovi->colorspace = space;
-	ovi->range = range;
+	ovi.output_format = format;
+	ovi.colorspace = space;
+	ovi.range = range;
 
-	ovi->output_height = height;
-	ovi->output_width = width;
-	ovi->scale_type = encoder->gpu_scale_type;
+	ovi.output_height = height;
+	ovi.output_width = width;
+	ovi.scale_type = encoder->gpu_scale_type;
 
-	ovi->gpu_conversion = true;
+	ovi.gpu_conversion = true;
 
-	mix = obs_create_video_mix(ovi);
+	mix = obs_create_video_mix(&ovi);
 	if (!mix)
 		return;
 
 	mix->encoder_only_mix = true;
 	mix->encoder_refs = 1;
+	mix->canvas_ovi = current_mix->canvas_ovi;
 	mix->view = current_mix->view;
+	mix->rendering_mode = current_mix->rendering_mode;
 
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 
@@ -291,8 +296,12 @@ static void maybe_set_up_gpu_rescale(struct obs_encoder *encoder)
 		const struct video_output_info *voi = video_output_get_info(current->video);
 		if (current->view != current_mix->view)
 			continue;
+		if (current->canvas_ovi != current_mix->canvas_ovi)
+			continue;
+		if (current->rendering_mode != current_mix->rendering_mode)
+			continue;
 
-		if (current->ovi->scale_type != encoder->gpu_scale_type)
+		if (current->ovi.scale_type != encoder->gpu_scale_type)
 			continue;
 
 		if (voi->width != width || voi->height != height)
@@ -301,6 +310,7 @@ static void maybe_set_up_gpu_rescale(struct obs_encoder *encoder)
 		if (voi->format != format || voi->colorspace != space || voi->range != range)
 			continue;
 
+		current->encoder_refs += 1;
 		obs_encoder_set_video(encoder, current->video);
 		create_mix = false;
 		break;

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -538,8 +538,7 @@ struct obs_core {
 	/* Active mix for the current render pass. */
 	struct obs_core_video_mix *video_rendering_mix;
 
-	struct obs_video_info *video_rendering_canvas;
-	struct obs_video_info *audio_rendering_canvas;
+	struct obs_video_info *audio_rendering_canvas; /* Canonical canvas identity for the current audio render context. */
 
 	os_task_queue_t *destruction_task_thread;
 
@@ -575,8 +574,8 @@ extern void cache_multiple_rendering(void);
 extern bool get_cached_multiple_rendering(void);
 
 extern struct obs_core_video_mix *get_mix_for_video(video_t *video);
-/* Use during an active mix render pass to set both the snapshot and canonical canvas context. */
-extern void obs_set_video_rendering_mix(struct obs_core_video_mix *mix);
+/* Use to set the active video render context for the current render pass. */
+extern void obs_set_video_render_context(struct obs_core_video_mix *mix);
 
 extern void start_raw_video(video_t *video, const struct video_scale_info *conversion, uint32_t frame_rate_divisor,
 			    void (*callback)(void *param, struct video_data *frame), void *param);

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -535,10 +535,11 @@ struct obs_core {
 	enum obs_video_rendering_mode video_rendering_mode;
 	enum obs_audio_rendering_mode audio_rendering_mode;
 
-	/* Active mix for the current render pass. */
+	/* Active mix for the current video render pass. */
 	struct obs_core_video_mix *video_rendering_mix;
 
-	struct obs_video_info *audio_rendering_canvas; /* Canonical canvas identity for the current audio render context. */
+	/* Canvas identity for the current audio render context. */
+	struct obs_video_info *audio_rendering_canvas;
 
 	os_task_queue_t *destruction_task_thread;
 

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -575,6 +575,7 @@ extern void cache_multiple_rendering(void);
 extern bool get_cached_multiple_rendering(void);
 
 extern struct obs_core_video_mix *get_mix_for_video(video_t *video);
+/* Use during an active mix render pass to set both the snapshot and canonical canvas context. */
 extern void obs_set_video_rendering_mix(struct obs_core_video_mix *mix);
 
 extern void start_raw_video(video_t *video, const struct video_scale_info *conversion, uint32_t frame_rate_divisor,

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -316,7 +316,8 @@ struct obs_core_video_mix {
 	bool gpu_want_destroy_thread;
 
 	video_t *video;
-	struct obs_video_info *ovi;
+	struct obs_video_info ovi;         /* Mix-local render settings. */
+	struct obs_video_info *canvas_ovi; /* Stable public canvas identity for lookups/routing. */
 	enum obs_video_rendering_mode rendering_mode;
 
 	bool gpu_conversion;
@@ -394,7 +395,7 @@ struct audio_monitor;
 
 struct obs_core_audio {
 	audio_t *audio;
-	/* These 3 values are not present in the original OBS code. They serve as a main audio parameters cache, 
+	/* These 3 values are not present in the original OBS code. They serve as a main audio parameters cache,
 	 * allowing audio processing to finish the current iteration even if the global audio object has been destroyed. */
 	uint32_t samples_per_sec;
 	enum speaker_layout speakers;
@@ -533,6 +534,10 @@ struct obs_core {
 	enum obs_replay_buffer_rendering_mode replay_buffer_rendering_mode;
 	enum obs_video_rendering_mode video_rendering_mode;
 	enum obs_audio_rendering_mode audio_rendering_mode;
+
+	/* Active mix for the current render pass. */
+	struct obs_core_video_mix *video_rendering_mix;
+
 	struct obs_video_info *video_rendering_canvas;
 	struct obs_video_info *audio_rendering_canvas;
 
@@ -570,6 +575,7 @@ extern void cache_multiple_rendering(void);
 extern bool get_cached_multiple_rendering(void);
 
 extern struct obs_core_video_mix *get_mix_for_video(video_t *video);
+extern void obs_set_video_rendering_mix(struct obs_core_video_mix *mix);
 
 extern void start_raw_video(video_t *video, const struct video_scale_info *conversion, uint32_t frame_rate_divisor,
 			    void (*callback)(void *param, struct video_data *frame), void *param);

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -620,17 +620,8 @@ static void update_item_transform(struct obs_scene_item *item, bool update_tex)
 	/* Reset bounds crop */
 	memset(&item->bounds_crop, 0, sizeof(item->bounds_crop));
 
-	// TODO: this code seems to do nothing and can be safely removed
-	// struct obs_video_info *saved_canvas = NULL;
-	// if (item->canvas) {
-	// 	saved_canvas = obs_get_video_rendering_canvas();
-	// 	obs_set_video_rendering_canvas(item->canvas);
-	// }
 	width = obs_source_get_width(item->source);
 	height = obs_source_get_height(item->source);
-	// if (saved_canvas)
-	// 	obs_set_video_rendering_canvas(saved_canvas);
-
 
 	/* Adjust crop on nested scenes (if any) */
 	if (update_tex && item->is_scene)
@@ -1086,10 +1077,12 @@ static void scene_video_render(void *data, gs_effect_t *effect)
 	gs_blend_state_push();
 	gs_reset_blend_state();
 
+	struct obs_video_info *render_canvas = obs && obs->video_rendering_mix
+						       ? obs->video_rendering_mix->canvas_ovi
+						       : NULL;
 	item = scene->first_item;
 	while (item) {
-		if (obs_get_video_rendering_canvas() != item->canvas &&
-		    item->canvas != NULL) {
+		if (render_canvas != item->canvas && item->canvas != NULL) {
 			item = item->next;
 			continue;
 		}

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -347,8 +347,8 @@ static inline void get_scene_dimensions(const obs_sceneitem_t *item, float *x, f
 {
 	obs_scene_t *parent = item->parent;
 	if (!parent || (parent->is_group && !parent->source->canvas)) {
-		*x = (float)obs->data.main_canvas->mix->ovi->base_width;
-		*y = (float)obs->data.main_canvas->mix->ovi->base_height;
+		*x = (float)obs->data.main_canvas->mix->ovi.base_width;
+		*y = (float)obs->data.main_canvas->mix->ovi.base_height;
 	} else if (parent->is_group) {
 		*x = (float)canvas_getwidth(parent->source->canvas);
 		*y = (float)canvas_getheight(parent->source->canvas);

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -141,8 +141,8 @@ static inline bool can_reuse_mix_texture(const struct obs_core_video_mix *mix, s
 			continue;
 		if (other->render_space != mix->render_space)
 			continue;
-		if (other->ovi->base_width != mix->ovi->base_width ||
-		    other->ovi->base_height != mix->ovi->base_height)
+		if (other->ovi.base_width != mix->ovi.base_width ||
+		    other->ovi.base_height != mix->ovi.base_height)
 			continue;
 		if (!other->texture_rendered)
 			continue;
@@ -179,15 +179,13 @@ static inline void render_main_texture(struct obs_core_video_mix *video)
 	gs_set_render_target_with_color_space(video->render_texture, NULL, video->render_space);
 	gs_clear(GS_CLEAR_COLOR, &clear_color, 1.0f, 0);
 
-	set_render_size(video->ovi->base_width, video->ovi->base_height);
+	set_render_size(video->ovi.base_width, video->ovi.base_height);
 
 	pthread_mutex_lock(&obs->data.draw_callbacks_mutex);
 
 	for (size_t i = obs->data.draw_callbacks.num; i > 0; i--) {
-		struct draw_callback *const callback =
-			obs->data.draw_callbacks.array + (i - 1);
-		callback->draw(callback->param, video->ovi->base_width,
-			       video->ovi->base_height);
+		struct draw_callback *const callback = obs->data.draw_callbacks.array + (i - 1);
+		callback->draw(callback->param, video->ovi.base_width, video->ovi.base_height);
 	}
 
 	pthread_mutex_unlock(&obs->data.draw_callbacks_mutex);
@@ -224,12 +222,12 @@ static inline gs_effect_t *get_scale_effect_internal(struct obs_core_video_mix *
 	/* if the dimension is under half the size of the original image,
 	 * bicubic/lanczos can't sample enough pixels to create an accurate
 	 * image, so use the bilinear low resolution effect instead */
-	if (info->width < (mix->ovi->base_width / 2) &&
-	    info->height < (mix->ovi->base_height / 2)) {
+	if (info->width < (mix->ovi.base_width / 2) &&
+	    info->height < (mix->ovi.base_height / 2)) {
 		return video->bilinear_lowres_effect;
 	}
 
-	switch (mix->ovi->scale_type) {
+	switch (mix->ovi.scale_type) {
 	case OBS_SCALE_BILINEAR:
 		return video->default_effect;
 	case OBS_SCALE_LANCZOS:
@@ -246,8 +244,8 @@ static inline gs_effect_t *get_scale_effect_internal(struct obs_core_video_mix *
 static inline bool resolution_close(struct obs_core_video_mix *video,
 				    uint32_t width, uint32_t height)
 {
-	long width_cmp = (long)video->ovi->base_width - (long)width;
-	long height_cmp = (long)video->ovi->base_height - (long)height;
+	long width_cmp = (long)video->ovi.base_width - (long)width;
+	long height_cmp = (long)video->ovi.base_height - (long)height;
 
 	return labs(width_cmp) <= 16 && labs(height_cmp) <= 16;
 }
@@ -276,8 +274,7 @@ static gs_texture_t *render_output_texture(struct obs_core_video_mix *mix)
 	uint32_t width = gs_texture_get_width(target);
 	uint32_t height = gs_texture_get_height(target);
 
-	if ((width == mix->ovi->base_width) &&
-	    (height == mix->ovi->base_height))
+	if ((width == mix->ovi.base_width) && (height == mix->ovi.base_height))
 		return texture;
 
 	profile_start(render_output_texture_name);
@@ -295,15 +292,13 @@ static gs_texture_t *render_output_texture(struct obs_core_video_mix *mix)
 
 	if (bres) {
 		struct vec2 base;
-		vec2_set(&base, (float)mix->ovi->base_width,
-			 (float)mix->ovi->base_height);
+		vec2_set(&base, (float)mix->ovi.base_width, (float)mix->ovi.base_height);
 		gs_effect_set_vec2(bres, &base);
 	}
 
 	if (bres_i) {
 		struct vec2 base_i;
-		vec2_set(&base_i, 1.0f / (float)mix->ovi->base_width,
-			 1.0f / (float)mix->ovi->base_height);
+		vec2_set(&base_i, 1.0f / (float)mix->ovi.base_width, 1.0f / (float)mix->ovi.base_height);
 		gs_effect_set_vec2(bres_i, &base_i);
 	}
 
@@ -883,7 +878,7 @@ static inline void output_frame(struct obs_core_video_mix *video)
 	else
 		return;
 
-	obs_set_video_rendering_canvas(video->ovi);
+	obs_set_video_rendering_mix(video);
 
 	const bool raw_active = video->raw_was_active;
 	const bool gpu_active = video->gpu_was_active;

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -878,7 +878,7 @@ static inline void output_frame(struct obs_core_video_mix *video)
 	else
 		return;
 
-	obs_set_video_rendering_mix(video);
+	obs_set_video_render_context(video);
 
 	const bool raw_active = video->raw_was_active;
 	const bool gpu_active = video->gpu_was_active;

--- a/libobs/obs-view.c
+++ b/libobs/obs-view.c
@@ -143,7 +143,8 @@ void obs_view_render(obs_view_t *view)
 static inline size_t find_mix_for_view(obs_view_t *view)
 {
 	for (size_t i = 0, num = obs->video.mixes.num; i < num; i++) {
-		if (obs->video.mixes.array[i]->view == view)
+		if (obs->video.mixes.array[i]->view == view &&
+		    !obs->video.mixes.array[i]->encoder_only_mix)
 			return i;
 	}
 
@@ -154,7 +155,7 @@ video_t *obs_view_add(obs_view_t *view)
 {
 	if (!obs->data.main_canvas->mix)
 		return NULL;
-	return obs_view_add2(view, obs->data.main_canvas->mix->ovi);
+	return obs_view_add2(view, obs->data.main_canvas->mix->canvas_ovi);
 }
 
 video_t *obs_view_add2(obs_view_t *view, struct obs_video_info *ovi)
@@ -239,7 +240,9 @@ void obs_view_enum_video_info(obs_view_t *view, bool (*enum_proc)(void *, struct
 		struct obs_core_video_mix *mix = obs->video.mixes.array[i];
 		if (mix->view != view)
 			continue;
-		if (!enum_proc(param, mix->ovi))
+		if (mix->encoder_only_mix)
+			continue;
+		if (!enum_proc(param, mix->canvas_ovi))
 			break;
 	}
 
@@ -255,7 +258,7 @@ bool obs_view_get_video_info(obs_view_t *view, struct obs_video_info *ovi)
 
 	size_t idx = find_mix_for_view(view);
 	if (idx != DARRAY_INVALID) {
-		*ovi = *(obs->video.mixes.array[idx]->ovi);
+		*ovi = obs->video.mixes.array[idx]->ovi;
 		pthread_mutex_unlock(&obs->video.mixes_mutex);
 		return true;
 	}

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -2914,23 +2914,25 @@ struct obs_video_info *obs_get_audio_rendering_canvas(void)
 	return obs ? obs->audio_rendering_canvas : NULL;
 }
 
-void obs_set_video_rendering_canvas(struct obs_video_info *ovi)
-{
-	if (!obs)
-		return;
-
-	// blog(LOG_INFO, "obs_set_video_rendering_canvas - canvas (ovi): 0x%"PRIXPTR, (uintptr_t)ovi);
-	obs->video_rendering_mix = NULL;
-	obs->video_rendering_canvas = ovi;
-}
-
-void obs_set_video_rendering_mix(struct obs_core_video_mix *mix)
+static inline void obs_set_video_render_context(struct obs_core_video_mix *mix,
+						struct obs_video_info *canvas)
 {
 	if (!obs)
 		return;
 
 	obs->video_rendering_mix = mix;
-	obs->video_rendering_canvas = mix ? mix->canvas_ovi : NULL;
+	obs->video_rendering_canvas = mix ? mix->canvas_ovi : canvas;
+}
+
+void obs_set_video_rendering_canvas(struct obs_video_info *ovi)
+{
+	// blog(LOG_INFO, "obs_set_video_rendering_canvas - canvas (ovi): 0x%"PRIXPTR, (uintptr_t)ovi);
+	obs_set_video_render_context(NULL, ovi);
+}
+
+void obs_set_video_rendering_mix(struct obs_core_video_mix *mix)
+{
+	obs_set_video_render_context(mix, NULL);
 }
 
 struct obs_video_info *obs_get_video_rendering_canvas(void)

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -434,7 +434,7 @@ static bool obs_init_textures(struct obs_core_video_mix *video)
 		break;
 	}
 
-	struct obs_video_info *ovi = video->ovi;
+	struct obs_video_info *ovi = &video->ovi;
 	video->render_texture = gs_texture_create(ovi->base_width,
 						  ovi->base_height, format, 1,
 						  NULL, GS_RENDER_TARGET);
@@ -623,16 +623,16 @@ static int obs_init_video_mix(struct obs_video_info *ovi, struct obs_core_video_
 	pthread_mutex_init_value(&video->gpu_encoder_mutex);
 
 	make_video_info(&vi, ovi);
-	video->ovi = ovi;
+	video->ovi = *ovi;
 
 	/* main view graphics thread drives all frame output,
 	 * so share FPS settings for aux views */
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 	size_t num = obs->video.mixes.num;
 	if (num && obs->data.main_canvas->mix) {
-		struct obs_video_info main_ovi = *obs->data.main_canvas->mix->ovi;
-		video->ovi->fps_num = main_ovi.fps_num;
-		video->ovi->fps_den = main_ovi.fps_den;
+		struct obs_video_info main_ovi = obs->data.main_canvas->mix->ovi;
+		video->ovi.fps_num = main_ovi.fps_num;
+		video->ovi.fps_den = main_ovi.fps_den;
 	}
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
 
@@ -673,7 +673,7 @@ struct obs_core_video_mix *obs_create_video_mix(struct obs_video_info *ovi)
 {
 	struct obs_core_video_mix *video =
 		bzalloc(sizeof(struct obs_core_video_mix));
-	video->ovi = ovi;
+	video->canvas_ovi = ovi;
 	if (obs_init_video_mix(ovi, video) != OBS_VIDEO_SUCCESS) {
 		bfree(video);
 		video = NULL;
@@ -864,6 +864,9 @@ static void obs_free_render_textures(struct obs_core_video_mix *video)
 
 void obs_free_video_mix(struct obs_core_video_mix *video)
 {
+	if (obs && obs->video_rendering_mix == video)
+		obs->video_rendering_mix = NULL;
+
 	if (video->video) {
 		video_output_close(video->video);
 		video->video = NULL;
@@ -1847,9 +1850,17 @@ bool obs_reset_audio(const struct obs_audio_info *oai)
 
 bool obs_get_video_info_current(struct obs_video_info *ovi)
 {
-	if (!obs->video.graphics || !obs->video_rendering_canvas || !ovi) {
+	if (!obs->video.graphics || !ovi) {
 		return false;
 	}
+
+	if (obs->video_rendering_mix) {
+		*ovi = obs->video_rendering_mix->ovi;
+		return true;
+	}
+
+	if (!obs->video_rendering_canvas)
+		return false;
 
 	*ovi = *(obs->video_rendering_canvas);
 
@@ -1885,17 +1896,16 @@ bool obs_get_video_info_for_output(obs_output_t *output,
 					      ovi);
 }
 
-bool obs_get_video_info_for_encoder(obs_encoder_t *encoder,
-				    struct obs_video_info *ovi)
+bool obs_get_video_info_for_encoder(obs_encoder_t *encoder, struct obs_video_info *ovi)
 {
 	blog(LOG_INFO, "[VIDEO_CANVAS] video info requested for encoder");
 	if (!encoder || !encoder->video || !ovi)
 		return false;
 	struct obs_core_video_mix *video = encoder->video;
-	if (!video || !video->ovi)
+	if (!video)
 		return false;
 
-	*ovi = *(video->ovi);
+	*ovi = video->ovi;
 
 	return true;
 }
@@ -2857,7 +2867,9 @@ obs_core_video_mix_t *obs_video_mix_get(struct obs_video_info *ovi,
 	// As this canvas is unused, we can safely skip it.
 	for (size_t i = 1, num = obs->video.mixes.num; i < num; i++) {
 		struct obs_core_video_mix *mix = obs->video.mixes.array[i];
-		if ((mix->ovi == ovi || ovi == NULL) &&
+		if (!mix || mix->encoder_only_mix)
+			continue;
+		if ((mix->canvas_ovi == ovi || ovi == NULL) &&
 		    mix->rendering_mode == mode)
 			return mix;
 	}
@@ -2908,7 +2920,17 @@ void obs_set_video_rendering_canvas(struct obs_video_info *ovi)
 		return;
 
 	// blog(LOG_INFO, "obs_set_video_rendering_canvas - canvas (ovi): 0x%"PRIXPTR, (uintptr_t)ovi);
+	obs->video_rendering_mix = NULL;
 	obs->video_rendering_canvas = ovi;
+}
+
+void obs_set_video_rendering_mix(struct obs_core_video_mix *mix)
+{
+	if (!obs)
+		return;
+
+	obs->video_rendering_mix = mix;
+	obs->video_rendering_canvas = mix ? mix->canvas_ovi : NULL;
 }
 
 struct obs_video_info *obs_get_video_rendering_canvas(void)

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1850,19 +1850,11 @@ bool obs_reset_audio(const struct obs_audio_info *oai)
 
 bool obs_get_video_info_current(struct obs_video_info *ovi)
 {
-	if (!obs->video.graphics || !ovi) {
+	if (!obs->video.graphics || !ovi || !obs->video_rendering_mix) {
 		return false;
 	}
 
-	if (obs->video_rendering_mix) {
-		*ovi = obs->video_rendering_mix->ovi;
-		return true;
-	}
-
-	if (!obs->video_rendering_canvas)
-		return false;
-
-	*ovi = *(obs->video_rendering_canvas);
+	*ovi = obs->video_rendering_mix->ovi;
 
 	return true;
 }
@@ -1939,7 +1931,6 @@ int obs_remove_video_info(struct obs_video_info *ovi)
 		if (obs->video.canvases.array[i] == ovi) {
 			bfree(obs->video.canvases.array[i]);
 			da_erase(obs->video.canvases, i);
-			obs_set_video_rendering_canvas(NULL);
 			break;
 		}
 	}
@@ -2914,30 +2905,12 @@ struct obs_video_info *obs_get_audio_rendering_canvas(void)
 	return obs ? obs->audio_rendering_canvas : NULL;
 }
 
-static inline void obs_set_video_render_context(struct obs_core_video_mix *mix,
-						struct obs_video_info *canvas)
+void obs_set_video_render_context(struct obs_core_video_mix *mix)
 {
 	if (!obs)
 		return;
 
 	obs->video_rendering_mix = mix;
-	obs->video_rendering_canvas = mix ? mix->canvas_ovi : canvas;
-}
-
-void obs_set_video_rendering_canvas(struct obs_video_info *ovi)
-{
-	// blog(LOG_INFO, "obs_set_video_rendering_canvas - canvas (ovi): 0x%"PRIXPTR, (uintptr_t)ovi);
-	obs_set_video_render_context(NULL, ovi);
-}
-
-void obs_set_video_rendering_mix(struct obs_core_video_mix *mix)
-{
-	obs_set_video_render_context(mix, NULL);
-}
-
-struct obs_video_info *obs_get_video_rendering_canvas(void)
-{
-	return obs ? obs->video_rendering_canvas : NULL;
 }
 
 void obs_set_replay_buffer_rendering_mode(

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -616,25 +616,37 @@ static inline void set_video_matrix(struct obs_core_video_mix *video, struct vid
 	memcpy(video->color_matrix, &mat, sizeof(float) * 16);
 }
 
+static void sync_mix_fps_with_main_canvas(struct obs_core_video_mix *video)
+{
+	/* Main view graphics thread drives frame pacing for all views. Keep the
+	 * mix snapshot and the public canvas handle aligned for callers that
+	 * still read fps_num/fps_den from obs_video_info. */
+	pthread_mutex_lock(&obs->video.mixes_mutex);
+
+	if (obs->video.mixes.num && obs->data.main_canvas->mix) {
+		const struct obs_video_info *main_ovi = &obs->data.main_canvas->mix->ovi;
+
+		video->ovi.fps_num = main_ovi->fps_num;
+		video->ovi.fps_den = main_ovi->fps_den;
+
+		if (video->canvas_ovi) {
+			video->canvas_ovi->fps_num = main_ovi->fps_num;
+			video->canvas_ovi->fps_den = main_ovi->fps_den;
+		}
+	}
+
+	pthread_mutex_unlock(&obs->video.mixes_mutex);
+}
+
 static int obs_init_video_mix(struct obs_video_info *ovi, struct obs_core_video_mix *video)
 {
 	struct video_output_info vi;
 
 	pthread_mutex_init_value(&video->gpu_encoder_mutex);
 
-	make_video_info(&vi, ovi);
 	video->ovi = *ovi;
-
-	/* main view graphics thread drives all frame output,
-	 * so share FPS settings for aux views */
-	pthread_mutex_lock(&obs->video.mixes_mutex);
-	size_t num = obs->video.mixes.num;
-	if (num && obs->data.main_canvas->mix) {
-		struct obs_video_info main_ovi = obs->data.main_canvas->mix->ovi;
-		video->ovi.fps_num = main_ovi.fps_num;
-		video->ovi.fps_den = main_ovi.fps_den;
-	}
-	pthread_mutex_unlock(&obs->video.mixes_mutex);
+	sync_mix_fps_with_main_canvas(video);
+	make_video_info(&vi, &video->ovi);
 
 	video->gpu_conversion = ovi->gpu_conversion;
 	video->gpu_was_active = false;

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -875,9 +875,8 @@ EXPORT enum obs_audio_rendering_mode obs_get_audio_rendering_mode(void);
 EXPORT struct obs_video_info *obs_get_audio_rendering_canvas(void);
 EXPORT void obs_set_audio_rendering_canvas(struct obs_video_info *ovi);
 
-/** Sets/Gets the video rendering canvas for manual/fallback rendering when no mix is active. */
-EXPORT void obs_set_video_rendering_canvas(struct obs_video_info *ovi);
-EXPORT struct obs_video_info *obs_get_video_rendering_canvas(void);
+/** Sets the active video render context for the current render pass. */
+EXPORT void obs_set_video_render_context(obs_core_video_mix_t *mix);
 
 /** Set the replay buffer rendering mode*/
 EXPORT void obs_set_replay_buffer_rendering_mode(

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -875,7 +875,7 @@ EXPORT enum obs_audio_rendering_mode obs_get_audio_rendering_mode(void);
 EXPORT struct obs_video_info *obs_get_audio_rendering_canvas(void);
 EXPORT void obs_set_audio_rendering_canvas(struct obs_video_info *ovi);
 
-/** Sets/Gets current video rendering canvas*/
+/** Sets/Gets the video rendering canvas for manual/fallback rendering when no mix is active. */
 EXPORT void obs_set_video_rendering_canvas(struct obs_video_info *ovi);
 EXPORT struct obs_video_info *obs_get_video_rendering_canvas(void);
 


### PR DESCRIPTION
💡 This is an alternative way to fix the https://github.com/streamlabs/obs-studio/pull/719 (obs_video_info: add a parent_ovi pointer)

### Description
Fixed enhanced broadcasting black screen for secondary resolutions.

### Motivation and Context
Encoder-only GPU-rescale mixes need their own `obs_video_info` values for output size, format, colorspace, range, and scale settings, but they still need to behave like the original canvas when scene items are filtered by canvas. Reusing a single `mix->ovi` pointer for both jobs caused canvas-pinned items to be skipped, which could result in black frames being sent to the encoder.

To fix that, `obs_core_video_mix` now stores:

- `ovi` by value as the mix-local render snapshot
- `canvas_ovi` as the stable public canvas identity

The rest of the patch updates the render pipeline to use those fields for their intended purposes. This change also removes the old canvas-only render-context API. Rendering is now mix-based end to end:
- `obs_set_video_rendering_canvas()` was removed
- `obs_get_video_rendering_canvas()` was removed
- `obs_set_video_render_context(obs_core_video_mix_t *mix)` is now the only video render-context setter
- scene-item canvas filtering reads the required canvas from the active render mix

Additionally, we now store the `obs_video_info` by value like it does upstream OBS.

### How Has This Been Tested?
Manually, Windows only.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 
