### PR TITLE
libobs: fix shutdown crash from UAF of obs->data.encoders_mutex

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -959,11 +959,7 @@ static void obs_free_video(bool full_clean)
 		struct obs_core_video_mix *video = doomed_mixes.array[i];
 		if (!video)
 			continue;
-		/* On full shutdown, obs_free_data() has already destroyed every encoder
-		 * and obs->data.encoders_mutex (see obs_free_runtime_objects + the
-		 * pthread_mutex_destroy in obs_free_data). Calling the encoder-release
-		 * walk here would lock a dead mutex. The walk would also find nothing,
-		 * since first_encoder is NULL. */
+		/* full_clean: obs_free_data() already destroyed encoders_mutex. */
 		if (!full_clean)
 			obs_encoder_release_video_mix_references(video);
 		obs_free_video_mix(video);

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -959,7 +959,13 @@ static void obs_free_video(bool full_clean)
 		struct obs_core_video_mix *video = doomed_mixes.array[i];
 		if (!video)
 			continue;
-		obs_encoder_release_video_mix_references(video);
+		/* On full shutdown, obs_free_data() has already destroyed every encoder
+		 * and obs->data.encoders_mutex (see obs_free_runtime_objects + the
+		 * pthread_mutex_destroy in obs_free_data). Calling the encoder-release
+		 * walk here would lock a dead mutex. The walk would also find nothing,
+		 * since first_encoder is NULL. */
+		if (!full_clean)
+			obs_encoder_release_video_mix_references(video);
 		obs_free_video_mix(video);
 	}
 	da_free(doomed_mixes);


### PR DESCRIPTION
## Summary

Hotfix for the shutdown access-violation crash hitting Streamlabs Desktop 1.21.2 users:

```
0  w32-pthreads.dll  pthread_mutex_unlock        (pthread_mutex_unlock.c:61)
1  obs.dll           obs_encoder_release_video_mix_references (obs-encoder.c:718)
2  obs.dll           obs_free_video              (obs.c:962)
3  obs.dll           obs_shutdown                (obs.c:1652)
4  obs64.exe         OBS_API::destroyOBS_API     (nodeobs_api.cpp:1863)
```

EXCEPTION_ACCESS_VIOLATION_READ / 0x8 — w32-pthreads dereferencing an already-destroyed `pthread_mutex_t`.

## Root cause

The shutdown order in `obs_shutdown()` (libobs/obs.c) is:

1. `obs_free_runtime_objects()` — destroys every encoder; `obs->data.first_encoder = NULL`
2. `obs_free_data()` — at line 1259 calls `pthread_mutex_destroy(&data->encoders_mutex)`
3. `obs_free_video(true)` — iterates `obs->video.mixes` and calls `obs_encoder_release_video_mix_references(mix)` for each surviving entry, which locks/unlocks `obs->data.encoders_mutex` → use-after-destroy → crash.

This is a latent ordering issue. It was previously masked because `obs_free_video` started the loop at `i = 1`, and in practice the iteration was empty during full shutdown.

#724 changed the loop to `boundary = full_clean ? 0 : 1`, so any surviving mix (e.g. the leaked main mix the PR was designed to free) now reaches the encoder-release walk during shutdown and trips the destroyed mutex.

## Fix

Skip `obs_encoder_release_video_mix_references()` on full shutdown. The walk would be a noop anyway — `obs_free_runtime_objects()` has already zeroed `first_encoder` — but it crashes because the mutex it locks is gone.

`obs_free_video_mix()` is still called, so the mix struct itself is freed (which was the intent of #724's `boundary = 0` change for full shutdown).

## Test plan

- [ ] Reproduce 1.21.2 shutdown crash by running a session with at least one auxiliary canvas / dual output, then exit normally
- [ ] Confirm with sl18 (or whichever tag this lands on) that obs_shutdown completes without AV in `pthread_mutex_unlock`
- [ ] Confirm partial `obs_reset_video` path (full_clean=false) still calls the encoder-release walk and isn't regressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)