### PR TITLE
mac-virtualcam: Populate extensions for CMVideoFormatDescriptionCreate

### DIFF
--- a/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
+++ b/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
@@ -15,7 +15,7 @@ MODULE_EXPORT const char *obs_module_description(void)
 
 NSString *const OBSDalDestination = @"/Library/CoreMediaIO/Plug-Ins/DAL";
 
-static const char *VIRTUAL_CAM_CONNECTED = "activate"; // Indicates this plugin is now active.
+static const char *VIRTUAL_CAM_CONNECTED = "activate";  // Indicates this plugin is now active.
 static const char *VIRTUAL_CAM_FAILED = "deactivate";
 
 static bool cmio_extension_supported()
@@ -493,16 +493,18 @@ static bool virtualcam_output_start(void *data)
             vcam->streamID, [](CMIOStreamID, void *, void *) {
             }, NULL, &vcam->queue);
         CFDictionaryRef extensions = create_colorspace_format_extensions(vcam->videoInfo.colorspace);
+        OSStatus result = noErr;
         if (CMVideoFormatDescriptionCreate(kCFAllocatorDefault, video_format, vcam->videoInfo.output_width,
                                            vcam->videoInfo.output_height, extensions,
                                            &vcam->formatDescription) != noErr) {
             blog(LOG_WARNING, "Could not initialize virtualcam_output with create_colorspace_format_extensions");
-            CMVideoFormatDescriptionCreate(kCFAllocatorDefault, video_format, vcam->videoInfo.output_width,
-                                           vcam->videoInfo.output_height, NULL, &vcam->formatDescription);
+            result = CMVideoFormatDescriptionCreate(kCFAllocatorDefault, video_format, vcam->videoInfo.output_width,
+                                                    vcam->videoInfo.output_height, NULL, &vcam->formatDescription);
         }
         CFRelease(extensions);
 
-        OSStatus result = CMIODeviceStartStream(vcam->deviceID, vcam->streamID);
+        if (result == noErr)
+            result = CMIODeviceStartStream(vcam->deviceID, vcam->streamID);
 
         if (result != noErr) {
             obs_output_set_last_error(vcam->output, obs_module_text("Error.SystemExtension.CameraNotStarted"));

--- a/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
+++ b/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
@@ -144,6 +144,45 @@ struct virtualcam_data {
 
 @end
 
+// Returns a dictionary of extension key/value pairs for CMVideoFormatDescriptionCreate(). Caller should release after use.
+static CFMutableDictionaryRef create_colorspace_format_extensions(const enum video_colorspace colorspace)
+{
+    CFStringRef colorPrimaries = kCVImageBufferColorPrimaries_ITU_R_709_2;
+    CFStringRef transferFunction = kCVImageBufferTransferFunction_ITU_R_709_2;
+    CFStringRef ycbcrMatrix = kCVImageBufferYCbCrMatrix_ITU_R_709_2;
+
+    switch (colorspace) {
+        case VIDEO_CS_601:
+            colorPrimaries = kCVImageBufferColorPrimaries_SMPTE_C;
+            transferFunction = kCVImageBufferTransferFunction_ITU_R_709_2;
+            ycbcrMatrix = kCVImageBufferYCbCrMatrix_ITU_R_601_4;
+            break;
+        case VIDEO_CS_SRGB:
+            colorPrimaries = kCVImageBufferColorPrimaries_ITU_R_709_2;
+            transferFunction = kCVImageBufferTransferFunction_sRGB;
+            ycbcrMatrix = kCVImageBufferYCbCrMatrix_ITU_R_709_2;
+            break;
+        case VIDEO_CS_2100_PQ:
+            colorPrimaries = kCVImageBufferColorPrimaries_ITU_R_2020;
+            transferFunction = kCVImageBufferTransferFunction_SMPTE_ST_2084_PQ;
+            ycbcrMatrix = kCVImageBufferYCbCrMatrix_ITU_R_2020;
+            break;
+        case VIDEO_CS_2100_HLG:
+            colorPrimaries = kCVImageBufferColorPrimaries_ITU_R_2020;
+            transferFunction = kCVImageBufferTransferFunction_ITU_R_2100_HLG;
+            ycbcrMatrix = kCVImageBufferYCbCrMatrix_ITU_R_2020;
+            break;
+        default:  // VIDEO_CS_709, VIDEO_CS_DEFAULT
+            break;
+    }
+    CFMutableDictionaryRef extensions = CFDictionaryCreateMutable(
+        kCFAllocatorDefault, 3, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    CFDictionarySetValue(extensions, kCMFormatDescriptionExtension_ColorPrimaries, colorPrimaries);
+    CFDictionarySetValue(extensions, kCMFormatDescriptionExtension_TransferFunction, transferFunction);
+    CFDictionarySetValue(extensions, kCMFormatDescriptionExtension_YCbCrMatrix, ycbcrMatrix);
+    return extensions;
+}
+
 static void install_cmio_system_extension(struct virtualcam_data *vcam)
 {
     OSSystemExtensionRequest *request = [OSSystemExtensionRequest
@@ -453,8 +492,15 @@ static bool virtualcam_output_start(void *data)
         CMIOStreamCopyBufferQueue(
             vcam->streamID, [](CMIOStreamID, void *, void *) {
             }, NULL, &vcam->queue);
-        CMVideoFormatDescriptionCreate(kCFAllocatorDefault, video_format, vcam->videoInfo.output_width,
-                                       vcam->videoInfo.output_height, NULL, &vcam->formatDescription);
+        CFDictionaryRef extensions = create_colorspace_format_extensions(vcam->videoInfo.colorspace);
+        if (CMVideoFormatDescriptionCreate(kCFAllocatorDefault, video_format, vcam->videoInfo.output_width,
+                                           vcam->videoInfo.output_height, extensions,
+                                           &vcam->formatDescription) != noErr) {
+            blog(LOG_WARNING, "Could not initialize virtualcam_output with create_colorspace_format_extensions");
+            CMVideoFormatDescriptionCreate(kCFAllocatorDefault, video_format, vcam->videoInfo.output_width,
+                                           vcam->videoInfo.output_height, NULL, &vcam->formatDescription);
+        }
+        CFRelease(extensions);
 
         OSStatus result = CMIODeviceStartStream(vcam->deviceID, vcam->streamID);
 

--- a/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
+++ b/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
@@ -500,6 +500,9 @@ static bool virtualcam_output_start(void *data)
             blog(LOG_WARNING, "Could not initialize virtualcam_output with create_colorspace_format_extensions");
             result = CMVideoFormatDescriptionCreate(kCFAllocatorDefault, video_format, vcam->videoInfo.output_width,
                                                     vcam->videoInfo.output_height, NULL, &vcam->formatDescription);
+            if (result != noErr) {
+                blog(LOG_ERROR, "Could not create a format description for the video media stream");
+            }
         }
         CFRelease(extensions);
 


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
* Fix rare crash dump for mac-virtualcam users. Looking at call stack, we need to populate the Dictionary with the OBS->ColorSpace entries.
* Note: encoder.c has some obs->vt colorspace conversion functions but only looked at those for reference `obs_to_vt_colorspace`, `obs_to_vt_primaries`, & `obs_to_vt_transfer`. Perhaps it might have been more robust if I expose these functions to a header so we can reuse?


<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Potential crash fix for [callstack](https://streamlabs-desktop.sentry.io/issues/6807279193/?project=1283431&query=is%3Aunresolved%20os.name%3AmacOS%20release%3A1.21.%2A&referrer=issue-stream&sort=freq):
```
libsystem_kernel
+0x0095f0
__pthread_kill

libsystem_pthread
+0x006c1c
pthread_kill
libsystem_c
+0x076a2c
abort
obs64
+0x20d0c0
util::CrashManager::HandleCrash (new)
obs64
+0x211998
util::CrashManager::SignalActionHandler (util-crashmanager.cpp:1428)
libsystem_platform
+0x004580
_sigtramp
CoreFoundation
+0x01fd80
-[__NSDictionaryM objectForKey:]
CoreFoundation
+0x0429fc
-[NSDictionary containsObject:]
CoreFoundation
+0x042938
CFDictionaryContainsValue
ColorSync
+0x001850
create
ColorSync
+0x005d3c
ColorSyncProfileCreate
CoreGraphics
+0x498dc8
CGColorSpaceFromICCDataCacheGetRetained
CoreMedia
+0x0f4c94
sbufAtom_copyCFTypeFromAtom
CoreMedia
+0x0f42a0
sbufAtom_copyKeyValuePairFromAtom
CoreMedia
+0x0f6274
sbufAtom_copyDictionaryFromAtom
CoreMedia
+0x0f19c4
sbufAtom_createSampleBufferFromSerializedAtomDataAndSurface
CoreMedia
+0x0f2918
FigRemote_CreateSampleBufferFromSerializedAtomDataBlockBuffer
CoreMediaIO
+0x08df78
-[CMIOExtensionSample initWithXPCDictionary:]
CoreMediaIO
+0x061698
-[CMIOExtensionProviderHostContext receivedSample:message:]
CoreMediaIO
+0x060c04
-[CMIOExtensionProviderHostContext handleClientMessageWithConnection:message:]
CoreMediaIO
+0x060744
__64-[CMIOExtensionProviderHostContext initWithConnection:delegate:]_block_invoke
libxpc
+0x00ef70
_xpc_connection_call_event_handler
libxpc
+0x00d6e4
_xpc_connection_mach_event
libdispatch
+0x0044a4
_dispatch_client_callout4
libdispatch
+0x020884
_dispatch_mach_msg_invoke
libdispatch
+0x00b894
_dispatch_lane_serial_drain
libdispatch
+0x0215d4
_dispatch_mach_invoke
libdispatch
+0x00b894
_dispatch_lane_serial_drain
libdispatch
+0x00c574
_dispatch_lane_invoke
libdispatch
+0x0172cc
_dispatch_root_queue_drain_deferred_wlh
libdispatch
+0x016b40
_dispatch_workloop_worker_thread
libsystem_pthread
+0x003008
_pthread_wqthread
libsystem_pthread
+0x001d24
start_wqthread
```
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
I am unable to reproduce this crash. Verified mac-virtualcam still functions properly with these changes in Streamlabs Desktop.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
