### PR TITLE
libobs: Force-disconnect active encoders and free leaked main mix on video reset

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -720,15 +720,58 @@ void obs_encoder_release_video_mix_references(struct obs_core_video_mix *mix)
 	for (size_t i = 0; i < elimenated.num; i++) {
 		obs_encoder_t *enc = elimenated.array[i];
 
+		pthread_mutex_lock(&enc->init_mutex);
+
 		if (encoder_active(enc)) {
-			blog(LOG_WARNING,
-			     "obs_encoder_release_video_mix_references: encoder '%s' references a freed video mix while active; leaving as-is",
+			/* In correct use, obs_deactivate_video_info's
+			 * obs_video_active() check should prevent us from
+			 * getting here: start/stop_raw_video and
+			 * start/stop_gpu_encode bump the per-mix counters
+			 * that obs_video_active() inspects, so an active
+			 * encoder should always block the reset. If we do
+			 * land here, the alternative to forcing the
+			 * disconnect is a guaranteed UAF when
+			 * obs_free_video_mix closes the video_t below. */
+			bool gpu = (enc->info.caps & OBS_ENCODER_CAP_PASS_TEXTURE) != 0 &&
+				   (mix->using_p010_tex || mix->using_nv12_tex);
+
+			if (gpu) {
+				/* GPU path needs to drain the per-mix encode
+				 * thread (see stop_gpu_encode) before it's
+				 * safe to destroy enc->context.data, and we
+				 * don't have a way to do that with the mix
+				 * already detached from obs->video.mixes.
+				 * Leave the codec state alone but clear the
+				 * media pointers so future operations on this
+				 * encoder fail safely instead of following a
+				 * dangling pointer once obs_free_video_mix
+				 * closes the video_t below. */
+				blog(LOG_ERROR,
+				     "obs_encoder_release_video_mix_references: active GPU encoder '%s' references a freed video mix; leaving codec state (reset path should have been blocked)",
+				     obs_encoder_get_name(enc));
+				if (enc->video == mix)
+					enc->video = NULL;
+				encoder_set_video(enc, NULL);
+				pthread_mutex_unlock(&enc->init_mutex);
+				obs_encoder_release(enc);
+				continue;
+			}
+
+			/* Raw path: break the video->encoder callback.
+			 * video_output_disconnect2 holds the video's
+			 * input_mutex, which is also held by the video
+			 * thread for the duration of each receive_video
+			 * dispatch, so after it returns no in-flight or
+			 * future callback can touch this encoder. */
+			blog(LOG_ERROR,
+			     "obs_encoder_release_video_mix_references: active raw encoder '%s' references a freed video mix; forcing disconnect (reset path should have been blocked)",
 			     obs_encoder_get_name(enc));
-			obs_encoder_release(enc);
-			continue;
+
+			if (freed_video)
+				video_output_disconnect2(freed_video, receive_video, enc);
+			set_encoder_active(enc, false);
 		}
 
-		pthread_mutex_lock(&enc->init_mutex);
 		if (enc->context.data) {
 			enc->info.destroy(enc->context.data);
 			enc->context.data = NULL;

--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -723,46 +723,24 @@ void obs_encoder_release_video_mix_references(struct obs_core_video_mix *mix)
 		pthread_mutex_lock(&enc->init_mutex);
 
 		if (encoder_active(enc)) {
-			/* In correct use, obs_deactivate_video_info's
-			 * obs_video_active() check should prevent us from
-			 * getting here: start/stop_raw_video and
-			 * start/stop_gpu_encode bump the per-mix counters
-			 * that obs_video_active() inspects, so an active
-			 * encoder should always block the reset. If we do
-			 * land here, the alternative to forcing the
-			 * disconnect is a guaranteed UAF when
-			 * obs_free_video_mix closes the video_t below. */
+			/* Unexpected: active encoder still references a freed mix. */
 			bool gpu = (enc->info.caps & OBS_ENCODER_CAP_PASS_TEXTURE) != 0 &&
 				   (mix->using_p010_tex || mix->using_nv12_tex);
 
 			if (gpu) {
-				/* GPU path needs to drain the per-mix encode
-				 * thread (see stop_gpu_encode) before it's
-				 * safe to destroy enc->context.data, and we
-				 * don't have a way to do that with the mix
-				 * already detached from obs->video.mixes.
-				 * Leave the codec state alone but clear the
-				 * media pointers so future operations on this
-				 * encoder fail safely instead of following a
-				 * dangling pointer once obs_free_video_mix
-				 * closes the video_t below. */
+				/* Keep codec state; just clear media pointers. */
 				blog(LOG_ERROR,
 				     "obs_encoder_release_video_mix_references: active GPU encoder '%s' references a freed video mix; leaving codec state (reset path should have been blocked)",
 				     obs_encoder_get_name(enc));
 				if (enc->video == mix)
 					enc->video = NULL;
-				encoder_set_video(enc, NULL);
+				enc->media = NULL;
 				pthread_mutex_unlock(&enc->init_mutex);
 				obs_encoder_release(enc);
 				continue;
 			}
 
-			/* Raw path: break the video->encoder callback.
-			 * video_output_disconnect2 holds the video's
-			 * input_mutex, which is also held by the video
-			 * thread for the duration of each receive_video
-			 * dispatch, so after it returns no in-flight or
-			 * future callback can touch this encoder. */
+			/* Raw path: disconnect callback and mark inactive. */
 			blog(LOG_ERROR,
 			     "obs_encoder_release_video_mix_references: active raw encoder '%s' references a freed video mix; forcing disconnect (reset path should have been blocked)",
 			     obs_encoder_get_name(enc));

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -937,21 +937,23 @@ static void obs_free_video(bool full_clean)
 
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
 
-	/* Clear canvas mix pointers to detached mixes. */
-	pthread_mutex_lock(&obs->data.canvases_mutex);
-	struct obs_context_data *ctx, *tmp;
-	HASH_ITER (hh, (struct obs_context_data *)obs->data.canvases, ctx, tmp) {
-		obs_canvas_t *canvas = (obs_canvas_t *)ctx;
-		if (!canvas->mix)
-			continue;
-		for (size_t i = 0; i < doomed_mixes.num; i++) {
-			if (canvas->mix == doomed_mixes.array[i]) {
-				canvas->mix = NULL;
-				break;
+	/* Clear detached canvas mix pointers (partial reset only). */
+	if (!full_clean) {
+		pthread_mutex_lock(&obs->data.canvases_mutex);
+		struct obs_context_data *ctx, *tmp;
+		HASH_ITER (hh, (struct obs_context_data *)obs->data.canvases, ctx, tmp) {
+			obs_canvas_t *canvas = (obs_canvas_t *)ctx;
+			if (!canvas->mix)
+				continue;
+			for (size_t i = 0; i < doomed_mixes.num; i++) {
+				if (canvas->mix == doomed_mixes.array[i]) {
+					canvas->mix = NULL;
+					break;
+				}
 			}
 		}
+		pthread_mutex_unlock(&obs->data.canvases_mutex);
 	}
-	pthread_mutex_unlock(&obs->data.canvases_mutex);
 
 	for (size_t i = 0; i < doomed_mixes.num; i++) {
 		struct obs_core_video_mix *video = doomed_mixes.array[i];

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -941,7 +941,7 @@ static void obs_free_video(bool full_clean)
 		obs->video.mixes.num = boundary;
 	}
 	if (num_views > 0)
-		blog(LOG_WARNING, "Number of remaining views: %ld", num_views);
+		blog(LOG_WARNING, "Number of remaining views: %zu", num_views);
 
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
 

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -918,21 +918,52 @@ static void obs_free_video(bool full_clean)
 
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 	size_t num_views = 0;
-	// 0 value of "i" is reserved for the main canvas, which is created first and
-	// remains present throughout the lifetime of the application.
-	// As this canvas is unused, we can safely skip it.
-	for (size_t i = 1; i < obs->video.mixes.num; i++) {
+	/* For a partial reset (full_clean == false) we preserve the main
+	 * canvas's mix at index 0 so the subsequent
+	 * obs_init_video -> obs_canvas_clear_mix(main_canvas) call can still
+	 * find it in the global array and free it through
+	 * obs_encoder_release_video_mix_references. If we removed it here
+	 * the old main mix would be orphaned (leaked) and any encoder
+	 * pointing into it would never be invalidated. Full teardown
+	 * frees every mix including index 0. */
+	size_t boundary = full_clean ? 0 : 1;
+	for (size_t i = boundary; i < obs->video.mixes.num; i++) {
 		struct obs_core_video_mix *video = obs->video.mixes.array[i];
 		if (video && video->view)
 			num_views++;
 		da_push_back(doomed_mixes, &video);
 		obs->video.mixes.array[i] = NULL;
 	}
-	da_free(obs->video.mixes);
+	if (full_clean) {
+		da_free(obs->video.mixes);
+	} else {
+		/* Drop the freed slots; the main mix remains at index 0. */
+		obs->video.mixes.num = boundary;
+	}
 	if (num_views > 0)
 		blog(LOG_WARNING, "Number of remaining views: %ld", num_views);
 
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
+
+	/* Nullify canvas->mix pointers that reference mixes we just
+	 * detached. Without this, the subsequent obs_canvas_clear_mix calls
+	 * (from obs_init_video -> restore_canvases) would dereference
+	 * dangling pointers when comparing canvas->mix against the now-
+	 * shrunk global array. */
+	pthread_mutex_lock(&obs->data.canvases_mutex);
+	struct obs_context_data *ctx, *tmp;
+	HASH_ITER (hh, (struct obs_context_data *)obs->data.canvases, ctx, tmp) {
+		obs_canvas_t *canvas = (obs_canvas_t *)ctx;
+		if (!canvas->mix)
+			continue;
+		for (size_t i = 0; i < doomed_mixes.num; i++) {
+			if (canvas->mix == doomed_mixes.array[i]) {
+				canvas->mix = NULL;
+				break;
+			}
+		}
+	}
+	pthread_mutex_unlock(&obs->data.canvases_mutex);
 
 	for (size_t i = 0; i < doomed_mixes.num; i++) {
 		struct obs_core_video_mix *video = doomed_mixes.array[i];

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -911,21 +911,13 @@ static void obs_free_video(bool full_clean)
 		return;
 	}
 
-	/* Snapshot under mixes_mutex; cleanup runs outside it to preserve
-	 * the global encoders_mutex -> mixes_mutex order. */
+	/* Snapshot under mixes_mutex; cleanup happens after unlock. */
 	DARRAY(struct obs_core_video_mix *) doomed_mixes;
 	da_init(doomed_mixes);
 
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 	size_t num_views = 0;
-	/* For a partial reset (full_clean == false) we preserve the main
-	 * canvas's mix at index 0 so the subsequent
-	 * obs_init_video -> obs_canvas_clear_mix(main_canvas) call can still
-	 * find it in the global array and free it through
-	 * obs_encoder_release_video_mix_references. If we removed it here
-	 * the old main mix would be orphaned (leaked) and any encoder
-	 * pointing into it would never be invalidated. Full teardown
-	 * frees every mix including index 0. */
+	/* Partial reset keeps main mix at index 0. */
 	size_t boundary = full_clean ? 0 : 1;
 	for (size_t i = boundary; i < obs->video.mixes.num; i++) {
 		struct obs_core_video_mix *video = obs->video.mixes.array[i];
@@ -937,7 +929,7 @@ static void obs_free_video(bool full_clean)
 	if (full_clean) {
 		da_free(obs->video.mixes);
 	} else {
-		/* Drop the freed slots; the main mix remains at index 0. */
+		/* Drop freed slots; keep main mix. */
 		obs->video.mixes.num = boundary;
 	}
 	if (num_views > 0)
@@ -945,11 +937,7 @@ static void obs_free_video(bool full_clean)
 
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
 
-	/* Nullify canvas->mix pointers that reference mixes we just
-	 * detached. Without this, the subsequent obs_canvas_clear_mix calls
-	 * (from obs_init_video -> restore_canvases) would dereference
-	 * dangling pointers when comparing canvas->mix against the now-
-	 * shrunk global array. */
+	/* Clear canvas mix pointers to detached mixes. */
 	pthread_mutex_lock(&obs->data.canvases_mutex);
 	struct obs_context_data *ctx, *tmp;
 	HASH_ITER (hh, (struct obs_context_data *)obs->data.canvases, ctx, tmp) {


### PR DESCRIPTION
  Two follow-ups to #723 ("Invalidate stale encoder media on video mix
  free").

  **`obs_encoder_release_video_mix_references`** previously skipped any
  encoder with `encoder_active() == true`, logging a warning. The very
  next call (`obs_free_video_mix -> video_output_close`) destroys the
  `video_t`, so the skip turned a recoverable state into a guaranteed
  UAF the next time `start_raw_video(encoder->media, ...)` ran -
  crashing in `pthread_mutex_lock` of the destroyed mutex.

  - Take `enc->init_mutex` before the `encoder_active` check.
  - Raw path: `video_output_disconnect2(freed_video, receive_video, enc)`
    to break the callback (serializes with in-flight `receive_video` via
    the video's `input_mutex`), then fall through to normal cleanup.
  - GPU path: can't drain the per-mix encode thread once the mix is
    detached, so leave `context.data` alone but null `media` / `video`
    so future starts short-circuit on `!encoder->media`.
  - Both branches now `LOG_ERROR` - if either fires, something bypassed
    the `obs_video_active()` gate upstream.

  **`obs_free_video`** used to `da_free(obs->video.mixes)` wholesale.
  The subsequent `obs_init_video -> obs_canvas_clear_mix(main_canvas)`
  walked an empty array, never matched the old main mix, and so never
  called `obs_encoder_release_video_mix_references` or
  `obs_free_video_mix` on it. Mix + `video_t` leaked every reset.

  - Add `boundary = full_clean ? 0 : 1`. Partial resets preserve the
    main mix at index 0 by shrinking `num` instead of `da_free`'ing.
  - Walk all canvases under `canvases_mutex` and null `canvas->mix` for
    any pointer in `doomed_mixes`, so `restore_canvases ->
    obs_canvas_clear_mix` doesn't compare dangling pointers against
    live entries.

  ### Motivation

  `pthread_mutex_lock` UAF crashes (address `0xffffffffffffffff`,
  w32-pthreads' "destroyed" marker) inside `video_output_connect2`
  during `obs_output_start`. The reported dump pre-dated #723 so the
  primary fix is already in HEAD; this PR closes the two follow-up
  windows so the signature actually goes to zero post-rollout.

  ### Types of changes
  - Bug fix