### PR TITLE
CI: Gate symbol upload on tags and split it out of the build job

### DIFF
--- a/.github/actions/streamlabs-windows-artifacts/action.yaml
+++ b/.github/actions/streamlabs-windows-artifacts/action.yaml
@@ -44,14 +44,15 @@ runs:
     - name: Collect debug symbols 🪲
       shell: pwsh
       run: |
-        # Qt's host tools and examples never ship, and vc140-vc143.pdb are per-object compiler
-        # pdb's that no binary's debug directory points at. Neither can appear in a crash report,
-        # so keeping them out shrinks both this archive and the work the symbol server job does.
+        # Qt's host tools and examples never ship, vc140-vc143.pdb are per-object compiler pdb's
+        # that no binary's debug directory points at, and foo/boo come from CMake's LTO probe in
+        # CMakeFiles/_CMakeLTOTest-CXX. None can appear in a crash report, so keeping them out
+        # shrinks both this archive and the work the symbol server job does.
         $exclude = @(
           'vc1??.pdb', 'moc.pdb', 'rcc.pdb', 'uic.pdb', 'qlalr.pdb', 'qsb.pdb', 'syncqt.pdb',
           'tracegen.pdb', 'tracepointgen.pdb', 'qvkgen.pdb', 'qtpaths.pdb', 'designer.pdb',
           'cmake_automoc_parser.pdb', 'Qt6ExampleIcons*.pdb', 'Qt6ExamplesAssetDownloader.pdb',
-          'webrtc-testlibs.pdb'
+          'webrtc-testlibs.pdb', 'foo.pdb', 'boo.pdb'
         )
 
         $staging = Join-Path $env:RUNNER_TEMP 'obs-pdbs'

--- a/.github/actions/streamlabs-windows-artifacts/action.yaml
+++ b/.github/actions/streamlabs-windows-artifacts/action.yaml
@@ -1,0 +1,107 @@
+name: Package Streamlabs Windows artifacts
+description: Packs the libobs install tree and this build's debug symbols for the release jobs to pick up
+
+inputs:
+  target:
+    description: "Build target architecture."
+    required: false
+    default: x64
+  packageName:
+    description: "Base name of the published libobs archive."
+    required: false
+    default: libobs
+  osTag:
+    description: "Platform tag used in the published libobs archive name."
+    required: false
+    default: windows64
+  releaseName:
+    description: "Release channel used in the published libobs archive name."
+    required: false
+    default: release
+  retentionDays:
+    description: "How long to keep the intermediate artifacts."
+    required: false
+    default: "7"
+
+runs:
+  using: composite
+  steps:
+    - name: Get the version
+      id: version
+      shell: pwsh
+      run: |
+        $version = "${{ github.ref }}".Replace("refs/tags/", "")
+        "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+    - name: Package OBS lib 🗜️
+      shell: pwsh
+      run: |
+        # obs-studio-node consumes this by name, with install/ as the archive root
+        cd "build_${{ inputs.target }}"
+        7z a -r "../${{ inputs.packageName }}-${{ inputs.osTag }}-${{ inputs.releaseName }}-${{ steps.version.outputs.version }}.7z" install
+        cd ..
+
+    - name: Collect debug symbols 🪲
+      shell: pwsh
+      run: |
+        # Qt's host tools and examples never ship, and vc140-vc143.pdb are per-object compiler
+        # pdb's that no binary's debug directory points at. Neither can appear in a crash report,
+        # so keeping them out shrinks both this archive and the work the symbol server job does.
+        $exclude = @(
+          'vc1??.pdb', 'moc.pdb', 'rcc.pdb', 'uic.pdb', 'qlalr.pdb', 'qsb.pdb', 'syncqt.pdb',
+          'tracegen.pdb', 'tracepointgen.pdb', 'qvkgen.pdb', 'qtpaths.pdb', 'designer.pdb',
+          'cmake_automoc_parser.pdb', 'Qt6ExampleIcons*.pdb', 'Qt6ExamplesAssetDownloader.pdb',
+          'webrtc-testlibs.pdb'
+        )
+
+        $staging = Join-Path $env:RUNNER_TEMP 'obs-pdbs'
+        Remove-Item -LiteralPath $staging -Recurse -Force -ErrorAction SilentlyContinue
+        New-Item -ItemType Directory -Path $staging -Force | Out-Null
+
+        $kept = 0
+        $skipped = 0
+
+        # The relative layout is preserved so the symbol server job can still report which pdb's
+        # share a file name when it flattens them
+        foreach ($searchPath in @("build_${{ inputs.target }}", '.deps')) {
+          if (-Not (Test-Path -LiteralPath $searchPath)) { continue }
+          $root = (Resolve-Path -LiteralPath $searchPath).Path
+
+          foreach ($pdb in (Get-ChildItem -LiteralPath $searchPath -Filter *.pdb -Recurse -File -ErrorAction SilentlyContinue)) {
+            $drop = $false
+            foreach ($pattern in $exclude) {
+              if ($pdb.Name -like $pattern) { $drop = $true; break }
+            }
+            if ($drop) { $skipped++; continue }
+
+            $relative = $pdb.FullName.Substring($root.Length).TrimStart('\')
+            $destination = Join-Path (Join-Path $staging $searchPath) $relative
+            New-Item -ItemType Directory -Path (Split-Path -Parent $destination) -Force | Out-Null
+            Copy-Item -LiteralPath $pdb.FullName -Destination $destination -Force
+            $kept++
+          }
+        }
+
+        $megabytes = [math]::Round((Get-ChildItem -LiteralPath $staging -Recurse -File | Measure-Object Length -Sum).Sum / 1MB)
+        Write-Host "Collected $kept pdb's ($megabytes MB), skipped $skipped that can never be looked up"
+
+        # -mx1 keeps this to a minute or two; pdb's compress well even at the fastest setting
+        7z a -mx1 -mmt=on "$env:GITHUB_WORKSPACE\obs-pdbs.7z" "$staging\*"
+
+    - name: Upload libobs archive 📡
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      with:
+        name: streamlabs-libobs-${{ inputs.osTag }}
+        path: ${{ github.workspace }}/${{ inputs.packageName }}-${{ inputs.osTag }}-${{ inputs.releaseName }}-*.7z
+        compression-level: 0
+        retention-days: ${{ inputs.retentionDays }}
+        if-no-files-found: error
+
+    - name: Upload debug symbols 🪲
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      with:
+        name: streamlabs-pdbs-${{ inputs.osTag }}
+        path: ${{ github.workspace }}/obs-pdbs.7z
+        compression-level: 0
+        retention-days: ${{ inputs.retentionDays }}
+        if-no-files-found: error

--- a/.github/actions/streamlabs-windows-artifacts/action.yaml
+++ b/.github/actions/streamlabs-windows-artifacts/action.yaml
@@ -39,6 +39,7 @@ runs:
         # obs-studio-node consumes this by name, with install/ as the archive root
         cd "build_${{ inputs.target }}"
         7z a -r "../${{ inputs.packageName }}-${{ inputs.osTag }}-${{ inputs.releaseName }}-${{ steps.version.outputs.version }}.7z" install
+        if ($LASTEXITCODE -ne 0) { throw "7z failed with exit code $LASTEXITCODE" }
         cd ..
 
     - name: Collect debug symbols 🪲
@@ -88,6 +89,7 @@ runs:
 
         # -mx1 keeps this to a minute or two; pdb's compress well even at the fastest setting
         7z a -mx1 -mmt=on "$env:GITHUB_WORKSPACE\obs-pdbs.7z" "$staging\*"
+        if ($LASTEXITCODE -ne 0) { throw "7z failed with exit code $LASTEXITCODE" }
 
     - name: Upload libobs archive 📡
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/.github/actions/upload-debug-symbols/action.yaml
+++ b/.github/actions/upload-debug-symbols/action.yaml
@@ -39,6 +39,10 @@ inputs:
     description: "Verbose symbol scripts and aws --debug."
     required: false
     default: "false"
+  symsrvRef:
+    description: "Ref of symsrv-scripts to run. Empty uses its default branch."
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -49,6 +53,7 @@ runs:
       with:
         fetch-depth: 2
         repository: ${{ inputs.repoUserId }}/symsrv-scripts
+        ref: ${{ inputs.symsrvRef }}
         path: symsrv-scripts
 
     - name: Run symbol server scripts

--- a/.github/actions/upload-debug-symbols/action.yaml
+++ b/.github/actions/upload-debug-symbols/action.yaml
@@ -49,7 +49,7 @@ runs:
   steps:
     - name: Fetch symsrv-scripts
       if: runner.os != 'macOS'
-      uses: actions/checkout@v3
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       with:
         fetch-depth: 2
         repository: ${{ inputs.repoUserId }}/symsrv-scripts

--- a/.github/actions/upload-debug-symbols/action.yaml
+++ b/.github/actions/upload-debug-symbols/action.yaml
@@ -1,3 +1,6 @@
+name: Upload debug symbols
+description: Indexes pdb's against their source and uploads them to the Streamlabs symbol server
+
 inputs:
   githubWorkspace:
     description: "GitHub workspace path."
@@ -24,6 +27,18 @@ inputs:
   sentryAuthToken:
     description: "Auth token used for Sentry symbol uploads."
     required: false
+  pdbPaths:
+    description: "Comma separated folders to search for pdb's. Defaults to the whole workspace."
+    required: false
+    default: ""
+  forceUpload:
+    description: "Upload every pdb instead of skipping the ones the symbol store already has."
+    required: false
+    default: "false"
+  symsrvDebug:
+    description: "Verbose symbol scripts and aws --debug."
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -39,10 +54,11 @@ runs:
     - name: Run symbol server scripts
       if: runner.os != 'macOS'
       shell: powershell
-      run: ./symsrv-scripts/main.bat "${{ inputs.githubWorkspace }}/symsrv-scripts" ".\main.ps1 -localSourceDir '${{ inputs.githubWorkspace }}' -repo_userId '${{ inputs.repoUserId }}' -repo_name '${{ inputs.repoName }}' -repo_branch '${{ inputs.repoBranch }}' -subModules 'plugins/mediasoup-connector,stream-labs,mediasoup-connector,streamlabs;plugins/enc-amf,stream-labs,obs-amd-encoder,streamlabs;plugins/motion-effect,stream-labs,motion-effect,master;plugins/obs-browser,stream-labs,obs-browser,streamlabs;plugins/obs-ndi,stream-labs,obs-ndi,streamlabs;plugins/obs-ndi,stream-labs,obs-amd-encoder,streamlabs;plugins/obs-openvr,stream-labs,OBS-OpenVR-Input-Plugin,master;plugins/sl-vst,stream-labs,sl-vst,streamlabs;plugins/slobs-virtual-cam,stream-labs,slobs-virtual-cam,streamlabs;plugins/win-dshow/libdshowcapture,stream-labs,libdshowcapture,streamlabs'"
+      run: ./symsrv-scripts/main.bat "${{ inputs.githubWorkspace }}/symsrv-scripts" ".\main.ps1 -localSourceDir '${{ inputs.githubWorkspace }}' -repo_userId '${{ inputs.repoUserId }}' -repo_name '${{ inputs.repoName }}' -repo_branch '${{ inputs.repoBranch }}'${{ inputs.pdbPaths != '' && format(' -pdbPaths ''{0}''', inputs.pdbPaths) || '' }}${{ fromJSON(inputs.forceUpload) && ' -forceUpload' || '' }} -subModules 'plugins/mediasoup-connector,stream-labs,mediasoup-connector,streamlabs;plugins/enc-amf,stream-labs,obs-amd-encoder,streamlabs;plugins/motion-effect,stream-labs,motion-effect,master;plugins/obs-browser,stream-labs,obs-browser,streamlabs;plugins/obs-ndi,stream-labs,obs-ndi,streamlabs;plugins/obs-ndi,stream-labs,obs-amd-encoder,streamlabs;plugins/obs-openvr,stream-labs,OBS-OpenVR-Input-Plugin,master;plugins/sl-vst,stream-labs,sl-vst,streamlabs;plugins/slobs-virtual-cam,stream-labs,slobs-virtual-cam,streamlabs;plugins/win-dshow/libdshowcapture,stream-labs,libdshowcapture,streamlabs'"
       env:
         AWS_SYMB_ACCESS_KEY_ID: ${{ inputs.awsSymbAccessKeyId }}
         AWS_SYMB_SECRET_ACCESS_KEY: ${{ inputs.awsSymbSecretAccessKey }}
+        SYMSRV_DEBUG: ${{ fromJSON(inputs.symsrvDebug) && '1' || '' }}
 
     - name: Upload debug files to Sentry (macOS only)
       if: runner.os == 'macOS'

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -438,13 +438,6 @@ jobs:
         architecture: [x64]
     runs-on: windows-2022
     needs: check-event
-    env:
-      PACKAGE_NAME: libobs
-      OS_TAG: windows64
-      InstallDir: "install"
-      BuildDir: "build_x64"
-      RELEASE_BUCKET: "obsstudios3.streamlabs.com"
-      ReleaseName: release
     defaults:
       run:
         shell: pwsh
@@ -473,18 +466,6 @@ jobs:
           target: ${{ matrix.architecture }}
           config: ${{ needs.check-event.outputs.config }}
 
-      - name: Symbol Server and Sentry Integration 🪲
-        uses: ./.github/actions/upload-debug-symbols
-        with:
-          githubWorkspace: ${{ github.workspace }}
-          repoUserId: stream-labs
-          repoName: obs-studio
-          repoBranch: ${{ github.sha }}
-          buildConfig: RelWithDebInfo
-          awsSymbAccessKeyId: ${{ secrets.AWS_SYMB_ACCESS_KEY_ID }}
-          awsSymbSecretAccessKey: ${{ secrets.AWS_SYMB_SECRET_ACCESS_KEY }}
-          sentryAuthToken: ${{ secrets.SENTRY_AUTH_TOKEN }}
-
       - name: Package OBS Studio 📀
         if: github.repository == 'obsproject/obs-studio'
         uses: ./.github/actions/package-obs
@@ -500,30 +481,10 @@ jobs:
           name: obs-studio-windows-${{ matrix.architecture }}-${{ needs.check-event.outputs.commitHash }}
           path: ${{ github.workspace }}/build_${{ matrix.architecture }}/obs-studio-*-windows-${{ matrix.architecture }}.zip
 
-      - name: Get the version
-        id: get_version
-        run: |
-          $version = "${{ github.ref }}".Replace("refs/tags/", "")
-          echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-
-      - name: Package OBS lib 🗜️
-        run: |
-          cd ${{ env.BuildDir }}
-          7z a -r ../${{ env.TARGET_ARTIFACT }}.7z ${{ env.InstallDir }}
-          cd ..
-        env:
-          TARGET_ARTIFACT: ${{ env.PACKAGE_NAME }}-${{ env.OS_TAG }}-${{ env.ReleaseName }}-${{ steps.get_version.outputs.VERSION }}
-
-      - name: Configure AWS credentials
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: aws-actions/configure-aws-credentials@v2
+      # Publishing and symbol upload happen in streamlabs-windows-release.yaml, off the artifacts
+      # this produces, so either can be re-run without rebuilding
+      - name: Package Streamlabs artifacts 📦
+        if: github.ref_type == 'tag'
+        uses: ./.github/actions/streamlabs-windows-artifacts
         with:
-          aws-access-key-id: ${{ secrets.AWS_RELEASE_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_RELEASE_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-
-      - name: Deploy
-        if: startsWith(github.ref, 'refs/tags/')
-        run: aws s3 cp ${{ env.TARGET_ARTIFACT }}.7z s3://${{ env.RELEASE_BUCKET }} --acl public-read
-        env:
-          TARGET_ARTIFACT: ${{ env.PACKAGE_NAME }}-${{ env.OS_TAG }}-${{ env.ReleaseName }}-${{ steps.get_version.outputs.VERSION }}
+          target: ${{ matrix.architecture }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -27,6 +27,15 @@ jobs:
     permissions:
       contents: read
 
+  streamlabs-windows-release:
+    name: Streamlabs Windows Release 📦
+    if: github.ref_type == 'tag'
+    needs: build-project
+    uses: ./.github/workflows/streamlabs-windows-release.yaml
+    secrets: inherit
+    permissions:
+      contents: read
+
   compatibility-validation:
     name: Validate Compatibility 🕵️
     if: github.ref_name == 'master'

--- a/.github/workflows/streamlabs-windows-release.yaml
+++ b/.github/workflows/streamlabs-windows-release.yaml
@@ -1,0 +1,93 @@
+name: Streamlabs Windows Release
+on:
+  workflow_call:
+    inputs:
+      symsrvDebug:
+        description: "Verbose symbol scripts and aws --debug."
+        required: false
+        type: boolean
+        default: false
+      forceUpload:
+        description: "Upload every pdb instead of skipping the ones the symbol store already has."
+        required: false
+        type: boolean
+        default: false
+
+# Both jobs run off the artifacts windows-build produced, so neither needs a rebuild and either
+# can be re-run on its own. They do not depend on each other.
+jobs:
+  windows-publish:
+    name: Publish libobs 📦
+    runs-on: windows-2022
+    env:
+      RELEASE_BUCKET: obsstudios3.streamlabs.com
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Download libobs archive 📥
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: streamlabs-libobs-windows64
+          path: ${{ github.workspace }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_RELEASE_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_RELEASE_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+
+      - name: Deploy
+        run: |
+          $archive = Get-ChildItem -LiteralPath $env:GITHUB_WORKSPACE -Filter 'libobs-windows64-release-*.7z' | Select-Object -First 1
+          if (-Not $archive) { throw "No libobs archive in the downloaded artifact" }
+
+          Write-Host "Publishing $($archive.Name) ($([math]::Round($archive.Length / 1MB)) MB)"
+          aws s3 cp $archive.FullName "s3://${{ env.RELEASE_BUCKET }}" --acl public-read
+          if ($LASTEXITCODE -ne 0) { throw "aws s3 cp failed with exit code $LASTEXITCODE" }
+
+  windows-symbols:
+    name: Upload debug symbols 🪲
+    runs-on: windows-2022
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      # Source indexing rewrites the absolute paths baked into each pdb, so the tree has to be
+      # checked out at the same commit and land on the same runner path the build used
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: recursive
+          fetch-depth: 0
+          ref: ${{ github.sha }}
+
+      - name: Download debug symbols 📥
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: streamlabs-pdbs-windows64
+          path: ${{ runner.temp }}
+
+      - name: Unpack debug symbols
+        run: |
+          $target = Join-Path $env:RUNNER_TEMP 'pdbs'
+          New-Item -ItemType Directory -Path $target -Force | Out-Null
+          7z x "$env:RUNNER_TEMP\obs-pdbs.7z" "-o$target" -y
+          if ($LASTEXITCODE -ne 0) { throw "7z extraction failed with exit code $LASTEXITCODE" }
+
+          $count = @(Get-ChildItem -LiteralPath $target -Filter *.pdb -Recurse -File).Count
+          Write-Host "Unpacked $count pdb's"
+          "PDB_PATH=$target" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Symbol Server Integration 🪲
+        uses: ./.github/actions/upload-debug-symbols
+        with:
+          githubWorkspace: ${{ github.workspace }}
+          repoUserId: stream-labs
+          repoName: obs-studio
+          repoBranch: ${{ github.sha }}
+          pdbPaths: ${{ env.PDB_PATH }}
+          forceUpload: ${{ inputs.forceUpload }}
+          symsrvDebug: ${{ inputs.symsrvDebug }}
+          awsSymbAccessKeyId: ${{ secrets.AWS_SYMB_ACCESS_KEY_ID }}
+          awsSymbSecretAccessKey: ${{ secrets.AWS_SYMB_SECRET_ACCESS_KEY }}

--- a/.github/workflows/streamlabs-windows-release.yaml
+++ b/.github/workflows/streamlabs-windows-release.yaml
@@ -12,6 +12,13 @@ on:
         required: false
         type: boolean
         default: false
+      symsrvRef:
+        description: "Ref of symsrv-scripts to run. Empty uses its default branch."
+        required: false
+        type: string
+        # TEMPORARY: revert to "" once streamlabs/symsrv-scripts#3 is merged.
+        # Until then this workflow needs the unreleased -forceUpload and store lookup handling.
+        default: "ci/skip-existing-symbols"
 
 # Both jobs run off the artifacts windows-build produced, so neither needs a rebuild and either
 # can be re-run on its own. They do not depend on each other.

--- a/.github/workflows/streamlabs-windows-release.yaml
+++ b/.github/workflows/streamlabs-windows-release.yaml
@@ -13,12 +13,11 @@ on:
         type: boolean
         default: false
       symsrvRef:
-        description: "Ref of symsrv-scripts to run. Empty uses its default branch."
+        description: "Ref of symsrv-scripts to run."
         required: false
         type: string
-        # TEMPORARY: revert to "" once streamlabs/symsrv-scripts#3 is merged.
-        # Until then this workflow needs the unreleased -forceUpload and store lookup handling.
-        default: "ci/skip-existing-symbols"
+        # Pinned so a push to symsrv-scripts cannot change this build without a PR here
+        default: "v1.1.0"
 
 # Both jobs run off the artifacts windows-build produced, so neither needs a rebuild and either
 # can be re-run on its own. They do not depend on each other.

--- a/.github/workflows/streamlabs-windows-release.yaml
+++ b/.github/workflows/streamlabs-windows-release.yaml
@@ -93,6 +93,7 @@ jobs:
           repoName: obs-studio
           repoBranch: ${{ github.sha }}
           pdbPaths: ${{ env.PDB_PATH }}
+          symsrvRef: ${{ inputs.symsrvRef }}
           forceUpload: ${{ inputs.forceUpload }}
           symsrvDebug: ${{ inputs.symsrvDebug }}
           awsSymbAccessKeyId: ${{ secrets.AWS_SYMB_ACCESS_KEY_ID }}


### PR DESCRIPTION
### Description

`windows-build` now packs the install tree and the pdbs as artifacts on tags, and nothing else. Publishing and symbol upload move to a new `streamlabs-windows-release.yaml` as two independent jobs.

- PR and scheduled builds do no symbol work and no packaging at all
- `Package OBS lib` was ungated and burned 1.5 min on every PR producing a discarded archive named `libobs-windows64-release-refs/pull/744/merge.7z`
- Either release job can be re-run without rebuilding, so an AWS flake costs ~30s instead of 21 min
- Pdb collection skips Qt host tools and examples and the `vc14x` per-object compiler pdbs â€” none ship, so none can appear in a crash report
- The symbol scripts are pinned to a tag via a new `symsrvRef` input, so a push to symsrv-scripts can no longer change this build without a PR here

Published artifact is unchanged: `libobs-windows64-release-<TAG>.7z` on `obsstudios3.streamlabs.com`, `install/` as archive root.

Runs against [symsrv-scripts v1.1.0](https://github.com/streamlabs/symsrv-scripts/releases/tag/v1.1.0) (streamlabs/symsrv-scripts#3), which is what makes the symbol job skip work the store already has. `v1.0.0` is the tag for the previous behaviour if this needs backing out.

### Motivation and Context

The symbol step reached **13.2 min against a 5.3 min build** once libcef shipped debug symbols:

| Run | Branch | Build | Symbol step |
|---|---|---|---|
| 29042765420 | `rno/filter` | 5.5 min | 2.8 min |
| 29871660198 | webrtc m140 | 5.0 min | 4.3 min |
| 30314026129 | `update-cef-windows-x64-v3` | 5.3 min | **13.2 min** |

Symbols are only needed for the tagged builds obs-studio-node consumes. `main.yml` and `main-streamlabs.yml` both gated this on `startsWith(github.ref, 'refs/tags/')`; the condition was not carried over when the step moved into `build-project.yaml` in `8f4935ab5`.

This also shrinks the upmerge surface. Upstream's `windows-build` had a Streamlabs `env:` block plus five steps inserted into the middle of it. It now has one step appended at the end, with everything else in files upstream does not have.

### How Has This Been Tested?

**The PR path is confirmed by this PR's own build** â€” run [30361115015](https://github.com/streamlabs/obs-studio/actions/runs/30361115015), Windows job:

```
success  Build OBS Studio            12:57:13 -> 13:02:12   (4m59s)
skipped  Package OBS Studio
skipped  Upload Artifacts
skipped  Package Streamlabs artifacts
```

**6m01s total, against ~21 min before.** No symbol step, no packaging.

Also checked:

- `actionlint` over the whole `.github` tree: **29 findings before, 26 after, zero new**. The change removes three pre-existing ones.
- Diffed `windows-build` against current upstream: the only Streamlabs insertion mid-job is the pre-existing `Add msbuild to PATH`; the new step is a clean append.
- Pinned artifact actions confirmed compatible (upload v4.6.2 / download v4.3.0, both supporting `compression-level`).
- Pdb collection step run verbatim against a real local build: 161 pdbs / 1359 MB packed to 257 MB in 6.6s, directory layout preserved so the symbol scripts still see and report name collisions.
- Confirmed no caller regressions: `pr-pull` and `scheduled` both skip the new step, and the removed `env:` keys are not referenced outside the macOS job.

**The tag path is confirmed by test tag `32.1.1semsrv1`** — run [30364071177](https://github.com/streamlabs/obs-studio/actions/runs/30364071177):

```
success  Build / Windows (x64)                          7.7 min  (build 4.8 + package 2.0)
success  Streamlabs Windows Release / Upload symbols    2.1 min  (symsrv step itself 0.9)
success  Streamlabs Windows Release / Publish libobs    0.4 min
skipped  Windows Signing / Create Release
```

Symbol step **13.2 min -> 0.9 min**. The store lookup reported `115 indexed, 9 without a usable signature, 99 already stored, 7 to upload`.

- **Re-runnable in isolation**: re-ran `Publish libobs` alone - 25 seconds, no rebuild, object re-uploaded. That is the ~30s-instead-of-21min claim, measured.
- **osn contract intact**: downloaded both archives and diffed full path listings against the last real release `32.1.1sl1` - **2357 paths each, identical**, archive root `install\`.
- **Symbols resolve**: obs-studio-node built against this libobs (tag `0.27.1-semsrv1`) and loaded into a desktop build; Visual Studio resolves stack frames inside libobs from the symbol server.

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [ ] My code has been run through clang-format. â€” n/a, CI configuration only
- [x] I have read the contributing document.
- [x] My code is not on the streamlabs branch.
- [ ] The code has been tested. â€” PR path verified in CI above; the tag path needs a test tag
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
