### PR TITLE
CI: Bump symsrv-scripts to v1.2.0

### DIFF
--- a/.github/workflows/streamlabs-windows-release.yaml
+++ b/.github/workflows/streamlabs-windows-release.yaml
@@ -17,7 +17,7 @@ on:
         required: false
         type: string
         # Pinned so a push to symsrv-scripts cannot change this build without a PR here
-        default: "v1.1.1"
+        default: "v1.2.0"
 
 # Both jobs run off the artifacts windows-build produced, so neither needs a rebuild and either
 # can be re-run on its own. They do not depend on each other.


### PR DESCRIPTION
Picks up [symsrv-scripts#6](https://github.com/streamlabs/symsrv-scripts/pull/6) (tagged `v1.2.0`).

## Why

`symstore /compress` hands its cabinet writer a single output name. Once a pdb is big enough that the output spans more than one cabinet, every cabinet in the set is written to that same name — only the last one survives on disk.

`libcef.dll.pdb` is 1.7 GB and hit exactly that after #744 added the CEF debug-symbols dist. What reached the bucket under `symbols/libcef.dll.pdb/A94A105081261FCD4C4C44205044422E1/libcef.dll.pd_` was cabinet 1 of a set (`cfhdrPREV_CABINET`, `iCabinet=1`, `szCabinetPrev` pointing at its own filename). It downloads fine and then fails to expand with `ERROR_NOT_SUPPORTED`, so Visual Studio downloads 60 MB and then asks for the pdb again — which is what we were seeing.

The old guard in `main.ps1` only asserted that *at least one* `.pd_` existed, and a spanned set passes that.

I checked every other shipped binary — 57 store entries are healthy single cabinets, `libcef.dll.pdb` was the only broken one.

## What v1.2.0 does

Pdb's over 1 GB skip the `/compress` pass, get stored uncompressed so symstore still works out the key, then are compressed in place with `makecab` and `MaxDiskSize=0` — one cabinet. The store key is unchanged, so nothing here or in the bucket layout moves.

Every `.pd_` is verified before upload (cabinet magic, declared size vs real size, spanned-set flags) and the run fails rather than publishing one no client can use.

Verified against the real `libcef.dll.pdb`: 314 MiB single cabinet, `expand` round-trip byte-identical (sha256 `14C0A0BA…B5EB`). Full evidence in symsrv-scripts#6.

## Note

The broken `libcef.dll.pd_` key has already been deleted from the bucket, so `Get-PresentSymbolKeys` will see it missing and re-upload on this run — no `forceUpload` needed. Expect the libcef entry to come back at ~314 MB instead of the previous (unusable) 60 MB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
