### PR TITLE
libobs: append message/get_messages to obs_source_info (fix ABI skew crash)

### DIFF
--- a/libobs/obs-source.h
+++ b/libobs/obs-source.h
@@ -301,12 +301,6 @@ struct obs_source_info {
 	/** Called when the source has been activated in the main view */
 	void (*activate)(void *data);
 
-	/** Called to send message to the source */
-	void (*message)(void *data, obs_data_t *settings);
-
-	/** Called to get messages from the source */
-	obs_data_array_t *(*get_messages)(void *data);
-
 	/**
 	 * Called when the source has been deactivated from the main view
 	 * (no longer being played/displayed)
@@ -562,6 +556,14 @@ struct obs_source_info {
 	 * @param  source  Source that the filter is being added to
 	 */
 	void (*filter_add)(void *data, obs_source_t *source);
+
+	/* Append-only: mid-struct inserts shift later offsets and break module ABI. */
+
+	/** Called to send message to the source */
+	void (*message)(void *data, obs_data_t *settings);
+
+	/** Called to get messages from the source */
+	obs_data_array_t *(*get_messages)(void *data);
 };
 
 EXPORT void obs_register_source_s(const struct obs_source_info *info, size_t size);


### PR DESCRIPTION
Fixes a 1.21.2 Sentry crash: `EXCEPTION_ACCESS_VIOLATION_EXEC` at `obs-source.c:385` (`info->get_defaults2`).

`message`/`get_messages` were inserted mid-struct (after `activate`, #647), shifting the offsets of `get_defaults2` and every later field. A module built against an older `obs-source.h` then reads `get_defaults2` at the wrong offset and calls a garbage pointer during `obs_source_create`. Appending them to the end of `obs_source_info` restores the original offsets; older structs simply zero-fill the new fields.

Field reorder only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)