### PR TITLE
Fix text gdiplus objects lifetime

### DIFF
--- a/plugins/obs-text/gdiplus/obs-text.cpp
+++ b/plugins/obs-text/gdiplus/obs-text.cpp
@@ -2,6 +2,7 @@
 #include <util/platform.h>
 #include <util/util.hpp>
 #include <obs-module.h>
+#include <obs.hpp>
 #include <sys/stat.h>
 #include <combaseapi.h>
 #include <gdiplus.h>
@@ -156,37 +157,19 @@ static inline uint32_t rgb_to_bgr(uint32_t rgb)
 }
 
 /* ------------------------------------------------------------------------- */
+// This helper is needed because OBSRefAutoRelease in unhappy about WinAPI functions as deleters
+template<typename H, typename ReleaseArg, BOOL(WINAPI *ReleaseFunc)(ReleaseArg)>
+static void release_win_handle(H handle)
+{
+	if (handle)
+		ReleaseFunc((ReleaseArg)handle);
+}
 
-template<typename T, typename T2, BOOL WINAPI deleter(T2)> class GDIObj {
-	T obj = nullptr;
+template<typename T, typename ReleaseArg, BOOL(WINAPI *ReleaseFunc)(ReleaseArg)>
+using WinHandleAutoRelease = OBSRefAutoRelease<T, release_win_handle<T, ReleaseArg, ReleaseFunc>>;
 
-	inline GDIObj &Replace(T obj_)
-	{
-		if (obj)
-			deleter(obj);
-		obj = obj_;
-		return *this;
-	}
-
-public:
-	inline GDIObj() {}
-	inline GDIObj(T obj_) : obj(obj_) {}
-	inline ~GDIObj() { deleter(obj); }
-
-	inline T operator=(T obj_)
-	{
-		Replace(obj_);
-		return obj;
-	}
-
-	inline operator T() const { return obj; }
-
-	inline bool operator==(T obj_) const { return obj == obj_; }
-	inline bool operator!=(T obj_) const { return obj != obj_; }
-};
-
-using HDCObj = GDIObj<HDC, HDC, DeleteDC>;
-using HFONTObj = GDIObj<HFONT, HGDIOBJ, DeleteObject>;
+using HDCAutoRelease = WinHandleAutoRelease<HDC, HDC, ::DeleteDC>;
+using HFONTAutoRelease = WinHandleAutoRelease<HFONT, HGDIOBJ, ::DeleteObject>;
 
 /* ------------------------------------------------------------------------- */
 
@@ -209,13 +192,14 @@ struct TextSource {
 	uint32_t cx = 0;
 	uint32_t cy = 0;
 
-	HDCObj hdc;
+	HDCAutoRelease hdc;
 	Graphics graphics;
 
 	unique_ptr<PrivateFontCollection> private_fonts;
-	HFONTObj hfont;
+	HFONTAutoRelease hfont;
 	unique_ptr<Font> font;
 	string custom_font_path;
+	time_t custom_font_timestamp = 0;
 
 	bool read_from_file = false;
 	string file;
@@ -833,11 +817,31 @@ inline void TextSource::Update(obs_data_t *s)
 	/* ----------------------------- */
 	string new_custom_font = custom_font_str ? custom_font_str : "";
 	wstring new_face = to_wide(font_face);
+	time_t new_custom_font_timestamp = 0;
 
-	if (new_face != face || face_size != font_size || new_bold != bold ||
-	    new_italic != italic || new_underline != underline ||
-	    new_strikeout != strikeout ||
-	    new_custom_font != custom_font_path) {
+	if (!new_custom_font.empty())
+		new_custom_font_timestamp =
+			get_modified_timestamp(new_custom_font.c_str());
+
+	bool font_settings_changed = new_face != face ||
+				     face_size != font_size ||
+				     new_bold != bold ||
+				     new_italic != italic ||
+				     new_underline != underline ||
+				     new_strikeout != strikeout ||
+				     new_custom_font != custom_font_path;
+	bool custom_font_file_changed =
+		!new_custom_font.empty() &&
+		new_custom_font == custom_font_path &&
+		new_custom_font_timestamp != custom_font_timestamp;
+	bool retry_custom_font =
+		!new_custom_font.empty() &&
+		new_custom_font == custom_font_path &&
+		!private_fonts &&
+		new_custom_font_timestamp != -1;
+
+	if (font_settings_changed || custom_font_file_changed ||
+	    retry_custom_font) {
 		face = new_face;
 		face_size = font_size;
 		bold = new_bold;
@@ -845,6 +849,7 @@ inline void TextSource::Update(obs_data_t *s)
 		underline = new_underline;
 		strikeout = new_strikeout;
 		custom_font_path = new_custom_font;
+		custom_font_timestamp = new_custom_font_timestamp;
 
 		if (!custom_font_path.empty()) {
 			UpdateCustomFont(to_wide(custom_font_path.c_str()).c_str());

--- a/plugins/obs-text/gdiplus/obs-text.cpp
+++ b/plugins/obs-text/gdiplus/obs-text.cpp
@@ -646,30 +646,46 @@ void TextSource::RenderText()
 	if (!text.empty()) {
 		if (use_outline) {
 			box.Offset(outline_size / 2, outline_size / 2);
-
-			FontFamily family;
+			bool rendered_outline = false;
 			GraphicsPath path;
 
-			stat = font->GetFamily(&family);
-			warn_stat("font->GetFamily");
+			if (!custom_font_path.empty() && private_fonts) {
+				FontFamily family(face.c_str(), private_fonts.get());
+				stat = family.GetLastStatus();
+				warn_stat("FontFamily(custom)");
 
-			if (stat == Ok) {
-				stat = path.AddString(text.c_str(), (int)text.size(),
-						      &family, font->GetStyle(),
-						      font->GetSize(), box,
-						      &format);
-				warn_stat("path.AddString");
+				if (stat == Ok && family.IsAvailable()) {
+					stat = path.AddString(
+						text.c_str(), (int)text.size(), &family,
+						font->GetStyle(), font->GetSize(), box, &format);
+					warn_stat("path.AddString");
 
-				if (stat == Ok)
-					RenderOutlineText(graphics_bitmap, path,
-							  brush);
+					if (stat == Ok) {
+						RenderOutlineText(graphics_bitmap, path, brush);
+						rendered_outline = true;
+					}
+				}
+			} else {
+				FontFamily family;
+				stat = font->GetFamily(&family);
+				warn_stat("font->GetFamily");
+
+				if (stat == Ok) {
+					stat = path.AddString(
+						text.c_str(), (int)text.size(), &family,
+						font->GetStyle(), font->GetSize(), box, &format);
+					warn_stat("path.AddString");
+
+					if (stat == Ok) {
+						RenderOutlineText(graphics_bitmap, path, brush);
+						rendered_outline = true;
+					}
+				}
 			}
 
-			if (stat != Ok) {
-				stat = graphics_bitmap.DrawString(text.c_str(),
-								  (int)text.size(),
-								  font.get(), box,
-								  &format, &brush);
+			if (!rendered_outline) {
+				stat = graphics_bitmap.DrawString(
+					text.c_str(), (int)text.size(), font.get(), box, &format, &brush);
 				warn_stat("graphics_bitmap.DrawString");
 			}
 		} else {

--- a/plugins/obs-text/gdiplus/obs-text.cpp
+++ b/plugins/obs-text/gdiplus/obs-text.cpp
@@ -157,6 +157,39 @@ static inline uint32_t rgb_to_bgr(uint32_t rgb)
 
 /* ------------------------------------------------------------------------- */
 
+template<typename T, typename T2, BOOL WINAPI deleter(T2)> class GDIObj {
+	T obj = nullptr;
+
+	inline GDIObj &Replace(T obj_)
+	{
+		if (obj)
+			deleter(obj);
+		obj = obj_;
+		return *this;
+	}
+
+public:
+	inline GDIObj() {}
+	inline GDIObj(T obj_) : obj(obj_) {}
+	inline ~GDIObj() { deleter(obj); }
+
+	inline T operator=(T obj_)
+	{
+		Replace(obj_);
+		return obj;
+	}
+
+	inline operator T() const { return obj; }
+
+	inline bool operator==(T obj_) const { return obj == obj_; }
+	inline bool operator!=(T obj_) const { return obj != obj_; }
+};
+
+using HDCObj = GDIObj<HDC, HDC, DeleteDC>;
+using HFONTObj = GDIObj<HFONT, HGDIOBJ, DeleteObject>;
+
+/* ------------------------------------------------------------------------- */
+
 enum class Align {
 	Left,
 	Center,
@@ -176,14 +209,12 @@ struct TextSource {
 	uint32_t cx = 0;
 	uint32_t cy = 0;
 
-	HDC hdc;
+	HDCObj hdc;
 	Graphics graphics;
 
-	bool custom_font = false;
-	PrivateFontCollection private_fonts;
-	InstalledFontCollection installed_fonts;
-
-	unique_ptr<FontFamily> family;
+	unique_ptr<PrivateFontCollection> private_fonts;
+	HFONTObj hfont;
+	unique_ptr<Font> font;
 
 	bool read_from_file = false;
 	string file;
@@ -240,8 +271,6 @@ struct TextSource {
 
 	inline ~TextSource()
 	{
-		DeleteDC(hdc);
-
 		if (tex) {
 			obs_enter_graphics();
 			gs_texture_destroy(tex);
@@ -252,10 +281,9 @@ struct TextSource {
 	void UpdateFont();
 	void UpdateCustomFont(const wchar_t *font_path);
 	void GetStringFormat(StringFormat &format);
-	void RemoveNewlinePadding(Font *font, const StringFormat &format,
-				  RectF &box);
-	void CalculateTextSizes(Font *font, const StringFormat &format,
-				RectF &bounding_box, SIZE &text_size);
+	void RemoveNewlinePadding(const StringFormat &format, RectF &box);
+	void CalculateTextSizes(const StringFormat &format, RectF &bounding_box,
+				SIZE &text_size);
 	void RenderOutlineText(Graphics &graphics, const GraphicsPath &path,
 			       const Brush &brush);
 	void RenderText();
@@ -280,15 +308,70 @@ static time_t get_modified_timestamp(const char *filename)
 
 void TextSource::UpdateCustomFont(const wchar_t *font_path)
 {
-	private_fonts.AddFontFile(font_path);
+	hfont = nullptr;
+	font.reset(nullptr);
+	private_fonts.reset(nullptr);
 
-	family.reset(new FontFamily(face.c_str(), &private_fonts));
+	unique_ptr<PrivateFontCollection> collection(new PrivateFontCollection());
+	Status stat = collection->GetLastStatus();
+	warn_stat("PrivateFontCollection");
+
+	if (stat != Ok)
+		return;
+
+	stat = collection->AddFontFile(font_path);
+	warn_stat("PrivateFontCollection::AddFontFile");
+
+	if (stat != Ok)
+		return;
+
+	INT style = (underline ? FontStyleUnderline : 0) |
+		    (strikeout ? FontStyleStrikeout : 0) |
+		    (italic ? FontStyleItalic : 0) | (bold ? FontStyleBold : 0);
+
+	font.reset(new Font(face.c_str(), REAL(face_size), style, UnitPixel,
+			    collection.get()));
+	if (!font)
+		return;
+
+	stat = font->GetLastStatus();
+	warn_stat("Font");
+
+	if (stat != Ok || !font->IsAvailable()) {
+		font.reset(nullptr);
+		return;
+	}
+
+	private_fonts = std::move(collection);
 }
 
 void TextSource::UpdateFont()
 {
-	/* We don't spawn a font from this, we use it for metainfo */
-	family.reset(new FontFamily(face.c_str(), &installed_fonts));
+	hfont = nullptr;
+	font.reset(nullptr);
+	private_fonts.reset(nullptr);
+
+	LOGFONT lf = {};
+	lf.lfHeight = face_size;
+	lf.lfWeight = bold ? FW_BOLD : FW_DONTCARE;
+	lf.lfItalic = italic;
+	lf.lfUnderline = underline;
+	lf.lfStrikeOut = strikeout;
+	lf.lfQuality = ANTIALIASED_QUALITY;
+	lf.lfCharSet = DEFAULT_CHARSET;
+
+	if (!face.empty()) {
+		wcscpy(lf.lfFaceName, face.c_str());
+		hfont = CreateFontIndirect(&lf);
+	}
+
+	if (!hfont) {
+		wcscpy(lf.lfFaceName, L"Arial");
+		hfont = CreateFontIndirect(&lf);
+	}
+
+	if (hfont)
+		font.reset(new Font(hdc, hfont));
 }
 
 void TextSource::GetStringFormat(StringFormat &format)
@@ -349,18 +432,18 @@ void TextSource::GetStringFormat(StringFormat &format)
  * calculating the texture size, so we have to calculate the size of '\n' to
  * remove the padding.  Because we always add a newline to the string, we
  * also remove the extra unused newline. */
-void TextSource::RemoveNewlinePadding(Font *font, const StringFormat &format,
-				      RectF &box)
+void TextSource::RemoveNewlinePadding(const StringFormat &format, RectF &box)
 {
 	RectF before;
 	RectF after;
 	Status stat;
 
-	stat = graphics.MeasureString(L"W", 2, font, PointF(0.0f, 0.0f),
+	stat = graphics.MeasureString(L"W", 2, font.get(), PointF(0.0f, 0.0f),
 				      &format, &before);
 	warn_stat("MeasureString (without newline)");
 
-	stat = graphics.MeasureString(L"W\n", 3, font, PointF(0.0f, 0.0f),
+	stat = graphics.MeasureString(L"W\n", 3, font.get(),
+				      PointF(0.0f, 0.0f),
 				      &format, &after);
 	warn_stat("MeasureString (with newline)");
 
@@ -389,7 +472,7 @@ void TextSource::RemoveNewlinePadding(Font *font, const StringFormat &format,
 	box.Height -= offset_cy;
 }
 
-void TextSource::CalculateTextSizes(Font *font, const StringFormat &format,
+void TextSource::CalculateTextSizes(const StringFormat &format,
 				    RectF &bounding_box, SIZE &text_size)
 {
 	RectF layout_box;
@@ -407,18 +490,17 @@ void TextSource::CalculateTextSizes(Font *font, const StringFormat &format,
 				layout_box.Height -= outline_size;
 			}
 
-			stat = graphics.MeasureString(text.c_str(),
-						      (int)text.size() + 1,
-						      font, layout_box, &format,
-						      &bounding_box);
+			stat = graphics.MeasureString(text.c_str(), (int)text.size() + 1,
+						      font.get(), layout_box,
+						      &format, &bounding_box);
 			warn_stat("MeasureString (wrapped)");
 
 			temp_box = bounding_box;
 		} else {
-			stat = graphics.MeasureString(text.c_str(),
-						      (int)text.size() + 1,
-						      font, PointF(0.0f, 0.0f),
-						      &format, &bounding_box);
+			stat = graphics.MeasureString(text.c_str(), (int)text.size() + 1,
+						      font.get(),
+						      PointF(0.0f, 0.0f), &format,
+						      &bounding_box);
 			warn_stat("MeasureString (non-wrapped)");
 
 			temp_box = bounding_box;
@@ -426,7 +508,7 @@ void TextSource::CalculateTextSizes(Font *font, const StringFormat &format,
 			bounding_box.X = 0.0f;
 			bounding_box.Y = 0.0f;
 
-			RemoveNewlinePadding(font, format, bounding_box);
+			RemoveNewlinePadding(format, bounding_box);
 
 			if (use_outline) {
 				bounding_box.Width += outline_size;
@@ -521,46 +603,18 @@ void TextSource::RenderText()
 	RectF box;
 	SIZE size;
 
-	std::unique_ptr<Font> font;
-	HFONT hfont = NULL;
-
-	INT style = (underline ? FontStyleUnderline : 0) |
-		    (strikeout ? FontStyleStrikeout : 0) |
-		    (italic ? FontStyleItalic : 0) | (bold ? FontStyleBold : 0);
-
 	if (text_transform == S_TRANSFORM_UPPERCASE)
 		transform(text.begin(), text.end(), text.begin(), towupper);
 	else if (text_transform == S_TRANSFORM_LOWERCASE)
 		transform(text.begin(), text.end(), text.begin(), towlower);
 
-	/* This has gotten a bit messy. FIXME */
-	if (custom_font)
-		font.reset(new Font(family.get(), REAL(face_size), style,
-				    UnitPixel));
-	else {
-		/* I realize that we're not passing emSize here, unlike
-		 * above. Unfortunately, since we passed cell height
-		 * before, we still need to do so now for compatibility */
-		LOGFONT lf = {0};
-		lf.lfHeight = face_size;
-		lf.lfWeight = bold ? FW_BOLD : FW_DONTCARE;
-		lf.lfItalic = italic;
-		lf.lfUnderline = underline;
-		lf.lfStrikeOut = strikeout;
-		lf.lfQuality = ANTIALIASED_QUALITY;
-		lf.lfCharSet = DEFAULT_CHARSET;
-
-		if (!face.empty()) {
-			wcscpy(lf.lfFaceName, face.c_str());
-			hfont = CreateFontIndirectW(&lf);
-		}
-
-		if (hfont)
-			font.reset(new Font(hdc, hfont));
+	if (!font || !font->IsAvailable()) {
+		warning("%s: no usable font is available", __FUNCTION__);
+		return;
 	}
 
 	GetStringFormat(format);
-	CalculateTextSizes(font.get(), format, box, size);
+	CalculateTextSizes(format, box, size);
 
 	unique_ptr<uint8_t[]> bits(new uint8_t[size.cx * size.cy * 4]);
 	Bitmap bitmap(size.cx, size.cy, 4 * size.cx, PixelFormat32bppARGB, bits.get());
@@ -592,14 +646,31 @@ void TextSource::RenderText()
 		if (use_outline) {
 			box.Offset(outline_size / 2, outline_size / 2);
 
+			FontFamily family;
 			GraphicsPath path;
 
-			stat = path.AddString(text.c_str(), (int)text.size(),
-					      family.get(), font->GetStyle(),
-					      font->GetSize(), box, &format);
-			warn_stat("path.AddString");
+			stat = font->GetFamily(&family);
+			warn_stat("font->GetFamily");
 
-			RenderOutlineText(graphics_bitmap, path, brush);
+			if (stat == Ok) {
+				stat = path.AddString(text.c_str(), (int)text.size(),
+						      &family, font->GetStyle(),
+						      font->GetSize(), box,
+						      &format);
+				warn_stat("path.AddString");
+
+				if (stat == Ok)
+					RenderOutlineText(graphics_bitmap, path,
+							  brush);
+			}
+
+			if (stat != Ok) {
+				stat = graphics_bitmap.DrawString(text.c_str(),
+								  (int)text.size(),
+								  font.get(), box,
+								  &format, &brush);
+				warn_stat("graphics_bitmap.DrawString");
+			}
 		} else {
 			stat = graphics_bitmap.DrawString(text.c_str(), (int)text.size(), font.get(), box, &format,
 							  &brush);
@@ -626,8 +697,6 @@ void TextSource::RenderText()
 		gs_texture_set_image(tex, bits.get(), size.cx * 4, false);
 		obs_leave_graphics();
 	}
-
-	DeleteObject(hfont);
 }
 
 const char *TextSource::GetMainString(const char *str)
@@ -755,11 +824,11 @@ inline void TextSource::Update(obs_data_t *s)
 	strikeout = new_strikeout;
 
 	if (strlen(custom_font_str) != 0) {
-		custom_font = true;
 		UpdateCustomFont(to_wide(custom_font_str).c_str());
+		if (!font)
+			UpdateFont();
 	} else {
 		UpdateFont();
-		custom_font = false;
 	}
 
 	/* ----------------------------- */

--- a/plugins/obs-text/gdiplus/obs-text.cpp
+++ b/plugins/obs-text/gdiplus/obs-text.cpp
@@ -215,6 +215,7 @@ struct TextSource {
 	unique_ptr<PrivateFontCollection> private_fonts;
 	HFONTObj hfont;
 	unique_ptr<Font> font;
+	string custom_font_path;
 
 	bool read_from_file = false;
 	string file;
@@ -814,21 +815,28 @@ inline void TextSource::Update(obs_data_t *s)
 	uint32_t new_bk_opacity = obs_data_get_uint32(s, S_BKOPACITY);
 
 	/* ----------------------------- */
+	string new_custom_font = custom_font_str ? custom_font_str : "";
 	wstring new_face = to_wide(font_face);
 
-	face = new_face;
-	face_size = font_size;
-	bold = new_bold;
-	italic = new_italic;
-	underline = new_underline;
-	strikeout = new_strikeout;
+	if (new_face != face || face_size != font_size || new_bold != bold ||
+	    new_italic != italic || new_underline != underline ||
+	    new_strikeout != strikeout ||
+	    new_custom_font != custom_font_path) {
+		face = new_face;
+		face_size = font_size;
+		bold = new_bold;
+		italic = new_italic;
+		underline = new_underline;
+		strikeout = new_strikeout;
+		custom_font_path = new_custom_font;
 
-	if (strlen(custom_font_str) != 0) {
-		UpdateCustomFont(to_wide(custom_font_str).c_str());
-		if (!font)
+		if (!custom_font_path.empty()) {
+			UpdateCustomFont(to_wide(custom_font_path.c_str()).c_str());
+			if (!font)
+				UpdateFont();
+		} else {
 			UpdateFont();
-	} else {
-		UpdateFont();
+		}
 	}
 
 	/* ----------------------------- */


### PR DESCRIPTION
### Description
Ported the safer OBS 32-style GDI+ font lifetime model into `obs-text` and fixed the custom font.

This fixes crashes with the following stack trace:
```
obs-text      +0x01a8d Gdiplus::FontFamily::{dtor} (GdiplusFontFamily.h:113)
obs-text      +0x01a8d std::default_delete<T>::operator() (memory:3309)
obs-text      +0x01a8d std::unique_ptr<T>::{dtor} (memory:3427)
obs-text      +0x01a8d TextSource::~TextSource (obs-text.cpp:254)
w32-pthreads  +0x0529b pthread_mutex_unlock (pthread_mutex_unlock.c:87)
obs-text      +0x052c1 `obs_module_load'::`2'::<T>::<T> (obs-text.cpp:1194)
obs           +0x510e2 obs_source_destroy_defer (obs-source.c:722)
obs           +0x8ec9b tiny_tubular_task_thread (task.c:161)
w32-pthreads  +0x01460 ptw32_threadStart (ptw32_threadStart.c:225)
ucrtbase      +0x037af thread_start<T>
KERNEL32.DLL  +0x2e8d6 BaseThreadInitThunk
ntdll         +0x8c48b RtlUserThreadStart
```

### Motivation and Context
The old code kept GDI+ font-family objects alive across updates and teardown, which was fragile for private/custom fonts and showed up in crashes during source destruction and text editing.

This change replaces the old long-lived `FontFamily` ownership model with stable `Font`/`HFONT`/`PrivateFontCollection` state.

### How Has This Been Tested?
Manually, Windows only.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 