### PR TITLE
libobs: bound volmeter plane index against MAX_AV_PLANES

### DIFF
--- a/libobs/obs-audio-controls.c
+++ b/libobs/obs-audio-controls.c
@@ -418,7 +418,7 @@ static void volmeter_process_peak(obs_volmeter_t *volmeter, const struct audio_d
 {
 	int nr_samples = data->frames;
 	int channel_nr = 0;
-	for (int plane_nr = 0; channel_nr < nr_channels; plane_nr++) {
+	for (int plane_nr = 0; channel_nr < nr_channels && plane_nr < MAX_AV_PLANES; plane_nr++) {
 		float *samples = (float *)data->data[plane_nr];
 		if (!samples) {
 			continue;
@@ -466,7 +466,7 @@ static void volmeter_process_magnitude(obs_volmeter_t *volmeter, const struct au
 	size_t nr_samples = data->frames;
 
 	int channel_nr = 0;
-	for (int plane_nr = 0; channel_nr < nr_channels; plane_nr++) {
+	for (int plane_nr = 0; channel_nr < nr_channels && plane_nr < MAX_AV_PLANES; plane_nr++) {
 		float *samples = (float *)data->data[plane_nr];
 		if (!samples) {
 			continue;


### PR DESCRIPTION
## What

Adds an explicit `plane_nr < MAX_AV_PLANES` bound to the two plane-scan loops in `libobs/obs-audio-controls.c` (`volmeter_process_peak` and `volmeter_process_magnitude`).

```c
- for (int plane_nr = 0; channel_nr < nr_channels; plane_nr++) {
+ for (int plane_nr = 0; channel_nr < nr_channels && plane_nr < MAX_AV_PLANES; plane_nr++) {
```

## Why

Both loops index `data->data[plane_nr]` while `plane_nr` is advanced solely by the `channel_nr < nr_channels` condition — `plane_nr` itself is never checked against `MAX_AV_PLANES`.

It is safe **today** only because `nr_channels` is produced by `get_nr_channels_from_audio_data()`, which counts the non-NULL planes in the *same* `data->data[]` array. That guarantees the loop encounters enough planes before `plane_nr` leaves bounds, for any plane layout (contiguous, interleaved, or trailing-NULL).

The footgun: the safety lives in a *different function* than the unguarded access. If `nr_channels` were ever derived from a source's declared channel/speaker layout instead of from counting planes, the loop would read past `data->data[MAX_AV_PLANES - 1]`. Because `MAX_AUDIO_CHANNELS == MAX_AV_PLANES == 8`, the existing `CLAMP` in `get_nr_channels_from_audio_data()` would not catch that case either.

This is a **behavior-preserving** hardening change — under the current invariant the new guard is never the condition that ends the loop.

## Testing

- Built the `libobs` target locally (VS 2022 / RelWithDebInfo) — compiles clean, no new warnings.
- Change is a no-op under current data flow; the guard only bounds the index.

## Note on the clang-format CI check

The `clang-format` check is expected to come back **red**, and it is **not** caused by this change. CI runs clang-format (v19) over the *entire* changed file, and `obs-audio-controls.c` carries one pre-existing deviation unrelated to this PR (the `obs_fader_add_callback` signature, last formatted under the old 80-col config). That line was deliberately left untouched to keep this diff minimal and focused on the actual fix. Happy to fold in the one-line format normalization if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
