### PR TITLE
 Invalidate stale encoder media on video mix free

### DIFF
--- a/libobs/obs-canvas.c
+++ b/libobs/obs-canvas.c
@@ -268,16 +268,25 @@ void obs_canvas_clear_mix(obs_canvas_t *canvas)
 	if (!canvas->mix)
 		return;
 
+	/* Detach under mixes_mutex; cleanup runs outside it to preserve
+	 * the global encoders_mutex -> mixes_mutex order. */
+	struct obs_core_video_mix *doomed = NULL;
+
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 	for (size_t i = 0; i < obs->video.mixes.num; i++) {
 		struct obs_core_video_mix *mix = obs->video.mixes.array[i];
 		if (mix == canvas->mix) {
 			da_erase(obs->video.mixes, i);
-			obs_free_video_mix(mix);
+			doomed = mix;
 			break;
 		}
 	}
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
+
+	if (doomed) {
+		obs_encoder_release_video_mix_references(doomed);
+		obs_free_video_mix(doomed);
+	}
 
 	canvas->mix = NULL;
 }

--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -700,22 +700,47 @@ void obs_encoder_release_video_mix_references(struct obs_core_video_mix *mix)
 
 	video_t *freed_video = mix->video;
 
+	DARRAY(obs_encoder_t *) elimenated;
+	da_init(elimenated);
+
 	pthread_mutex_lock(&obs->data.encoders_mutex);
 	obs_encoder_t *encoder = obs->data.first_encoder;
 	while (encoder) {
 		obs_encoder_t *next = (obs_encoder_t *)encoder->context.next;
-
-		if (encoder->info.type == OBS_ENCODER_VIDEO) {
-			if (encoder->video == mix)
-				encoder->video = NULL;
-
-			if (freed_video && encoder->media == freed_video)
-				encoder_set_video(encoder, NULL);
+		if (encoder->info.type == OBS_ENCODER_VIDEO &&
+		    ((encoder->video == mix) || (freed_video && encoder->media == freed_video))) {
+			da_push_back(elimenated, &encoder);
 		}
-
 		encoder = next;
 	}
 	pthread_mutex_unlock(&obs->data.encoders_mutex);
+
+	for (size_t i = 0; i < elimenated.num; i++) {
+		obs_encoder_t *enc = elimenated.array[i];
+
+		if (encoder_active(enc)) {
+			blog(LOG_WARNING,
+			     "obs_encoder_release_video_mix_references: encoder '%s' references a freed video mix while active; leaving as-is",
+			     obs_encoder_get_name(enc));
+			continue;
+		}
+
+		pthread_mutex_lock(&enc->init_mutex);
+		if (enc->context.data) {
+			enc->info.destroy(enc->context.data);
+			enc->context.data = NULL;
+			enc->first_received = false;
+			enc->offset_usec = 0;
+			enc->start_ts = 0;
+			enc->frame_rate_divisor_counter = 0;
+		}
+		enc->initialized = false;
+		if (enc->video == mix)
+			enc->video = NULL;
+		encoder_set_video(enc, NULL);
+		pthread_mutex_unlock(&enc->init_mutex);
+	}
+	da_free(elimenated);
 }
 
 void obs_encoder_shutdown(obs_encoder_t *encoder)

--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -709,7 +709,9 @@ void obs_encoder_release_video_mix_references(struct obs_core_video_mix *mix)
 		obs_encoder_t *next = (obs_encoder_t *)encoder->context.next;
 		if (encoder->info.type == OBS_ENCODER_VIDEO &&
 		    ((encoder->video == mix) || (freed_video && encoder->media == freed_video))) {
-			da_push_back(elimenated, &encoder);
+			obs_encoder_t *ref = obs_encoder_get_ref(encoder);
+			if (ref)
+				da_push_back(elimenated, &ref);
 		}
 		encoder = next;
 	}
@@ -722,6 +724,7 @@ void obs_encoder_release_video_mix_references(struct obs_core_video_mix *mix)
 			blog(LOG_WARNING,
 			     "obs_encoder_release_video_mix_references: encoder '%s' references a freed video mix while active; leaving as-is",
 			     obs_encoder_get_name(enc));
+			obs_encoder_release(enc);
 			continue;
 		}
 
@@ -739,6 +742,8 @@ void obs_encoder_release_video_mix_references(struct obs_core_video_mix *mix)
 			enc->video = NULL;
 		encoder_set_video(enc, NULL);
 		pthread_mutex_unlock(&enc->init_mutex);
+
+		obs_encoder_release(enc);
 	}
 	da_free(elimenated);
 }

--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -693,6 +693,31 @@ static void maybe_clear_encoder_core_video_mix(obs_encoder_t *encoder)
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
 }
 
+void obs_encoder_release_video_mix_references(struct obs_core_video_mix *mix)
+{
+	if (!obs || !mix)
+		return;
+
+	video_t *freed_video = mix->video;
+
+	pthread_mutex_lock(&obs->data.encoders_mutex);
+	obs_encoder_t *encoder = obs->data.first_encoder;
+	while (encoder) {
+		obs_encoder_t *next = (obs_encoder_t *)encoder->context.next;
+
+		if (encoder->info.type == OBS_ENCODER_VIDEO) {
+			if (encoder->video == mix)
+				encoder->video = NULL;
+
+			if (freed_video && encoder->media == freed_video)
+				encoder_set_video(encoder, NULL);
+		}
+
+		encoder = next;
+	}
+	pthread_mutex_unlock(&obs->data.encoders_mutex);
+}
+
 void obs_encoder_shutdown(obs_encoder_t *encoder)
 {
 	blog(LOG_INFO, "obs_encoder_shutdown '%s' (%s) (%p)",

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -336,6 +336,7 @@ struct obs_core_video_mix {
 
 extern struct obs_core_video_mix *obs_create_video_mix(struct obs_video_info *ovi);
 extern void obs_free_video_mix(struct obs_core_video_mix *video);
+extern void obs_encoder_release_video_mix_references(struct obs_core_video_mix *mix);
 
 struct obs_core_video {
 	graphics_t *graphics;

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -879,6 +879,8 @@ void obs_free_video_mix(struct obs_core_video_mix *video)
 	if (obs && obs->video_rendering_mix == video)
 		obs->video_rendering_mix = NULL;
 
+	obs_encoder_release_video_mix_references(video);
+
 	if (video->video) {
 		video_output_close(video->video);
 		video->video = NULL;

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -879,8 +879,6 @@ void obs_free_video_mix(struct obs_core_video_mix *video)
 	if (obs && obs->video_rendering_mix == video)
 		obs->video_rendering_mix = NULL;
 
-	obs_encoder_release_video_mix_references(video);
-
 	if (video->video) {
 		video_output_close(video->video);
 		video->video = NULL;
@@ -913,6 +911,11 @@ static void obs_free_video(bool full_clean)
 		return;
 	}
 
+	/* Snapshot under mixes_mutex; cleanup runs outside it to preserve
+	 * the global encoders_mutex -> mixes_mutex order. */
+	DARRAY(struct obs_core_video_mix *) doomed_mixes;
+	da_init(doomed_mixes);
+
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 	size_t num_views = 0;
 	// 0 value of "i" is reserved for the main canvas, which is created first and
@@ -922,7 +925,7 @@ static void obs_free_video(bool full_clean)
 		struct obs_core_video_mix *video = obs->video.mixes.array[i];
 		if (video && video->view)
 			num_views++;
-		obs_free_video_mix(video);
+		da_push_back(doomed_mixes, &video);
 		obs->video.mixes.array[i] = NULL;
 	}
 	da_free(obs->video.mixes);
@@ -930,6 +933,15 @@ static void obs_free_video(bool full_clean)
 		blog(LOG_WARNING, "Number of remaining views: %ld", num_views);
 
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
+
+	for (size_t i = 0; i < doomed_mixes.num; i++) {
+		struct obs_core_video_mix *video = doomed_mixes.array[i];
+		if (!video)
+			continue;
+		obs_encoder_release_video_mix_references(video);
+		obs_free_video_mix(video);
+	}
+	da_free(doomed_mixes);
 
 	if (full_clean) {
 		pthread_mutex_destroy(&obs->video.mixes_mutex);


### PR DESCRIPTION
 Description:
  Fixes a crash in video_output_get_width → get_const_root triggered after obs_set_video_info reuse. When obs_free_video tears down all non-main video mixes, encoders that had been initialized against those
  mixes keep a dangling encoder->media (and encoder->video). The next obs_encoder_update forwards into the encoder's update callback (e.g. obs_x264_update), which calls obs_encoder_get_width and dereferences
  the freed video_t.

  Adds obs_encoder_release_video_mix_references(), called from obs_free_video_mix(). It walks the encoder list under encoders_mutex and, for any video encoder pointing at the mix being freed, clears
  encoder->video and resets encoder->media (also freeing fps_override) via the existing encoder_set_video(encoder, NULL).


### How Has This Been Tested?
crash was not reproduced locally. so tests only show overall stability after changes.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
