### PR TITLE
libobs: fix AB-BA deadlock in maybe_clear_encoder_core_video_mix

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -671,9 +671,18 @@ bool obs_encoder_initialize(obs_encoder_t *encoder)
 /**
  * free video mix if it's an encoder only video mix
  * see `maybe_set_up_gpu_rescale`
+ *
+ * obs_free_video_mix takes the graphics mutex (via gs_enter_context in
+ * obs_free_render_textures), and the graphics thread can be holding the
+ * graphics mutex while waiting on mixes_mutex inside obs_video_mix_get -
+ * calling obs_free_video_mix while holding mixes_mutex deadlocks. Snapshot
+ * the mix to free under the lock and free after release, matching the
+ * pattern used by obs_free_video in obs.c.
  */
 static void maybe_clear_encoder_core_video_mix(obs_encoder_t *encoder)
 {
+	struct obs_core_video_mix *to_free = NULL;
+
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 	for (size_t i = 0; i < obs->video.mixes.num; i++) {
 		struct obs_core_video_mix *mix = obs->video.mixes.array[i];
@@ -687,10 +696,14 @@ static void maybe_clear_encoder_core_video_mix(obs_encoder_t *encoder)
 		mix->encoder_refs -= 1;
 		if (mix->encoder_refs == 0) {
 			da_erase(obs->video.mixes, i);
-			obs_free_video_mix(mix);
+			to_free = mix;
 		}
+		break;
 	}
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
+
+	if (to_free)
+		obs_free_video_mix(to_free);
 }
 
 void obs_encoder_release_video_mix_references(struct obs_core_video_mix *mix)

--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -288,6 +288,8 @@ static void maybe_set_up_gpu_rescale(struct obs_encoder *encoder)
 	mix->view = current_mix->view;
 	mix->rendering_mode = current_mix->rendering_mode;
 
+	struct obs_core_video_mix *to_free = NULL;
+
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 
 	// double check that nobody else added a matching mix while we've created our mix
@@ -317,13 +319,19 @@ static void maybe_set_up_gpu_rescale(struct obs_encoder *encoder)
 	}
 
 	if (!create_mix) {
-		obs_free_video_mix(mix);
+		// mix was never published into obs->video.mixes; defer the free until
+		// after the unlock to avoid the same AB-BA with the graphics mutex
+		// documented on maybe_clear_encoder_core_video_mix.
+		to_free = mix;
 	} else {
 		da_push_back(obs->video.mixes, &mix);
 		obs_encoder_set_video(encoder, mix->video);
 	}
 
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
+
+	if (to_free)
+		obs_free_video_mix(to_free);
 }
 
 static void add_connection(struct obs_encoder *encoder)


### PR DESCRIPTION
## Summary

`obs->video.mixes_mutex` and the graphics mutex form an AB-BA when `obs_free_video_mix` is called while `mixes_mutex` is held: `obs_free_video_mix` -> `obs_free_render_textures` -> `gs_enter_context` takes the graphics mutex, and `obs_graphics_thread` simultaneously holds the graphics mutex while waiting on `mixes_mutex` via `obs_video_mix_get`. Two sites in `obs-encoder.c` hit this:

1. **`maybe_clear_encoder_core_video_mix`** — encoder *shutdown* path. Drops the last reference to an encoder-only mix and frees it inline.
2. **`maybe_set_up_gpu_rescale`** — encoder *initialization* path. Creates a redundant mix, re-checks under the lock, and frees the redundant one inline if another thread already published a matching mix.

Both freed inside the locked section; both deadlock against the graphics thread.

## How it surfaces

Reachable from any `obs_encoder_shutdown` (for site 1) or any `obs_encoder_initialize` (for site 2) on an encoder using GPU rescaling. In single-output / single-resolution scenarios it's rare because all encoders share one mix and the race window is narrow.

It becomes reliably reproducible with the multitrack video output when the service returns a multi-resolution bitrate ladder: each non-canvas resolution creates its own encoder-only mix, and during start/stop those refcounts churn one-by-one, giving multiple chances per teardown to hit the race.

Concrete shutdown repro (Streamlabs Desktop 1.21.1, Twitch Enhanced Broadcasting + VOD Track enabled):
- 5 video encoders across 5 resolutions (1280x720, 852x480, 640x360, 720x1280, 360x640) + 2 audio encoders
- User stops the stream
- Encoders 0 and 1 shut down cleanly
- Encoder 2's shutdown enters `maybe_clear_encoder_core_video_mix`, frees its mix, deadlocks on `gs_enter_context`

Deadlock stack on the shutdown thread:
```
ntdll!NtWaitForAlertByThreadId
KernelBase!WaitOnAddress
w32-pthreads!pthread_mutex_lock              <- waiting on graphics mutex
obs!gs_enter_context                          (obs.dll)
obs!obs_free_render_textures                  (obs.c:831)
obs!obs_free_video_mix                        (obs.c:886)
obs!maybe_clear_encoder_core_video_mix        (obs-encoder.c:690) <- holding mixes_mutex
obs!obs_encoder_shutdown                      (obs-encoder.c:786)
obs!remove_connection
obs!obs_encoder_stop
obs!stop_video_encoders
obs!end_data_capture_thread
```

Graphics thread holds the graphics mutex and is itself blocked taking `mixes_mutex` in `obs_video_mix_get`.

Site 2 (the init-path variant) wasn't observed in the wild but is the same lock ordering, raised in review by @aleksandr-voitenko and the Copilot bot. Worth fixing in the same PR since the analysis and the fix shape are identical.

## Fix

Same pattern in both functions, mirroring what `obs_free_video` in `obs.c` already does ("Snapshot under mixes_mutex; cleanup happens after unlock"):

- `maybe_clear_encoder_core_video_mix` — snapshot the mix into a local under `mixes_mutex`, `da_erase` it from the array, drop the lock, then call `obs_free_video_mix`.
- `maybe_set_up_gpu_rescale` — snapshot the doomed mix into a local under `mixes_mutex` (no `da_erase` needed since the redundant mix was never published into `obs->video.mixes`), drop the lock, then call `obs_free_video_mix`.

With the free moved outside the lock, the graphics thread can complete `obs_video_mix_get` and release the graphics mutex, and the shutdown/init path then proceeds normally.

Also adds a missing `break` after handling the matched mix in `maybe_clear_encoder_core_video_mix`:
- after `da_erase(obs->video.mixes, i)` the loop index `i` is invalid for the next iteration
- there is only ever one mix for a given `encoder->media`, so continuing the loop is wasted work even when no erase happens

## Test plan

- [x] Stop reliably completes after repro scenario above with patched `obs.dll`
- [x] Single-output single-resolution streams still stop cleanly (no regression in the common path)
- [x] `libobs` builds clean (`cmake --build build_x64 --config RelWithDebInfo --target libobs`, zero errors)
- [ ] Worth a soak test from anyone running multitrack-video output in earnest
- [ ] Init-path variant in `maybe_set_up_gpu_rescale` is a static fix only — same lock ordering as the shutdown site, not separately repro'd

## Notes for reviewers

- This same bug exists in OBS upstream; worth raising upstream after merge here.
- Both fixes are purely a re-ordering of the existing operations - no semantic change. The only behavior difference is that `obs_free_video_mix` runs with `mixes_mutex` released, which is what the analogous code in `obs_free_video` already does.
- Init-path fix added in response to review comments from @aleksandr-voitenko and the Copilot bot.

Generated with [Claude Code](https://claude.com/claude-code)