### PR TITLE
libobs-winrt: Guard WGC capture against removed graphics device

### DIFF
--- a/libobs-winrt/winrt-capture.cpp
+++ b/libobs-winrt/winrt-capture.cpp
@@ -301,13 +301,22 @@ static void winrt_capture_device_loss_rebuild(void *device_void, void *data)
 		return;
 
 	ID3D11Device *const d3d_device = (ID3D11Device *)device_void;
+	if (!d3d_device || FAILED(d3d_device->GetDeviceRemovedReason())) {
+		blog(LOG_WARNING, "Skipping WinRT capture rebuild; graphics device unavailable or removed");
+		return;
+	}
+
 	ComPtr<IDXGIDevice> dxgi_device;
-	if (FAILED(d3d_device->QueryInterface(&dxgi_device)))
+	if (FAILED(d3d_device->QueryInterface(&dxgi_device))) {
 		blog(LOG_ERROR, "Failed to get DXGI device");
+		return;
+	}
 
 	winrt::com_ptr<IInspectable> inspectable;
-	if (FAILED(CreateDirect3D11DeviceFromDXGIDevice(dxgi_device.Get(), inspectable.put())))
+	if (FAILED(CreateDirect3D11DeviceFromDXGIDevice(dxgi_device.Get(), inspectable.put()))) {
 		blog(LOG_ERROR, "Failed to get WinRT device");
+		return;
+	}
 
 	const winrt::Windows::Graphics::DirectX::Direct3D11::IDirect3DDevice device =
 		inspectable.as<winrt::Windows::Graphics::DirectX::Direct3D11::IDirect3DDevice>();
@@ -349,6 +358,11 @@ static struct winrt_capture *winrt_capture_init_internal(BOOL cursor, HWND windo
 							 HMONITOR monitor)
 try {
 	ID3D11Device *const d3d_device = (ID3D11Device *)gs_get_device_obj();
+	if (!d3d_device || FAILED(d3d_device->GetDeviceRemovedReason())) {
+		blog(LOG_WARNING, "Skipping WinRT capture init; graphics device unavailable or removed");
+		return nullptr;
+	}
+
 	ComPtr<IDXGIDevice> dxgi_device;
 
 	HRESULT hr = d3d_device->QueryInterface(&dxgi_device);


### PR DESCRIPTION
## Problem

Sentry crash (`EXCEPTION_ACCESS_VIOLATION_READ`) on the graphics thread during Windows Graphics Capture (WGC) window-capture init:

```
wc_tick (window-capture.c:751)
  → winrt_capture_init_window
    → winrt_capture_init_internal  → inspectable.as<IDirect3DDevice>()  ← AV
```

`winrt_capture_init_internal` and `winrt_capture_device_loss_rebuild` take the D3D11 device from the graphics subsystem without checking whether it is still valid. When the device enters a **removed** state (GPU TDR / driver reset, hybrid-GPU switch, display reconfiguration), `CreateDirect3D11DeviceFromDXGIDevice` can return a **non-null** inspectable wrapping a dead device, and the following `inspectable.as<IDirect3DDevice>()` QueryInterface faults inside the WinRT/DXGI runtime.

The fault is a **Windows SEH access violation**, not a `winrt::hresult_error`, so the function's existing `try`/`catch` does not catch it — the process crashes. This is stock upstream code (no Streamlabs modifications to the init path), so it has been present since the WGC feature shipped.

## Fix

- Bail out early in **both** paths when the device is null or `GetDeviceRemovedReason()` reports it is gone. `wc_tick` already handles a `NULL` init return, and the graphics subsystem rebuilds the device via the loss callbacks, so capture recovers cleanly.
- Convert the **rebuild** path's log-and-continue on `QueryInterface` / `CreateDirect3D11DeviceFromDXGIDevice` failure into proper early returns (matching the init path), so it can no longer reach `.as()` on a null inspectable.

This complements the earlier device-loss release/rebuild hardening, which left the init path exposed.
