### PR TITLE
Add structured module load failures

### DIFF
--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -113,6 +113,8 @@ struct obs_module {
 	char *data_path;
 	void *module;
 	bool loaded;
+	char *load_error_code;
+	char *load_error_message;
 
 	bool (*load)(void);
 	void (*unload)(void);

--- a/libobs/obs-module.c
+++ b/libobs/obs-module.c
@@ -156,6 +156,18 @@ int obs_open_module(obs_module_t **module, const char *path, const char *data_pa
 	return MODULE_SUCCESS;
 }
 
+static void clear_module_load_error(obs_module_t *module)
+{
+	if (!module)
+		return;
+
+	bfree(module->load_error_code);
+	module->load_error_code = NULL;
+
+	bfree(module->load_error_message);
+	module->load_error_message = NULL;
+}
+
 bool obs_init_module(obs_module_t *module)
 {
 	if (!module || !obs)
@@ -167,12 +179,32 @@ bool obs_init_module(obs_module_t *module)
 		profile_store_name(obs_get_profiler_name_store(), "obs_init_module(%s)", module->file);
 	profile_start(profile_name);
 
+	clear_module_load_error(module);
 	module->loaded = module->load();
-	if (!module->loaded)
-		blog(LOG_WARNING, "Failed to initialize module '%s'", module->file);
+	if (!module->loaded) {
+		if (module->load_error_code && module->load_error_message) {
+			blog(LOG_WARNING, "Failed to initialize module '%s': %s (%s)", module->file,
+			     module->load_error_message, module->load_error_code);
+		} else if (module->load_error_code) {
+			blog(LOG_WARNING, "Failed to initialize module '%s': %s", module->file,
+			     module->load_error_code);
+		} else {
+			blog(LOG_WARNING, "Failed to initialize module '%s'", module->file);
+		}
+	}
 
 	profile_end(profile_name);
 	return module->loaded;
+}
+
+void obs_module_set_load_error(obs_module_t *module, const char *code, const char *message)
+{
+	if (!module)
+		return;
+
+	clear_module_load_error(module);
+	module->load_error_code = bstrdup(code ? code : "");
+	module->load_error_message = bstrdup(message ? message : "");
 }
 
 void obs_log_loaded_modules(void)
@@ -294,8 +326,24 @@ extern void get_plugin_info(const char *path, bool *is_obs_plugin, bool *can_loa
 
 struct fail_info {
 	struct dstr fail_modules;
-	size_t fail_count;
+	DARRAY(struct obs_module_load_failure) failures;
 };
+
+static void add_module_failure(struct fail_info *fail_info, const char *module, const char *code, const char *message)
+{
+	if (!fail_info)
+		return;
+
+	struct obs_module_load_failure failure = {
+		bstrdup(module ? module : ""),
+		bstrdup((code && *code) ? code : "MODULE_LOAD_FAILED"),
+		bstrdup((message && *message) ? message : "Module failed to load."),
+	};
+
+	dstr_cat(&fail_info->fail_modules, failure.module);
+	dstr_cat(&fail_info->fail_modules, ";");
+	da_push_back(fail_info->failures, &failure);
+}
 
 static bool is_safe_module(const char *name)
 {
@@ -356,18 +404,16 @@ static void load_all_callback(void *param, const struct obs_module_info2 *info)
 		return;
 	}
 
-	if (!obs_init_module(module))
+	if (!obs_init_module(module)) {
+		add_module_failure(fail_info, info->name, module->load_error_code, module->load_error_message);
 		free_module(module);
+	}
 
 	UNUSED_PARAMETER(param);
 	return;
 
 load_failure:
-	if (fail_info) {
-		dstr_cat(&fail_info->fail_modules, info->name);
-		dstr_cat(&fail_info->fail_modules, ";");
-		fail_info->fail_count++;
-	}
+	add_module_failure(fail_info, info->name, NULL, NULL);
 }
 
 static const char *obs_load_all_modules_name = "obs_load_all_modules";
@@ -403,7 +449,8 @@ void obs_load_all_modules2(struct obs_module_failure_info *mfi)
 #endif
 	profile_end(obs_load_all_modules2_name);
 
-	mfi->count = fail_info.fail_count;
+	mfi->count = fail_info.failures.num;
+	mfi->failures = fail_info.failures.array;
 	mfi->failed_modules = strlist_split(fail_info.fail_modules.array, ';', false);
 	dstr_free(&fail_info.fail_modules);
 }
@@ -414,6 +461,19 @@ void obs_module_failure_info_free(struct obs_module_failure_info *mfi)
 		bfree(mfi->failed_modules);
 		mfi->failed_modules = NULL;
 	}
+
+	if (mfi->failures) {
+		for (size_t i = 0; i < mfi->count; i++) {
+			bfree(mfi->failures[i].module);
+			bfree(mfi->failures[i].code);
+			bfree(mfi->failures[i].message);
+		}
+
+		bfree(mfi->failures);
+		mfi->failures = NULL;
+	}
+
+	mfi->count = 0;
 }
 
 void obs_post_load_modules(void)
@@ -621,6 +681,8 @@ void free_module(struct obs_module *mod)
 	bfree(mod->mod_name);
 	bfree(mod->bin_path);
 	bfree(mod->data_path);
+	bfree(mod->load_error_code);
+	bfree(mod->load_error_message);
 	bfree(mod);
 }
 

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -589,13 +589,21 @@ EXPORT void obs_add_safe_module(const char *name);
 /** Automatically loads all modules from module paths (convenience function) */
 EXPORT void obs_load_all_modules(void);
 
+struct obs_module_load_failure {
+	char *module;
+	char *code;
+	char *message;
+};
+
 struct obs_module_failure_info {
 	char **failed_modules;
 	size_t count;
+	struct obs_module_load_failure *failures;
 };
 
 EXPORT void obs_module_failure_info_free(struct obs_module_failure_info *mfi);
 EXPORT void obs_load_all_modules2(struct obs_module_failure_info *mfi);
+EXPORT void obs_module_set_load_error(obs_module_t *module, const char *code, const char *message);
 
 /** Notifies modules that all modules have been loaded.  This function should
  * be called after all modules have been loaded. */


### PR DESCRIPTION
### Description
Adds structured OBS module load failure details so callers can identify and surface actionable plugin load errors.

### Motivation and Context
OBS currently exposes module load failures primarily as module names, which is not enough for downstream callers to explain why a plugin failed or guide users toward a fix. This change lets modules attach a stable error code and human-readable message when load fails, while keeping the existing failure list intact for current callers.

The immediate use case is `obs-ndi`: when the installed NDI runtime is missing or too old, paired desktop code needs to distinguish those cases and show the appropriate user-facing notification.

Note:
> `load_error_code` is a string because module load failures are intentionally open-ended and may be plugin-specific. OBS does not need to own a closed enum for every possible module failure reason; a plugin can report a stable symbolic code such as `NDI_RUNTIME_NOT_FOUND` or `NDI_RUNTIME_VERSION_MISMATCH`, and downstream callers can match on that value directly.
>
> The paired `message` field remains the human-readable explanation, while `code` is the machine-readable identifier. Using a string keeps logs readable and avoids coordinating numeric enum values across OBS, plugins, `obs-studio-node`, and desktop for every new plugin-specific failure.

### How Has This Been Tested?
Manually, Windows only.

### Types of changes
- Breaking change (fix or feature that would cause existing functionality to change) 