### PR TITLE
libobs-d3d11: check std::filesystem::remove() for error code

### DIFF
--- a/libobs-d3d11/d3d11-shader.cpp
+++ b/libobs-d3d11/d3d11-shader.cpp
@@ -233,7 +233,7 @@ void gs_shader::Compile(const char *shaderString, const char *file, const char *
 	std::fstream cacheFile;
 	cacheFile.exceptions(fstream::badbit | fstream::eofbit);
 
-	if (std::filesystem::exists(cachePath) && !std::filesystem::is_empty(cachePath))
+	if (filesystem::exists(cachePath) && !filesystem::is_empty(cachePath))
 		cacheFile.open(cachePath, ios::in | ios::binary | ios::ate);
 
 	if (cacheFile.is_open()) {
@@ -262,7 +262,7 @@ void gs_shader::Compile(const char *shaderString, const char *file, const char *
 			blog(LOG_WARNING, "Loading shader cache file failed with \"%s\": %s", e.what(), file);
 			cacheFile.close();
 			std::error_code ec;
-			std::filesystem::remove(cachePath, ec);
+			filesystem::remove(cachePath, ec);
 			if (ec)
 				blog(LOG_WARNING, "Failed to delete shader cache file: %s", ec.message().c_str());
 		}
@@ -289,7 +289,10 @@ void gs_shader::Compile(const char *shaderString, const char *file, const char *
 			} catch (const exception &e) {
 				blog(LOG_WARNING, "Writing shader cache file failed with \"%s\": %s", e.what(), file);
 				cacheFile.close();
-				filesystem::remove(cachePath);
+				std::error_code ec;
+				filesystem::remove(cachePath, ec);
+				if (ec)
+					blog(LOG_WARNING, "Failed to delete shader cache file: %s", ec.message().c_str());
 			}
 		}
 	}

--- a/libobs-d3d11/d3d11-shader.cpp
+++ b/libobs-d3d11/d3d11-shader.cpp
@@ -232,6 +232,12 @@ void gs_shader::Compile(const char *shaderString, const char *file, const char *
 
 	std::fstream cacheFile;
 	cacheFile.exceptions(fstream::badbit | fstream::eofbit);
+	auto removeCacheFile = [&cachePath]() {
+		std::error_code ec;
+		filesystem::remove(cachePath, ec);
+		if (ec)
+			blog(LOG_WARNING, "Failed to delete shader cache file: %s", ec.message().c_str());
+	};
 
 	if (filesystem::exists(cachePath) && !filesystem::is_empty(cachePath))
 		cacheFile.open(cachePath, ios::in | ios::binary | ios::ate);
@@ -261,10 +267,7 @@ void gs_shader::Compile(const char *shaderString, const char *file, const char *
 			// Something went wrong reading the cache file, delete it
 			blog(LOG_WARNING, "Loading shader cache file failed with \"%s\": %s", e.what(), file);
 			cacheFile.close();
-			std::error_code ec;
-			filesystem::remove(cachePath, ec);
-			if (ec)
-				blog(LOG_WARNING, "Failed to delete shader cache file: %s", ec.message().c_str());
+			removeCacheFile();
 		}
 	}
 
@@ -289,10 +292,7 @@ void gs_shader::Compile(const char *shaderString, const char *file, const char *
 			} catch (const exception &e) {
 				blog(LOG_WARNING, "Writing shader cache file failed with \"%s\": %s", e.what(), file);
 				cacheFile.close();
-				std::error_code ec;
-				filesystem::remove(cachePath, ec);
-				if (ec)
-					blog(LOG_WARNING, "Failed to delete shader cache file: %s", ec.message().c_str());
+				removeCacheFile();
 			}
 		}
 	}

--- a/libobs-d3d11/d3d11-shader.cpp
+++ b/libobs-d3d11/d3d11-shader.cpp
@@ -233,7 +233,7 @@ void gs_shader::Compile(const char *shaderString, const char *file, const char *
 	std::fstream cacheFile;
 	cacheFile.exceptions(fstream::badbit | fstream::eofbit);
 
-	if (filesystem::exists(cachePath) && !filesystem::is_empty(cachePath))
+	if (std::filesystem::exists(cachePath) && !std::filesystem::is_empty(cachePath))
 		cacheFile.open(cachePath, ios::in | ios::binary | ios::ate);
 
 	if (cacheFile.is_open()) {
@@ -261,7 +261,10 @@ void gs_shader::Compile(const char *shaderString, const char *file, const char *
 			// Something went wrong reading the cache file, delete it
 			blog(LOG_WARNING, "Loading shader cache file failed with \"%s\": %s", e.what(), file);
 			cacheFile.close();
-			filesystem::remove(cachePath);
+			std::error_code ec;
+			std::filesystem::remove(cachePath, ec);
+			if (ec)
+				blog(LOG_WARNING, "Failed to delete shader cache file: %s", ec.message().c_str());
 		}
 	}
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
* detect error code and blog a warning during an exception to avoid std::terminate(). std::terminate() caused by an exception thrown during stack unwinding of another exception.
* fix sentry call stack 
* I checked upstream `master`. They did not resolve this issue.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Attempt to resolve a sentry crash report from a user

```
obs64
+0x2df326
crashpad::`anonymous namespace'::HandleAbortSignal (crashpad_client_win.cc:194)

<unknown>
0x00bbc7afd9e0
<unknown>
VCRUNTIME140
+0x001218
__processing_throw (ehhelpers.cpp:125)
VCRUNTIME140_1
+0x0033ca
_vcrt_getptdbase
VCRUNTIME140_1
+0x002198
__InternalCxxFrameHandler<T>
VCRUNTIME140_1
+0x0021f4
__InternalCxxFrameHandlerWrapper<T>
VCRUNTIME140_1
+0x003dd1
_CxxFrameHandler4
ntdll
+0x16623e
RtlpExecuteHandlerForException
ntdll
+0x012396
RtlDispatchException
ntdll
+0x00a950
RtlRaiseException
KERNELBASE
+0x0c79d9
RaiseException
VCRUNTIME140
+0x005276
_CxxThrowException (throw.cpp:79)
libobs-d3d11
+0x006133
std::filesystem::_Throw_fs_error (filesystem:1863)
MSVCP140
+0x00950f
std::locale::{dtor} (xlocale:355)
MSVCP140
+0x00950f
std::basic_ios<T>::widen (ios:113)
```
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Unable to repro; all shaders compile on my Windows machine to my knowledge. This is a best guess.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
