### PR TITLE
libobs: mix scene-item audio when item canvas is unset

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -2111,9 +2111,12 @@ static bool scene_audio_render_do(void *data, uint64_t *ts_out,
 				for (size_t canvas_idx = 0;
 				     canvas_idx < audio_output->outputs.num;
 				     canvas_idx++) {
-					if (item->canvas !=
-					    obs->video.canvases
-						    .array[canvas_idx]) {
+					/* NULL canvas = all canvases, as in
+					 * scene_video_render */
+					if (item->canvas &&
+					    item->canvas !=
+						    obs->video.canvases
+							    .array[canvas_idx]) {
 						continue;
 					}
 


### PR DESCRIPTION
## Problem

A source's audio plays when the source is set directly as an output channel, but goes **silent** once the source is wrapped in a scene and the scene is the output source. Reported in streamlabs/obs-studio-node#1493.

## Root cause

`scene_audio_render_do` (`libobs/obs-scene.c`) mixes each scene item's audio only into a canvas whose pointer exactly matches `item->canvas`:

```c
if (item->canvas != obs->video.canvases.array[canvas_idx])
    continue;
```

A scene item's `canvas` defaults to `NULL` (scene items are zero-allocated; it is only set via `obs_sceneitem_set_canvas`, e.g. osn's `sceneItem.video`). With a NULL canvas the comparison never matches, so the item's audio is dropped on **every** canvas — while its **video** still renders, because the video path (`scene_video_render`) already special-cases NULL:

```c
if (render_canvas != item->canvas && item->canvas != NULL)
    continue;
```

The asymmetry dates to the video path gaining its `!= NULL` guard ("Fix video mix canvas identity", #720) while the audio path — rewritten separately in `da3255b9` — did not.

## Fix

Give the audio path the same escape hatch: a NULL item canvas means "mix into every canvas".

## Test

Regression test mirroring the exact #1493 repro (scene-wrapped `ffmpeg_source` with the item canvas left unset must record non-silent audio): **streamlabs/obs-studio-node PR — _link added below_**.

## Notes

- One-line behavioral change plus a short comment; matches the file's existing wrapping.
- Not built locally — verified by inspection against the parallel video path; relying on CI for the libobs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)