### PR TITLE
libobs: Close remaining encoder->media UAF holes after #723/#724

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -2062,17 +2062,38 @@ void obs_encoder_set_last_error(obs_encoder_t *encoder, const char *message)
 		encoder->last_error_message = NULL;
 }
 
-void obs_encoder_set_video_mix(obs_encoder_t *encoder,
-			       struct obs_core_video_mix *video)
+void obs_encoder_set_video_mix(obs_encoder_t *encoder, struct obs_core_video_mix *video)
 {
 	if (!obs_encoder_valid(encoder, "obs_encoder_set_video_mix"))
 		return;
 
-	if (!video)
+	if (!video) {
+		blog(LOG_WARNING, "obs_encoder_set_video_mix: NULL mix for encoder '%s'",
+		     obs_encoder_get_name(encoder));
 		return;
+	}
 
-	encoder->video = video;
-	obs_encoder_set_video(encoder, video->video);
+	/* Validate and publish under mixes_mutex in a single critical section.
+	 * Free paths (obs_canvas_clear_mix / obs_free_video / output_frames) remove
+	 * the mix under mixes_mutex before calling obs_encoder_release_video_mix_references,
+	 * so either the removal is ordered before our lock (we see the mix gone and bail)
+	 * or after our unlock (the subsequent encoder walk sees encoder->media via the
+	 * release-acquire chain through mixes_mutex and clears it). */
+	bool bound = false;
+	pthread_mutex_lock(&obs->video.mixes_mutex);
+	for (size_t i = 0, num = obs->video.mixes.num; i < num; i++) {
+		if (obs->video.mixes.array[i] == video) {
+			encoder->video = video;
+			obs_encoder_set_video(encoder, video->video);
+			bound = true;
+			break;
+		}
+	}
+	pthread_mutex_unlock(&obs->video.mixes_mutex);
+
+	if (!bound)
+		blog(LOG_WARNING, "obs_encoder_set_video_mix: stale mix for encoder '%s'",
+		     obs_encoder_get_name(encoder));
 }
 
 uint64_t obs_encoder_get_pause_offset(const obs_encoder_t *encoder)

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -928,6 +928,10 @@ static inline void output_frame(struct obs_core_video_mix *video)
 
 static inline void output_frames(void)
 {
+	/* Free outside mixes_mutex: encoders_mutex -> mixes_mutex order. */
+	DARRAY(struct obs_core_video_mix *) orphaned;
+	da_init(orphaned);
+
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 	for (size_t i = 0, num = obs->video.mixes.num; i < num; i++) {
 		struct obs_core_video_mix *mix = obs->video.mixes.array[i];
@@ -935,13 +939,20 @@ static inline void output_frames(void)
 			output_frame(mix);
 		} else {
 			obs->video.mixes.array[i] = NULL;
-			obs_free_video_mix(mix);
+			da_push_back(orphaned, &mix);
 			da_erase(obs->video.mixes, i);
 			i--;
 			num--;
 		}
 	}
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
+
+	for (size_t i = 0; i < orphaned.num; i++) {
+		struct obs_core_video_mix *mix = orphaned.array[i];
+		obs_encoder_release_video_mix_references(mix);
+		obs_free_video_mix(mix);
+	}
+	da_free(orphaned);
 }
 
 #define NBSP "\xC2\xA0"

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -2897,9 +2897,11 @@ enum obs_video_rendering_mode obs_get_video_rendering_mode(void)
 		return obs->video_rendering_mode;
 }
 
-obs_core_video_mix_t *obs_video_mix_get(struct obs_video_info *ovi,
-					enum obs_video_rendering_mode mode)
+obs_core_video_mix_t *obs_video_mix_get(struct obs_video_info *ovi, enum obs_video_rendering_mode mode)
 {
+	struct obs_core_video_mix *result = NULL;
+
+	pthread_mutex_lock(&obs->video.mixes_mutex);
 	// 0 value of "i" is reserved for the main canvas, which is created first and
 	// remains present throughout the lifetime of the application.
 	// As this canvas is unused, we can safely skip it.
@@ -2907,11 +2909,14 @@ obs_core_video_mix_t *obs_video_mix_get(struct obs_video_info *ovi,
 		struct obs_core_video_mix *mix = obs->video.mixes.array[i];
 		if (!mix || mix->encoder_only_mix)
 			continue;
-		if ((mix->canvas_ovi == ovi || ovi == NULL) &&
-		    mix->rendering_mode == mode)
-			return mix;
+		if ((mix->canvas_ovi == ovi || ovi == NULL) && mix->rendering_mode == mode) {
+			result = mix;
+			break;
+		}
 	}
-	return NULL;
+	pthread_mutex_unlock(&obs->video.mixes_mutex);
+
+	return result;
 }
 
 video_t *obs_video_mix_get_video(struct obs_core_video_mix *mix)


### PR DESCRIPTION
Three small fixes targeting the same crash class the prior PRs began addressing — obs_x264_get_width crashing on a dangling video_t inside get_const_root because encoder->media outlived its mix.

* obs-video.c: output_frames() freed orphaned mixes (mix->view == NULL) without invalidating encoder references first. Snapshot the doomed mixes under mixes_mutex, then call obs_encoder_release_video_mix_references before obs_free_video_mix outside the lock, matching the pattern in #723.

* obs.c: obs_video_mix_get walked obs->video.mixes with no lock while other paths mutate it under mixes_mutex (canvas reset, partial/full video reset, output_frames). A torn read could hand back a freed mix. Hold mixes_mutex for the iteration.

* obs-encoder.c: obs_encoder_set_video_mix re-validates that the mix is still registered under mixes_mutex and captures mix->video atomically, closing the race window between obs_video_mix_get returning and the pointer being stored into encoder->media. NULL/unregistered inputs now log a warning instead of silently leaving encoder->media stale.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
