### PR TITLE
Drain mux pipe data before shutdown EOF in obs-ffmpeg

### DIFF
--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -682,15 +682,17 @@ static size_t safe_read(void *vdata, size_t size)
 
 	uint8_t *dst = vdata;
 	size_t remain = size;
-	HANDLE h[2] = {psi.shutdown_event, psi.data_event};
+	/*
+	* If data_event and shutdown_event are both signaled, WaitForMultipleObjects returns the lowest-index
+	* signaled handle. Prefer pending pipe data over shutdown so mux packets already written by the parent
+	* are drained before safe_read reports EOF.
+	*/
+	HANDLE h[2] = {psi.data_event, psi.shutdown_event};
 
 	while (remain) {
 		DWORD wr = WaitForMultipleObjects(2, h, FALSE, INFINITE);
 
-		if (wr == WAIT_OBJECT_0) // shutdown
-			return 0;
-
-		if (wr == WAIT_OBJECT_0 + 1) { // data available
+		if (wr == WAIT_OBJECT_0) { // data available
 			DWORD want = (DWORD)remain, got = 0;
 			if (!ReadFile(psi.pipe, dst, want, &got, NULL) ||
 			    got == 0)
@@ -698,6 +700,14 @@ static size_t safe_read(void *vdata, size_t size)
 
 			dst += got;
 			remain -= got;
+		} else if (wr == WAIT_OBJECT_0 + 1) { // shutdown
+			DWORD avail = 0;
+			if (PeekNamedPipe(psi.pipe, NULL, 0, NULL, &avail, NULL) &&
+			    avail > 0) {
+				continue;
+			}
+
+			return 0;
 		} else {
 			fprintf(stderr, "safe_read: Wait failed: %lu\n",
 				GetLastError());


### PR DESCRIPTION
### Description
Fix a Windows replay-buffer muxing race where the ffmpeg mux helper could treat shutdown as EOF before draining data already written to the named pipe.

### Motivation and Context
Replay-buffer saves can write mux packets in a short burst and then immediately signal shutdown. On Windows, `safe_read()` was waiting on `{shutdown_event, data_event}`. If both events were signaled, `WaitForMultipleObjects()` returned the lowest-index handle, so shutdown could win even while mux packet bytes were still pending in the pipe.

This could let the mux helper exit successfully after writing only headers/trailer, causing replay files to be reported as `wrote` even though ffmpeg/ffprobe later saw `Duration: N/A` or no streams.

The fix prioritizes `data_event` over `shutdown_event` and peeks the named pipe before treating shutdown as EOF, so pending bytes are drained first.

See also:
https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitformultipleobjects

### How Has This Been Tested?
Manually, Windows only.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 