### PR TITLE
CI: Bump symsrv-scripts to v1.1.1

### DIFF
--- a/.github/workflows/streamlabs-windows-release.yaml
+++ b/.github/workflows/streamlabs-windows-release.yaml
@@ -17,7 +17,7 @@ on:
         required: false
         type: string
         # Pinned so a push to symsrv-scripts cannot change this build without a PR here
-        default: "v1.1.0"
+        default: "v1.1.1"
 
 # Both jobs run off the artifacts windows-build produced, so neither needs a rebuild and either
 # can be re-run on its own. They do not depend on each other.


### PR DESCRIPTION
### Description

`symsrvRef` default `v1.1.0` → `v1.1.1`. One line.

### Motivation and Context

Picks up streamlabs/symsrv-scripts#4 and #5:

- `main.bat` used a drive-relative `cd`, which would run the scripts from the wrong directory on a runner whose workspace is on another drive
- The submodule commit lookup hit `api.github.com` anonymously with no error handling; a rate-limit response aborted the whole symbol upload. It now sends a token and degrades to following the branch instead
- Scratch folders no longer land inside the checkout
- symsrv-scripts now has CI (parse under Windows PowerShell 5.1 + PSScriptAnalyzer)

No interface change — every parameter behaves as in v1.1.0.

### How Has This Been Tested?

Not exercised here yet; the symbols job only runs on tags. v1.1.1 was tested in its own repo (end-to-end run, parse checks, analyzer clean) and the pin mechanism itself was verified on tag `32.1.1semsrv2`, where the log showed `symsrv-scripts` resolving the pinned tag rather than its default branch.

Worth a test tag before the next release if you want it confirmed in place.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [ ] My code has been run through clang-format. — n/a, CI configuration only
- [x] My code is not on the streamlabs branch.
- [ ] The code has been tested. — verified upstream; the tag path here needs a test tag
- [x] All commit messages are properly formatted and commits squashed where appropriate.