### PR TITLE
Stinger transition: guard audio mix loop against NULL/garbage child buffers

### DIFF
--- a/plugins/obs-transitions/transition-stinger.c
+++ b/plugins/obs-transitions/transition-stinger.c
@@ -530,7 +530,7 @@ static bool stinger_audio_render(void *data, uint64_t *ts_out, struct obs_source
 	if (!*ts_out || ts < *ts_out)
 		*ts_out = ts;
 
-	struct obs_source_audio_mix child_audio;
+	struct obs_source_audio_mix child_audio = {0};
 	obs_source_get_audio_mix(s->media_source, &child_audio);
 
 	for (size_t mix = 0; mix < MAX_AUDIO_MIXES; mix++) {
@@ -540,6 +540,8 @@ static bool stinger_audio_render(void *data, uint64_t *ts_out, struct obs_source
 		for (size_t ch = 0; ch < channels; ch++) {
 			register float *out = audio->output[mix].data[ch];
 			register float *in = child_audio.output[mix].data[ch];
+			if (!in || !out)
+				continue;
 			register float *end = in + AUDIO_OUTPUT_FRAMES;
 
 			while (in < end)
@@ -578,7 +580,7 @@ static bool stinger_audio_render_do(void *data, uint64_t *ts_out,
 	if (!*ts_out || ts < *ts_out)
 		*ts_out = ts;
 
-	struct obs_source_audio_mix child_audio;
+	struct obs_source_audio_mix child_audio = {0};
 	obs_source_get_audio_mix(s->media_source, &child_audio);
 	for (size_t canvas_idx = 0; canvas_idx < audio->outputs.num;
 	     canvas_idx++) {
@@ -593,6 +595,8 @@ static bool stinger_audio_render_do(void *data, uint64_t *ts_out,
 						.data[ch];
 				register float *in =
 					child_audio.output[mix].data[ch];
+				if (!in || !out)
+					continue;
 				register float *end = in + AUDIO_OUTPUT_FRAMES;
 
 				while (in < end)


### PR DESCRIPTION
  Crash report from Sentry showed EXCEPTION_ACCESS_VIOLATION_READ at 0x100000000 inside stinger_audio_render_do (transition-stinger.c). Root cause: the audio mix loop dereferences
  child_audio.output[mix].data[ch] without checking it, and child_audio is left uninitialized when obs_source_get_audio_mix early-returns on an invalid s->media_source — producing high-address stack garbage
  rather than a clean NULL.

  The same crash class was already fixed in obs-audio.c::mix_audio (commit d1a0c9f9a); this PR propagates the equivalent guard to the stinger.

  Changes

  plugins/obs-transitions/transition-stinger.c, applied to both stinger_audio_render and stinger_audio_render_do:
  - Zero-initialize child_audio = {0} so an early return from obs_source_get_audio_mix leaves .data[ch] as NULL, not stack garbage.
  - Skip the inner mix iteration when in or out is NULL (same pattern as mix_audio).


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
