### PR TITLE
fix: safe Windows recording opens

### DIFF
--- a/libobs/util/buffered-file-serializer.c
+++ b/libobs/util/buffered-file-serializer.c
@@ -332,7 +332,7 @@ bool buffered_file_serializer_init(struct serializer *s, const char *path, size_
 
 	dstr_init_copy(&out->filename, path);
 
-	out->io.output_file = os_fopen(path, "wb");
+	out->io.output_file = os_fopen_write_nofollow(path);
 	if (!out->io.output_file) {
 		dstr_free(&out->filename);
 		bfree(out);

--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -1565,7 +1565,7 @@ FILE *os_fopen_write_nofollow(const char *path)
 	for (size_t attempt = 0; attempt < 3; attempt++) {
 		DWORD error;
 
-		handle = CreateFileW(absolute, GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_EXISTING,
+		handle = CreateFileW(absolute, GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_DELETE, NULL, OPEN_EXISTING,
 				     FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, NULL);
 		if (handle != INVALID_HANDLE_VALUE)
 			break;
@@ -1576,7 +1576,7 @@ FILE *os_fopen_write_nofollow(const char *path)
 			goto cleanup;
 		}
 
-		handle = CreateFileW(absolute, GENERIC_WRITE, FILE_SHARE_READ, NULL, CREATE_NEW,
+		handle = CreateFileW(absolute, GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_DELETE, NULL, CREATE_NEW,
 				     FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, NULL);
 		if (handle != INVALID_HANDLE_VALUE)
 			break;
@@ -1603,8 +1603,8 @@ FILE *os_fopen_write_nofollow(const char *path)
 			goto cleanup;
 		}
 		CloseHandle(handle);
-		handle = CreateFileW(absolute, GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL,
-				     NULL);
+		handle = CreateFileW(absolute, GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_DELETE, NULL, OPEN_EXISTING,
+				     FILE_ATTRIBUTE_NORMAL, NULL);
 		if (handle == INVALID_HANDLE_VALUE) {
 			set_errno_from_win32(GetLastError());
 			goto cleanup;

--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -22,6 +22,8 @@
 #include <psapi.h>
 #include <math.h>
 #include <rpc.h>
+#include <fcntl.h>
+#include <io.h>
 
 #include "base.h"
 #include "platform.h"
@@ -1369,4 +1371,302 @@ char *os_generate_uuid(void)
 		    uuid.Data4[6], uuid.Data4[7]);
 
 	return uuid_str.array;
+}
+
+static void set_errno_from_win32(DWORD error)
+{
+	switch (error) {
+	case ERROR_FILE_NOT_FOUND:
+	case ERROR_PATH_NOT_FOUND:
+		errno = ENOENT;
+		break;
+	case ERROR_FILE_EXISTS:
+	case ERROR_ALREADY_EXISTS:
+		errno = EEXIST;
+		break;
+	case ERROR_INVALID_NAME:
+	case ERROR_BAD_PATHNAME:
+		errno = EINVAL;
+		break;
+	default:
+		errno = EACCES;
+		break;
+	}
+}
+
+static size_t get_path_root_length(const wchar_t *path)
+{
+	const size_t length = wcslen(path);
+	const wchar_t *first;
+	const wchar_t *second;
+
+	if (length >= 3 && path[1] == L':' && path[2] == L'\\')
+		return 3;
+
+	if (length < 5 || path[0] != L'\\' || path[1] != L'\\')
+		return 0;
+
+	if (path[2] == L'?' && path[3] == L'\\') {
+		if (length >= 7 && path[5] == L':' && path[6] == L'\\')
+			return 7;
+		if (length < 9 || _wcsnicmp(path + 4, L"UNC\\", 4) != 0)
+			return 0;
+		first = wcschr(path + 8, L'\\');
+	} else {
+		if (path[2] == L'.' && path[3] == L'\\')
+			return 0;
+		first = wcschr(path + 2, L'\\');
+	}
+
+	if (!first || !first[1])
+		return 0;
+	second = wcschr(first + 1, L'\\');
+	return second ? (size_t)(second - path + 1) : wcslen(path);
+}
+
+static wchar_t *get_absolute_path(const wchar_t *path)
+{
+	DWORD size;
+	DWORD length;
+	wchar_t *absolute;
+
+	if (!path || !*path)
+		return NULL;
+
+	size = GetFullPathNameW(path, 0, NULL, NULL);
+	if (!size)
+		return NULL;
+
+	absolute = bmalloc((size_t)size * sizeof(*absolute));
+	length = GetFullPathNameW(path, size, absolute, NULL);
+	if (!length || length >= size) {
+		bfree(absolute);
+		return NULL;
+	}
+
+	for (DWORD i = 0; i < length; i++) {
+		if (absolute[i] == L'/')
+			absolute[i] = L'\\';
+	}
+
+	if (!get_path_root_length(absolute)) {
+		bfree(absolute);
+		return NULL;
+	}
+
+	return absolute;
+}
+
+static void close_handles(HANDLE *handles, size_t count)
+{
+	while (count)
+		CloseHandle(handles[--count]);
+	bfree(handles);
+}
+
+static bool is_safe_path_handle(HANDLE handle, bool require_directory, bool *is_reparse)
+{
+	FILE_ATTRIBUTE_TAG_INFO info;
+
+	if (!GetFileInformationByHandleEx(handle, FileAttributeTagInfo, &info, sizeof(info)))
+		return false;
+	const bool reparse = (info.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0;
+	if (is_reparse)
+		*is_reparse = reparse;
+	/* Cloud placeholders are reparse points but not name surrogates. */
+	if (reparse && IsReparseTagNameSurrogate(info.ReparseTag))
+		return false;
+	return !require_directory || (info.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
+}
+
+static bool lock_safe_components(wchar_t *path, bool include_final, HANDLE **handles_out, size_t *count_out)
+{
+	const size_t length = wcslen(path);
+	const size_t root_length = get_path_root_length(path);
+	HANDLE *handles = bmalloc((length + 1) * sizeof(*handles));
+	size_t count = 0;
+	size_t component = root_length;
+
+	while (component < length) {
+		size_t end;
+		bool final;
+		wchar_t saved;
+		HANDLE handle;
+
+		while (component < length && path[component] == L'\\')
+			component++;
+		if (component == length)
+			break;
+
+		end = component;
+		while (end < length && path[end] != L'\\')
+			end++;
+		final = end == length;
+		if (final && !include_final)
+			break;
+
+		saved = path[end];
+		path[end] = 0;
+		/* Denying write/delete sharing prevents rename or reparse mutation until the final handle is secured. */
+		handle = CreateFileW(path, 0, FILE_SHARE_READ, NULL, OPEN_EXISTING,
+				     FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT, NULL);
+		path[end] = saved;
+
+		if (handle == INVALID_HANDLE_VALUE) {
+			DWORD error = GetLastError();
+			close_handles(handles, count);
+			set_errno_from_win32(error);
+			return false;
+		}
+
+		if (!is_safe_path_handle(handle, !final || include_final, NULL)) {
+			CloseHandle(handle);
+			close_handles(handles, count);
+			errno = EACCES;
+			return false;
+		}
+
+		handles[count++] = handle;
+		component = end + 1;
+	}
+
+	*handles_out = handles;
+	*count_out = count;
+	return true;
+}
+
+FILE *os_fopen_write_nofollow(const char *path)
+{
+	wchar_t *wide_path = NULL;
+	wchar_t *absolute = NULL;
+	HANDLE *parent_handles = NULL;
+	size_t parent_count = 0;
+	HANDLE handle = INVALID_HANDLE_VALUE;
+	FILE *file = NULL;
+	bool reparse = false;
+	BY_HANDLE_FILE_INFORMATION reparse_info;
+
+	if (!path || !*path) {
+		errno = EINVAL;
+		return NULL;
+	}
+
+	os_utf8_to_wcs_ptr(path, 0, &wide_path);
+	absolute = get_absolute_path(wide_path);
+	bfree(wide_path);
+	if (!absolute) {
+		errno = EINVAL;
+		return NULL;
+	}
+
+	if (!lock_safe_components(absolute, false, &parent_handles, &parent_count))
+		goto cleanup;
+
+	for (size_t attempt = 0; attempt < 3; attempt++) {
+		DWORD error;
+
+		handle = CreateFileW(absolute, GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_EXISTING,
+				     FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, NULL);
+		if (handle != INVALID_HANDLE_VALUE)
+			break;
+
+		error = GetLastError();
+		if (error != ERROR_FILE_NOT_FOUND && error != ERROR_PATH_NOT_FOUND) {
+			set_errno_from_win32(error);
+			goto cleanup;
+		}
+
+		handle = CreateFileW(absolute, GENERIC_WRITE, FILE_SHARE_READ, NULL, CREATE_NEW,
+				     FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, NULL);
+		if (handle != INVALID_HANDLE_VALUE)
+			break;
+		error = GetLastError();
+		if (error != ERROR_FILE_EXISTS && error != ERROR_ALREADY_EXISTS) {
+			set_errno_from_win32(error);
+			goto cleanup;
+		}
+	}
+
+	if (handle == INVALID_HANDLE_VALUE) {
+		errno = EACCES;
+		goto cleanup;
+	}
+
+	if (!is_safe_path_handle(handle, false, &reparse)) {
+		errno = EACCES;
+		goto cleanup;
+	}
+
+	if (reparse) {
+		if (!GetFileInformationByHandle(handle, &reparse_info)) {
+			set_errno_from_win32(GetLastError());
+			goto cleanup;
+		}
+		CloseHandle(handle);
+		handle = CreateFileW(absolute, GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL,
+				     NULL);
+		if (handle == INVALID_HANDLE_VALUE) {
+			set_errno_from_win32(GetLastError());
+			goto cleanup;
+		}
+
+		BY_HANDLE_FILE_INFORMATION data_info;
+		if (!GetFileInformationByHandle(handle, &data_info)) {
+			set_errno_from_win32(GetLastError());
+			goto cleanup;
+		}
+		if (data_info.dwVolumeSerialNumber != reparse_info.dwVolumeSerialNumber ||
+		    data_info.nFileIndexHigh != reparse_info.nFileIndexHigh ||
+		    data_info.nFileIndexLow != reparse_info.nFileIndexLow) {
+			errno = EACCES;
+			goto cleanup;
+		}
+	}
+
+	LARGE_INTEGER zero = {0};
+	if (!SetFilePointerEx(handle, zero, NULL, FILE_BEGIN) || !SetEndOfFile(handle)) {
+		set_errno_from_win32(GetLastError());
+		goto cleanup;
+	}
+
+	int fd = _open_osfhandle((intptr_t)handle, _O_WRONLY | _O_BINARY | _O_NOINHERIT);
+	if (fd == -1)
+		goto cleanup;
+	handle = INVALID_HANDLE_VALUE;
+	file = _fdopen(fd, "wb");
+	if (!file)
+		_close(fd);
+
+cleanup:
+	if (handle != INVALID_HANDLE_VALUE)
+		CloseHandle(handle);
+	close_handles(parent_handles, parent_count);
+	bfree(absolute);
+	return file;
+}
+
+bool os_is_path_safe(const char *path)
+{
+	wchar_t *wide_path = NULL;
+	wchar_t *absolute = NULL;
+	HANDLE *handles = NULL;
+	size_t count = 0;
+	bool safe = false;
+
+	if (!path || !*path)
+		return false;
+
+	os_utf8_to_wcs_ptr(path, 0, &wide_path);
+	absolute = get_absolute_path(wide_path);
+	bfree(wide_path);
+	if (!absolute)
+		return false;
+
+	while (wcslen(absolute) > get_path_root_length(absolute) && absolute[wcslen(absolute) - 1] == L'\\')
+		absolute[wcslen(absolute) - 1] = 0;
+
+	safe = lock_safe_components(absolute, true, &handles, &count);
+	close_handles(handles, count);
+	bfree(absolute);
+	return safe;
 }

--- a/libobs/util/platform.c
+++ b/libobs/util/platform.c
@@ -70,6 +70,18 @@ FILE *os_fopen(const char *path, const char *mode)
 #endif
 }
 
+#ifndef _WIN32
+FILE *os_fopen_write_nofollow(const char *path)
+{
+	return os_fopen(path, "wb");
+}
+
+bool os_is_path_safe(const char *path)
+{
+	return path && *path;
+}
+#endif
+
 int64_t os_fgetsize(FILE *file)
 {
 	int64_t cur_offset = os_ftelli64(file);

--- a/libobs/util/platform.h
+++ b/libobs/util/platform.h
@@ -32,6 +32,10 @@ extern "C" {
 
 EXPORT FILE *os_wfopen(const wchar_t *path, const char *mode);
 EXPORT FILE *os_fopen(const char *path, const char *mode);
+/* Opens a file for binary writing without following Windows name-surrogate reparse points. */
+EXPORT FILE *os_fopen_write_nofollow(const char *path);
+/* Best-effort preflight; write-time enforcement is os_fopen_write_nofollow. */
+EXPORT bool os_is_path_safe(const char *path);
 EXPORT int64_t os_fgetsize(FILE *file);
 
 #ifdef _WIN32

--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -1003,7 +1003,7 @@ static inline int open_output_file(struct ffmpeg_mux *ffm)
 			// stalls when recording.
 
 			// We're in charge of managing the actual file now
-			ffm->io.output_file = os_fopen(ffm->params.file, "wb");
+			ffm->io.output_file = os_fopen_write_nofollow(ffm->params.file);
 			if (!ffm->io.output_file) {
 				fprintf(stderr, "Couldn't open '%s', %s\n", ffm->params.printable_file.array,
 					strerror(errno));

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -18,10 +18,6 @@
 #include "obs-ffmpeg-mux.h"
 #include "obs-ffmpeg-formats.h"
 
-#ifdef _WIN32
-#include "util/windows/win-version.h"
-#endif
-
 #include <libavformat/avformat.h>
 
 #define do_log(level, format, ...) \
@@ -319,25 +315,6 @@ void start_pipe(struct ffmpeg_muxer *stream, const char *path)
 	os_process_args_destroy(args);
 }
 
-static void set_file_not_readable_error(struct ffmpeg_muxer *stream, obs_data_t *settings, const char *path)
-{
-	struct dstr error_message;
-	dstr_init_copy(&error_message, obs_module_text("UnableToWritePath"));
-#ifdef _WIN32
-	/* special warning for Windows 10 users about Defender */
-	struct win_version_info ver;
-	get_win_ver(&ver);
-	if (ver.major >= 10) {
-		dstr_cat(&error_message, "\n\n");
-		dstr_cat(&error_message, obs_module_text("WarnWindowsDefender"));
-	}
-#endif
-	dstr_replace(&error_message, "%1", path);
-	obs_output_set_last_error(stream->output, error_message.array);
-	dstr_free(&error_message);
-	obs_data_release(settings);
-}
-
 inline static void ts_offset_clear(struct ffmpeg_muxer *stream)
 {
 	stream->found_video = false;
@@ -404,7 +381,6 @@ static inline bool ffmpeg_mux_start_internal(struct ffmpeg_muxer *stream, obs_da
 		path = obs_service_get_connect_info(service, OBS_SERVICE_CONNECT_INFO_SERVER_URL);
 		stream->split_file = false;
 	} else {
-
 		stream->max_time = obs_data_get_int(settings, "max_time_sec") * 1000000LL;
 		stream->max_size = obs_data_get_int(settings, "max_size_mb") * (1024 * 1024);
 		stream->split_file = obs_data_get_bool(settings, "split_file");
@@ -414,22 +390,6 @@ static inline bool ffmpeg_mux_start_internal(struct ffmpeg_muxer *stream, obs_da
 	}
 
 	ts_offset_clear(stream);
-
-	if (!stream->is_network) {
-		/* ensure output path is writable to avoid generic error
-		 * message.
-		 *
-		 * TODO: remove once ffmpeg-mux is refactored to pass
-		 * errors back */
-		FILE *test_file = os_fopen(path, "wb");
-		if (!test_file) {
-			set_file_not_readable_error(stream, settings, path);
-			return false;
-		}
-
-		fclose(test_file);
-		os_unlink(path);
-	}
 
 	start_pipe(stream, path);
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -381,12 +381,13 @@ static inline bool init_streams(struct ffmpeg_data *data)
 	return true;
 }
 
+#ifdef _WIN32
 static int file_write_packet(void *opaque, const uint8_t *buffer, int size)
 {
 	FILE *file = opaque;
 	size_t written = fwrite(buffer, 1, (size_t)size, file);
 
-	if (!written && ferror(file))
+	if (written != (size_t)size)
 		return AVERROR(errno ? errno : EIO);
 	return (int)written;
 }
@@ -411,28 +412,20 @@ static bool is_native_file_path(const char *url)
 	const char *protocol = avio_find_protocol_name(url);
 	if ((protocol && strcmp(protocol, "file") == 0) || astrcmpi_n(url, "file:", 5) == 0)
 		return true;
-
-#ifdef _WIN32
 	const bool drive_path = ((url[0] >= 'A' && url[0] <= 'Z') || (url[0] >= 'a' && url[0] <= 'z')) &&
 				url[1] == ':';
 	const bool unc_path = (url[0] == '\\' && url[1] == '\\') || (url[0] == '/' && url[1] == '/');
 	return drive_path || unc_path;
-#else
-	return false;
-#endif
 }
 
 static const char *get_native_file_path(const char *url)
 {
 	const char *path = astrcmpi_n(url, "file:", 5) == 0 ? url + 5 : url;
-
-#ifdef _WIN32
 	/* Convert file:/C:/... and file:///C:/... to native drive paths. */
 	if (path[0] == '/' && path[1] && path[2] == ':')
 		path++;
 	else if (path[0] == '/' && path[1] == '/' && path[2] == '/' && path[3] && path[4] == ':')
 		path += 3;
-#endif
 	return path;
 }
 
@@ -465,6 +458,7 @@ static int open_native_output_file(struct ffmpeg_data *data)
 	data->output->flags |= AVFMT_FLAG_CUSTOM_IO;
 	return 0;
 }
+#endif
 
 static inline bool open_output_file(struct ffmpeg_data *data)
 {
@@ -492,9 +486,11 @@ static inline bool open_output_file(struct ffmpeg_data *data)
 	}
 
 	if ((format->flags & AVFMT_NOFILE) == 0) {
+#ifdef _WIN32
 		if (is_native_file_path(data->config.url))
 			ret = open_native_output_file(data);
 		else
+#endif
 			ret = avio_open2(&data->output->pb, data->config.url, AVIO_FLAG_WRITE, NULL, &dict);
 		if (ret < 0) {
 			ffmpeg_log_error(LOG_WARNING, data, "Couldn't open '%s', %s", data->config.url,

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -27,6 +27,7 @@
 #include "obs-ffmpeg-compat.h"
 #include <libavutil/channel_layout.h>
 #include <libavutil/mastering_display_metadata.h>
+#include <errno.h>
 
 /* ------------------------------------------------------------------------- */
 
@@ -380,6 +381,91 @@ static inline bool init_streams(struct ffmpeg_data *data)
 	return true;
 }
 
+static int file_write_packet(void *opaque, const uint8_t *buffer, int size)
+{
+	FILE *file = opaque;
+	size_t written = fwrite(buffer, 1, (size_t)size, file);
+
+	if (!written && ferror(file))
+		return AVERROR(errno ? errno : EIO);
+	return (int)written;
+}
+
+static int64_t file_seek(void *opaque, int64_t offset, int whence)
+{
+	FILE *file = opaque;
+
+	if (whence & AVSEEK_SIZE)
+		return os_fgetsize(file);
+
+	whence &= ~AVSEEK_FORCE;
+	if (whence != SEEK_SET && whence != SEEK_CUR && whence != SEEK_END)
+		return AVERROR(EINVAL);
+	if (os_fseeki64(file, offset, whence) != 0)
+		return AVERROR(errno ? errno : EIO);
+	return os_ftelli64(file);
+}
+
+static bool is_native_file_path(const char *url)
+{
+	const char *protocol = avio_find_protocol_name(url);
+	if ((protocol && strcmp(protocol, "file") == 0) || astrcmpi_n(url, "file:", 5) == 0)
+		return true;
+
+#ifdef _WIN32
+	const bool drive_path = ((url[0] >= 'A' && url[0] <= 'Z') || (url[0] >= 'a' && url[0] <= 'z')) &&
+				url[1] == ':';
+	const bool unc_path = (url[0] == '\\' && url[1] == '\\') || (url[0] == '/' && url[1] == '/');
+	return drive_path || unc_path;
+#else
+	return false;
+#endif
+}
+
+static const char *get_native_file_path(const char *url)
+{
+	const char *path = astrcmpi_n(url, "file:", 5) == 0 ? url + 5 : url;
+
+#ifdef _WIN32
+	/* Convert file:/C:/... and file:///C:/... to native drive paths. */
+	if (path[0] == '/' && path[1] && path[2] == ':')
+		path++;
+	else if (path[0] == '/' && path[1] == '/' && path[2] == '/' && path[3] && path[4] == ':')
+		path += 3;
+#endif
+	return path;
+}
+
+static int open_native_output_file(struct ffmpeg_data *data)
+{
+	const int buffer_size = 32768;
+	uint8_t *buffer;
+
+	data->output_file = os_fopen_write_nofollow(get_native_file_path(data->config.url));
+	if (!data->output_file)
+		return AVERROR(errno ? errno : EIO);
+
+	buffer = av_malloc(buffer_size);
+	if (!buffer) {
+		fclose(data->output_file);
+		data->output_file = NULL;
+		return AVERROR(ENOMEM);
+	}
+
+	data->output->pb = avio_alloc_context(buffer, buffer_size, 1, data->output_file, NULL, file_write_packet,
+					     file_seek);
+	if (!data->output->pb) {
+		av_free(buffer);
+		fclose(data->output_file);
+		data->output_file = NULL;
+		return AVERROR(ENOMEM);
+	}
+
+	data->custom_io = true;
+	data->output->flags |= AVFMT_FLAG_CUSTOM_IO;
+	return 0;
+}
+
 static inline bool open_output_file(struct ffmpeg_data *data)
 {
 	const AVOutputFormat *format = data->output->oformat;
@@ -406,7 +492,10 @@ static inline bool open_output_file(struct ffmpeg_data *data)
 	}
 
 	if ((format->flags & AVFMT_NOFILE) == 0) {
-		ret = avio_open2(&data->output->pb, data->config.url, AVIO_FLAG_WRITE, NULL, &dict);
+		if (is_native_file_path(data->config.url))
+			ret = open_native_output_file(data);
+		else
+			ret = avio_open2(&data->output->pb, data->config.url, AVIO_FLAG_WRITE, NULL, &dict);
 		if (ret < 0) {
 			ffmpeg_log_error(LOG_WARNING, data, "Couldn't open '%s', %s", data->config.url,
 					 av_err2str(ret));
@@ -479,8 +568,16 @@ void ffmpeg_data_free(struct ffmpeg_data *data)
 	}
 
 	if (data->output) {
-		if ((data->output->oformat->flags & AVFMT_NOFILE) == 0)
-			avio_close(data->output->pb);
+		if ((data->output->oformat->flags & AVFMT_NOFILE) == 0) {
+			if (data->custom_io) {
+				avio_flush(data->output->pb);
+				av_freep(&data->output->pb->buffer);
+				avio_context_free(&data->output->pb);
+				fclose(data->output_file);
+			} else {
+				avio_close(data->output->pb);
+			}
+		}
 
 		avformat_free_context(data->output);
 	}

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -395,16 +395,21 @@ static int file_write_packet(void *opaque, const uint8_t *buffer, int size)
 static int64_t file_seek(void *opaque, int64_t offset, int whence)
 {
 	FILE *file = opaque;
+	int64_t result;
 
-	if (whence & AVSEEK_SIZE)
-		return os_fgetsize(file);
+	if (whence & AVSEEK_SIZE) {
+		result = os_fgetsize(file);
+		return result < 0 ? AVERROR(errno ? errno : EIO) : result;
+	}
 
 	whence &= ~AVSEEK_FORCE;
 	if (whence != SEEK_SET && whence != SEEK_CUR && whence != SEEK_END)
 		return AVERROR(EINVAL);
 	if (os_fseeki64(file, offset, whence) != 0)
 		return AVERROR(errno ? errno : EIO);
-	return os_ftelli64(file);
+
+	result = os_ftelli64(file);
+	return result < 0 ? AVERROR(errno ? errno : EIO) : result;
 }
 
 static bool is_native_file_path(const char *url)
@@ -412,8 +417,7 @@ static bool is_native_file_path(const char *url)
 	const char *protocol = avio_find_protocol_name(url);
 	if ((protocol && strcmp(protocol, "file") == 0) || astrcmpi_n(url, "file:", 5) == 0)
 		return true;
-	const bool drive_path = ((url[0] >= 'A' && url[0] <= 'Z') || (url[0] >= 'a' && url[0] <= 'z')) &&
-				url[1] == ':';
+	const bool drive_path = ((url[0] >= 'A' && url[0] <= 'Z') || (url[0] >= 'a' && url[0] <= 'z')) && url[1] == ':';
 	const bool unc_path = (url[0] == '\\' && url[1] == '\\') || (url[0] == '/' && url[1] == '/');
 	return drive_path || unc_path;
 }
@@ -445,8 +449,8 @@ static int open_native_output_file(struct ffmpeg_data *data)
 		return AVERROR(ENOMEM);
 	}
 
-	data->output->pb = avio_alloc_context(buffer, buffer_size, 1, data->output_file, NULL, file_write_packet,
-					     file_seek);
+	data->output->pb =
+		avio_alloc_context(buffer, buffer_size, 1, data->output_file, NULL, file_write_packet, file_seek);
 	if (!data->output->pb) {
 		av_free(buffer);
 		fclose(data->output_file);

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdio.h>
 #include <libavutil/opt.h>
 #include <libavutil/pixdesc.h>
 #include <libavcodec/avcodec.h>
@@ -62,6 +63,7 @@ struct ffmpeg_data {
 	const AVCodec *acodec;
 	const AVCodec *vcodec;
 	AVFormatContext *output;
+	FILE *output_file;
 	struct SwsContext *swscale;
 
 	int64_t total_frames;
@@ -86,6 +88,7 @@ struct ffmpeg_data {
 	struct ffmpeg_cfg config;
 
 	bool initialized;
+	bool custom_io;
 
 	char *last_error;
 };

--- a/plugins/obs-outputs/flv-output.c
+++ b/plugins/obs-outputs/flv-output.c
@@ -483,7 +483,7 @@ static bool flv_output_start(void *data)
 	dstr_copy(&stream->path, path);
 	obs_data_release(settings);
 
-	stream->file = os_fopen(stream->path.array, "wb");
+	stream->file = os_fopen_write_nofollow(stream->path.array);
 	if (!stream->file) {
 		warn("Unable to open FLV file '%s'", stream->path.array);
 		return false;

--- a/test/cmocka/test_os_path.c
+++ b/test/cmocka/test_os_path.c
@@ -1,12 +1,15 @@
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>
+#include <string.h>
+#include <wchar.h>
 #include <cmocka.h>
 
 #include <util/platform.h>
 
 #ifdef _WIN32
 #include <windows.h>
+#include <winioctl.h>
 #endif
 
 struct testcase {
@@ -48,12 +51,62 @@ static void os_get_path_extension_test(void **state)
 }
 
 #ifdef _WIN32
+struct test_mount_point_reparse_buffer {
+	DWORD tag;
+	WORD data_length;
+	WORD reserved;
+	WORD substitute_offset;
+	WORD substitute_length;
+	WORD print_offset;
+	WORD print_length;
+	wchar_t path[1];
+};
+
 static bool create_test_symlink(const wchar_t *link, const wchar_t *target, DWORD flags)
 {
 	if (CreateSymbolicLinkW(link, target, flags | SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE))
 		return true;
 
 	return GetLastError() == ERROR_INVALID_PARAMETER && CreateSymbolicLinkW(link, target, flags);
+}
+
+static bool create_test_junction(const wchar_t *link, const wchar_t *target)
+{
+	BYTE buffer[MAXIMUM_REPARSE_DATA_BUFFER_SIZE] = {0};
+	struct test_mount_point_reparse_buffer *data = (struct test_mount_point_reparse_buffer *)buffer;
+	wchar_t substitute[MAX_PATH + 4];
+	DWORD bytes;
+	bool success;
+
+	if (swprintf_s(substitute, MAX_PATH + 4, L"\\??\\%ls", target) < 0 || !CreateDirectoryW(link, NULL))
+		return false;
+
+	HANDLE dir = CreateFileW(link, GENERIC_WRITE, 0, NULL, OPEN_EXISTING,
+				 FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS, NULL);
+	if (dir == INVALID_HANDLE_VALUE) {
+		RemoveDirectoryW(link);
+		return false;
+	}
+
+	const USHORT substitute_bytes = (USHORT)(wcslen(substitute) * sizeof(wchar_t));
+	const USHORT target_bytes = (USHORT)(wcslen(target) * sizeof(wchar_t));
+	const DWORD header_size = FIELD_OFFSET(struct test_mount_point_reparse_buffer, substitute_offset);
+	data->tag = IO_REPARSE_TAG_MOUNT_POINT;
+	data->substitute_offset = 0;
+	data->substitute_length = substitute_bytes;
+	data->print_offset = substitute_bytes + sizeof(wchar_t);
+	data->print_length = target_bytes;
+	memcpy(data->path, substitute, substitute_bytes + sizeof(wchar_t));
+	memcpy((BYTE *)data->path + data->print_offset, target, target_bytes + sizeof(wchar_t));
+	data->data_length = (USHORT)(FIELD_OFFSET(struct test_mount_point_reparse_buffer, path) - header_size +
+					 substitute_bytes + target_bytes + 2 * sizeof(wchar_t));
+
+	success = DeviceIoControl(dir, FSCTL_SET_REPARSE_POINT, data, data->data_length + header_size, NULL, 0, &bytes,
+				  NULL);
+	CloseHandle(dir);
+	if (!success)
+		RemoveDirectoryW(link);
+	return success;
 }
 
 static void os_fopen_write_nofollow_test(void **state)
@@ -64,10 +117,12 @@ static void os_fopen_write_nofollow_test(void **state)
 	wchar_t root[MAX_PATH];
 	wchar_t target_dir[MAX_PATH];
 	wchar_t linked_dir[MAX_PATH];
+	wchar_t junction_dir[MAX_PATH];
 	wchar_t target_file[MAX_PATH];
 	wchar_t normal_file[MAX_PATH];
 	wchar_t linked_file[MAX_PATH];
 	wchar_t child_file[MAX_PATH];
+	wchar_t junction_child[MAX_PATH];
 	char utf8_path[MAX_PATH * 4];
 	DWORD written;
 
@@ -78,10 +133,12 @@ static void os_fopen_write_nofollow_test(void **state)
 
 	swprintf_s(target_dir, MAX_PATH, L"%ls\\target", root);
 	swprintf_s(linked_dir, MAX_PATH, L"%ls\\linked-dir", root);
+	swprintf_s(junction_dir, MAX_PATH, L"%ls\\junction-dir", root);
 	swprintf_s(target_file, MAX_PATH, L"%ls\\target.bin", root);
 	swprintf_s(normal_file, MAX_PATH, L"%ls\\normal.bin", root);
 	swprintf_s(linked_file, MAX_PATH, L"%ls\\linked.bin", root);
 	swprintf_s(child_file, MAX_PATH, L"%ls\\child.bin", linked_dir);
+	swprintf_s(junction_child, MAX_PATH, L"%ls\\child.bin", junction_dir);
 	assert_true(CreateDirectoryW(target_dir, NULL));
 
 	HANDLE target = CreateFileW(target_file, GENERIC_WRITE, 0, NULL, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, NULL);
@@ -95,11 +152,18 @@ static void os_fopen_write_nofollow_test(void **state)
 	assert_true(fwrite("data", 1, 4, normal) == 4);
 	assert_int_equal(fclose(normal), 0);
 
+	assert_true(create_test_junction(junction_dir, target_dir));
+	assert_true(os_wcs_to_utf8(junction_child, 0, utf8_path, sizeof(utf8_path)) > 0);
+	assert_null(os_fopen_write_nofollow(utf8_path));
+	assert_true(os_wcs_to_utf8(junction_dir, 0, utf8_path, sizeof(utf8_path)) > 0);
+	assert_false(os_is_path_safe(utf8_path));
+
 	if (!create_test_symlink(linked_file, target_file, 0) ||
 	    !create_test_symlink(linked_dir, target_dir, SYMBOLIC_LINK_FLAG_DIRECTORY)) {
 		printf("Skipping nofollow symlink assertions: error %lu\n", GetLastError());
 		DeleteFileW(linked_file);
 		RemoveDirectoryW(linked_dir);
+		RemoveDirectoryW(junction_dir);
 		DeleteFileW(normal_file);
 		DeleteFileW(target_file);
 		RemoveDirectoryW(target_dir);
@@ -121,6 +185,7 @@ static void os_fopen_write_nofollow_test(void **state)
 
 	assert_true(DeleteFileW(linked_file));
 	assert_true(RemoveDirectoryW(linked_dir));
+	assert_true(RemoveDirectoryW(junction_dir));
 	assert_true(DeleteFileW(normal_file));
 	assert_true(DeleteFileW(target_file));
 	assert_true(RemoveDirectoryW(target_dir));

--- a/test/cmocka/test_os_path.c
+++ b/test/cmocka/test_os_path.c
@@ -99,7 +99,7 @@ static bool create_test_junction(const wchar_t *link, const wchar_t *target)
 	memcpy(data->path, substitute, substitute_bytes + sizeof(wchar_t));
 	memcpy((BYTE *)data->path + data->print_offset, target, target_bytes + sizeof(wchar_t));
 	data->data_length = (USHORT)(FIELD_OFFSET(struct test_mount_point_reparse_buffer, path) - header_size +
-					 substitute_bytes + target_bytes + 2 * sizeof(wchar_t));
+				     substitute_bytes + target_bytes + 2 * sizeof(wchar_t));
 
 	success = DeviceIoControl(dir, FSCTL_SET_REPARSE_POINT, data, data->data_length + header_size, NULL, 0, &bytes,
 				  NULL);

--- a/test/cmocka/test_os_path.c
+++ b/test/cmocka/test_os_path.c
@@ -5,6 +5,10 @@
 
 #include <util/platform.h>
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 struct testcase {
 	const char *path;
 	const char *ext;
@@ -43,10 +47,94 @@ static void os_get_path_extension_test(void **state)
 	run_testcases(testcases);
 }
 
+#ifdef _WIN32
+static bool create_test_symlink(const wchar_t *link, const wchar_t *target, DWORD flags)
+{
+	if (CreateSymbolicLinkW(link, target, flags | SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE))
+		return true;
+
+	return GetLastError() == ERROR_INVALID_PARAMETER && CreateSymbolicLinkW(link, target, flags);
+}
+
+static void os_fopen_write_nofollow_test(void **state)
+{
+	UNUSED_PARAMETER(state);
+
+	wchar_t temp_path[MAX_PATH];
+	wchar_t root[MAX_PATH];
+	wchar_t target_dir[MAX_PATH];
+	wchar_t linked_dir[MAX_PATH];
+	wchar_t target_file[MAX_PATH];
+	wchar_t normal_file[MAX_PATH];
+	wchar_t linked_file[MAX_PATH];
+	wchar_t child_file[MAX_PATH];
+	char utf8_path[MAX_PATH * 4];
+	DWORD written;
+
+	assert_true(GetTempPathW(MAX_PATH, temp_path) > 0);
+	assert_true(GetTempFileNameW(temp_path, L"obs", 0, root) > 0);
+	assert_true(DeleteFileW(root));
+	assert_true(CreateDirectoryW(root, NULL));
+
+	swprintf_s(target_dir, MAX_PATH, L"%ls\\target", root);
+	swprintf_s(linked_dir, MAX_PATH, L"%ls\\linked-dir", root);
+	swprintf_s(target_file, MAX_PATH, L"%ls\\target.bin", root);
+	swprintf_s(normal_file, MAX_PATH, L"%ls\\normal.bin", root);
+	swprintf_s(linked_file, MAX_PATH, L"%ls\\linked.bin", root);
+	swprintf_s(child_file, MAX_PATH, L"%ls\\child.bin", linked_dir);
+	assert_true(CreateDirectoryW(target_dir, NULL));
+
+	HANDLE target = CreateFileW(target_file, GENERIC_WRITE, 0, NULL, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, NULL);
+	assert_true(target != INVALID_HANDLE_VALUE);
+	assert_true(WriteFile(target, "safe", 4, &written, NULL));
+	CloseHandle(target);
+
+	assert_true(os_wcs_to_utf8(normal_file, 0, utf8_path, sizeof(utf8_path)) > 0);
+	FILE *normal = os_fopen_write_nofollow(utf8_path);
+	assert_non_null(normal);
+	assert_true(fwrite("data", 1, 4, normal) == 4);
+	assert_int_equal(fclose(normal), 0);
+
+	if (!create_test_symlink(linked_file, target_file, 0) ||
+	    !create_test_symlink(linked_dir, target_dir, SYMBOLIC_LINK_FLAG_DIRECTORY)) {
+		printf("Skipping nofollow symlink assertions: error %lu\n", GetLastError());
+		DeleteFileW(linked_file);
+		RemoveDirectoryW(linked_dir);
+		DeleteFileW(normal_file);
+		DeleteFileW(target_file);
+		RemoveDirectoryW(target_dir);
+		RemoveDirectoryW(root);
+		return;
+	}
+
+	assert_true(os_wcs_to_utf8(linked_file, 0, utf8_path, sizeof(utf8_path)) > 0);
+	assert_null(os_fopen_write_nofollow(utf8_path));
+	assert_true(os_wcs_to_utf8(child_file, 0, utf8_path, sizeof(utf8_path)) > 0);
+	assert_null(os_fopen_write_nofollow(utf8_path));
+	assert_true(os_wcs_to_utf8(linked_dir, 0, utf8_path, sizeof(utf8_path)) > 0);
+	assert_false(os_is_path_safe(utf8_path));
+
+	target = CreateFileW(target_file, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, NULL);
+	assert_true(target != INVALID_HANDLE_VALUE);
+	assert_int_equal(GetFileSize(target, NULL), 4);
+	CloseHandle(target);
+
+	assert_true(DeleteFileW(linked_file));
+	assert_true(RemoveDirectoryW(linked_dir));
+	assert_true(DeleteFileW(normal_file));
+	assert_true(DeleteFileW(target_file));
+	assert_true(RemoveDirectoryW(target_dir));
+	assert_true(RemoveDirectoryW(root));
+}
+#endif
+
 int main()
 {
 	const struct CMUnitTest tests[] = {
 		cmocka_unit_test(os_get_path_extension_test),
+#ifdef _WIN32
+		cmocka_unit_test(os_fopen_write_nofollow_test),
+#endif
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
## Summary
stop Windows recording outputs from following NTFS name-surrogate reparse points (symlinks/junctions).

- Add `os_fopen_write_nofollow` / `os_is_path_safe` (cloud placeholders allowed; surrogates rejected)
- Remove ffmpeg-mux placeholder create/delete/reopen
- Cover mux, FLV, buffered serializer, direct FFmpeg file output
- Windows cmocka regression tests

## Test plan
- [ ] cmocka `test_os_path` (symlink asserts need privilege; soft-skips otherwise)
- [ ] Manual SetOpLock PoC  
- [ ] Record/replay to normal path + OneDrive path
