### PR TITLE
MacOS: fix render issue in obs-32 branch

### DIFF
--- a/libobs-opengl/IOSurfaceHelper.h
+++ b/libobs-opengl/IOSurfaceHelper.h
@@ -1,5 +1,6 @@
 #pragma once
 
 #import <Cocoa/Cocoa.h>
+#import <IOSurface/IOSurface.h>
 
 void writeIOSurfaceContents(IOSurfaceRef surface, NSString *filePath);

--- a/libobs-opengl/IOSurfaceHelper.m
+++ b/libobs-opengl/IOSurfaceHelper.m
@@ -2,8 +2,6 @@
 
 #include <OpenGL/OpenGL.h>
 
-#include <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
-
 #import <AppKit/AppKit.h>
 
 void saveCGImageToFile(CGImageRef image, NSString *filePath, CFStringRef fileType)
@@ -79,7 +77,7 @@ void writeIOSurfaceContents(IOSurfaceRef surface, NSString *filePath)
                                      kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Little, provider, NULL,
                                      false, kCGRenderingIntentDefault);
 
-    saveCGImageToFile(image, filePath, (__bridge CFStringRef)UTTypePNG.identifier);
+    saveCGImageToFile(image, filePath, CFSTR("public.png"));
 
     CGDataProviderRelease(provider);
     CGColorSpaceRelease(colorSpace);
@@ -89,4 +87,3 @@ void writeIOSurfaceContents(IOSurfaceRef surface, NSString *filePath)
 
     NSLog(@"Completed examining IOSurface.");
 }
-

--- a/libobs-opengl/gl-cocoa.m
+++ b/libobs-opengl/gl-cocoa.m
@@ -18,6 +18,10 @@
 #include "gl-subsystem.h"
 #include <OpenGL/OpenGL.h>
 
+#if defined(DEBUG_WRITE_IOSURFACE)
+#include "IOSurfaceHelper.h"
+#endif
+
 #import <Cocoa/Cocoa.h>
 #import <AppKit/AppKit.h>
 
@@ -27,6 +31,7 @@ struct gl_windowinfo {
     gs_texture_t *texture;
     GLuint fbo;
     uint32_t surfaceID;
+    IOSurfaceRef surfaceRef;
 };
 
 struct gl_platform {
@@ -210,6 +215,10 @@ void gl_platform_cleanup_swapchain(struct gs_swap_chain *swap)
         swap->wi->fbo = 0;
         swap->wi->texture = NULL;
         swap->wi->context = nil;
+        if (swap->wi->surfaceRef) {
+            CFRelease(swap->wi->surfaceRef);
+            swap->wi->surfaceRef = NULL;
+        }
     }
 }
 
@@ -242,7 +251,10 @@ void gl_windowinfo_destroy(struct gl_windowinfo *windowInfo)
 {
     if (!windowInfo)
         return;
-
+    if (windowInfo->surfaceRef) {
+        CFRelease(windowInfo->surfaceRef);
+        windowInfo->surfaceRef = NULL;
+    }
     windowInfo->view = nil;
     bfree(windowInfo);
 }
@@ -389,7 +401,7 @@ void *device_get_device_obj(gs_device_t *device)
 
 void device_load_swapchain(gs_device_t *device, gs_swapchain_t *swap)
 {
-    if (device->cur_swap == swap)
+    if (device->cur_swap == swap && (swap == NULL || device->cur_render_target == swap->wi->texture))
         return;
 
     device->cur_swap = swap;
@@ -401,11 +413,12 @@ void device_load_swapchain(gs_device_t *device, gs_swapchain_t *swap)
 static void write_iosurface(gs_device_t *device)
 {
     gs_swapchain_t *swap = device->cur_swap;
-    if (!swap || !swap->wi || !swap->wi->surfaceID)
+    if (!swap || !swap->wi || !swap->wi->surfaceRef)
         return;
 
-    IOSurfaceRef surface = IOSurfaceLookup((IOSurfaceID)swap->wi->surfaceID);
-    if (!surface)
+    IOSurfaceRef surface = swap->wi->surfaceRef;
+
+    if (!gl_bind_framebuffer(GL_READ_FRAMEBUFFER, swap->wi->fbo))
         return;
 
     IOSurfaceLock(surface, 0, NULL);
@@ -414,21 +427,38 @@ static void write_iosurface(gs_device_t *device)
     if (!data) {
         blog(LOG_ERROR, "gl-cocoa: failed to write in the IOSurface");
         IOSurfaceUnlock(surface, 0, NULL);
-        CFRelease(surface);
+        gl_bind_framebuffer(GL_READ_FRAMEBUFFER, 0);
         return;
     }
 
-    glReadPixels(0, 0, IOSurfaceGetBytesPerRow(surface) / 4, IOSurfaceGetHeight(surface), GL_BGRA,
+    GLint prevPackRowLength = 0;
+    glGetIntegerv(GL_PACK_ROW_LENGTH, &prevPackRowLength);
+    glPixelStorei(GL_PACK_ROW_LENGTH, (GLint) (IOSurfaceGetBytesPerRow(surface) / 4));
+    glReadPixels(0, 0, (GLsizei) IOSurfaceGetWidth(surface), (GLsizei) IOSurfaceGetHeight(surface), GL_BGRA,
                  GL_UNSIGNED_INT_8_8_8_8_REV, data);
+    glPixelStorei(GL_PACK_ROW_LENGTH, prevPackRowLength);
     gl_success("glReadPixels");
-
+#if defined(DEBUG_WRITE_IOSURFACE)
+    static int imageIndex = 0;
+    const int max_images = 10;
+    NSString *myString = [NSString stringWithFormat:@"test_frame%d.png", imageIndex];
+    writeIOSurfaceContents(surface, myString);
+    imageIndex++;
+    if (imageIndex >= max_images) {
+        imageIndex = 0;
+    }
+#endif
     IOSurfaceUnlock(surface, 0, NULL);
-    CFRelease(surface);
+    gl_bind_framebuffer(GL_READ_FRAMEBUFFER, 0);
 }
 
-bool device_is_present_ready(gs_device_t *device __unused)
+bool device_is_present_ready(gs_device_t *device)
 {
-    return true;
+    if (!device || !device->cur_swap || !device->cur_swap->wi)
+        return false;
+
+    gs_texture_t *tex = device->cur_swap->wi->texture;
+    return tex != NULL && gs_texture_get_width(tex) > 0 && gs_texture_get_height(tex) > 0;
 }
 
 void device_present(gs_device_t *device)
@@ -666,21 +696,23 @@ uint32_t create_iosurface(gs_device_t *device, uint32_t width, uint32_t height)
         return 0;
     }
 
-    swap->wi->surfaceID = 0;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     NSDictionary *surfaceAttributes = [[NSDictionary alloc]
-        initWithObjectsAndKeys:[NSNumber numberWithBool:YES], (NSString *)kIOSurfaceIsGlobal,
-                               [NSNumber numberWithUnsignedInteger:(NSUInteger)width], (NSString *)kIOSurfaceWidth,
-                               [NSNumber numberWithUnsignedInteger:(NSUInteger)height], (NSString *)kIOSurfaceHeight,
-                               [NSNumber numberWithUnsignedInteger:4U], (NSString *)kIOSurfaceBytesPerElement, nil];
+        initWithObjectsAndKeys:[NSNumber numberWithBool:YES], (NSString *) kIOSurfaceIsGlobal,
+                               [NSNumber numberWithUnsignedInteger:(NSUInteger) width], (NSString *) kIOSurfaceWidth,
+                               [NSNumber numberWithUnsignedInteger:(NSUInteger) height], (NSString *) kIOSurfaceHeight,
+                               [NSNumber numberWithUnsignedInteger:4U], (NSString *) kIOSurfaceBytesPerElement, nil];
 #pragma clang diagnostic pop
-
-    IOSurfaceRef surfaceRef = IOSurfaceCreate((CFDictionaryRef)surfaceAttributes);
+    IOSurfaceRef surfaceRef = IOSurfaceCreate((CFDictionaryRef) surfaceAttributes);
     if (surfaceRef) {
         swap->wi->surfaceID = IOSurfaceGetID(surfaceRef);
-        CFRelease(surfaceRef);
+        if (swap->wi->surfaceRef) {
+            CFRelease(swap->wi->surfaceRef);
+        }
+        swap->wi->surfaceRef = surfaceRef;
     } else {
+        swap->wi->surfaceID = 0;
         blog(LOG_ERROR, "create_iosurface IOSurfaceCreate failed");
     }
 

--- a/libobs-opengl/gl-cocoa.m
+++ b/libobs-opengl/gl-cocoa.m
@@ -690,6 +690,11 @@ uint32_t create_iosurface(gs_device_t *device, uint32_t width, uint32_t height)
         return 0;
     }
 
+    if (width == 0 || height == 0) {
+        blog(LOG_WARNING, "create_iosurface was sent an empty width/height");
+        return 0;
+    }
+
     gs_swapchain_t *swap = device->cur_swap;
     if (!swap || !swap->wi) {
         blog(LOG_ERROR, "create_iosurface failed to acquire swap chain");


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
* Fix issue in Obs-32 branch where `create_iosurface` uses `kIOSurfaceIsGlobal: YES` but then immediately called `CFRelease` causing `IOSurfaceLookup` in both `write_iosurface` and `node-window-rendering` to return `NULL`.
* Fix pre-existing issue (while we are in here) where we'd have OpenGL `glClear` errors being sent to the logs. Add checks for 0x0 sized buffer.
* Add optional `DEBUG_WRITE_IOSURFACE` code path which will dump the `IOSurface` contents into a .png file which can be helpful determining if backend is properly rendering (because if we have pixels, then problem is upstream in NWR/Desktop).
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Depends on this PR: https://github.com/streamlabs/obs-studio/pull/734. Fix rendering issue for macOS in obs-32 branch
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Verified I see images rendered during dual output etc on Streamlabs Desktop in `obs_merge_32.1.1` locally
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
