### PR TITLE
Update obs-deps to 2025-08-23sl4 (FFmpeg 7.1.5, CVE-2026-8461)

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -27,28 +27,28 @@
         "obsproject.com/obs-studio": {
           "dependencies": {
               "prebuilt": {
-                  "version": "2025-08-23sl2",
+                  "version": "2025-08-23sl3",
                   "baseUrl": "https://github.com/streamlabs/obs-deps/releases/download",
                   "label": "Pre-Built obs-deps",
                   "hashes": {
-                      "macos-universal": "ebd61b5c58532297d06e642a9d9bc5245253f4fbf329d40cf9c555e17242883e",
-                      "windows-x64": "9fb82e7b9b80a14a6268b9579b18e06d086209d9a6e2ffd0ad21264ad8ba74ae",
-                      "windows-x86": "f0ff46acf6ef70e789af84ca9ecbb907a98776ea81841689182753fbecec4dff",
-                      "windows-arm64": "0143a51714f372b161f5fca4f2deed858527e06da35fb9a5ce987f09123e95ff"
+                      "macos-universal": "df735eddc685a11d2a563d820a05e8ed85bea39e2957d3aeed2b8c7e8d331004",
+                      "windows-x64": "38c263a9603954993a497eed255e87795eb3f60837e7bed10fe803fb70d11fc8",
+                      "windows-x86": "893840dfe6c5364bdb3d982b2873720d256eda2626eda65b75cc90effaa8d0c3",
+                      "windows-arm64": "d0a197dbd47dd117ed5db6370fb010b8e9b718f7b7fa0c47bd297997a067d521"
                   }
               },
               "qt6": {
-                  "version": "2025-08-23sl2",
+                  "version": "2025-08-23sl3",
                   "baseUrl": "https://github.com/streamlabs/obs-deps/releases/download",
                   "label": "Pre-Built Qt6",
                   "hashes": {
-                      "macos-universal": "9c4520ec4847f9cd33e6d7b6b9cc8e2e91bcd325803a1449e1ff78c3c197682c",
-                      "windows-x64": "1268f591d53d0d52b7a9a27591a0af74c17500277e4a17261b47cd664cf7cd1f",
-                      "windows-arm64": "20de25f7e48105b4de1adb739486b95b9d5cc9c3d9e7bb534227af7a6cb5e7b5"
+                      "macos-universal": "c0cd80342d6087b0f01ec079e6e8184fee2179d7ef16fbb99e5d63f82627d7d0",
+                      "windows-x64": "3745009ebc782a53acc940f4b340c31aba695f706344d1742712d4f89b96bf6f",
+                      "windows-arm64": "aad6f3ce801278b47377fae3bae0215e2bbe3264e6bab683e994a85679eaf02d"
                   },
                   "debugSymbols": {
-                      "windows-x64": "75e8423f42e088815754edc52d932f360f5ad2e68ab392c03fbda7fe87b2a727",
-                      "windows-arm64": "9e5d737c34fe05f446ecfe0a31047552f2295781fbb4cdcdcd2f61d132ad0e31"
+                      "windows-x64": "f81d47820065c6b7a3b711fc9e3ff0f0d43472fcba213e939e49c95317303447",
+                      "windows-arm64": "391cb3a2751144e6c0996d73bbb179105666e073487f859c2a29e2a39f3b81f0"
                   }
               },
               "cef": {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -27,28 +27,28 @@
         "obsproject.com/obs-studio": {
           "dependencies": {
               "prebuilt": {
-                  "version": "2025-08-23sl3",
+                  "version": "2025-08-23sl4",
                   "baseUrl": "https://github.com/streamlabs/obs-deps/releases/download",
                   "label": "Pre-Built obs-deps",
                   "hashes": {
-                      "macos-universal": "df735eddc685a11d2a563d820a05e8ed85bea39e2957d3aeed2b8c7e8d331004",
-                      "windows-x64": "38c263a9603954993a497eed255e87795eb3f60837e7bed10fe803fb70d11fc8",
-                      "windows-x86": "893840dfe6c5364bdb3d982b2873720d256eda2626eda65b75cc90effaa8d0c3",
-                      "windows-arm64": "d0a197dbd47dd117ed5db6370fb010b8e9b718f7b7fa0c47bd297997a067d521"
+                      "macos-universal": "829b26c1c35b0a70648dcde8ac6d5b0405e2b781dc14b2100c2df52281b948ec",
+                      "windows-x64": "fa14699662e2b321718cff43025c6457f19c3af009de57269f53d4eb71f6d481",
+                      "windows-x86": "df43ced1577163eb5989145e289bd5387ba2f19740ee72239232c7d4dfcef2d6",
+                      "windows-arm64": "2f03a2c6b7bdb4c0006ee64725f2109981a8b92b5af73e325809bd27dc42388a"
                   }
               },
               "qt6": {
-                  "version": "2025-08-23sl3",
+                  "version": "2025-08-23sl4",
                   "baseUrl": "https://github.com/streamlabs/obs-deps/releases/download",
                   "label": "Pre-Built Qt6",
                   "hashes": {
-                      "macos-universal": "c0cd80342d6087b0f01ec079e6e8184fee2179d7ef16fbb99e5d63f82627d7d0",
-                      "windows-x64": "3745009ebc782a53acc940f4b340c31aba695f706344d1742712d4f89b96bf6f",
-                      "windows-arm64": "aad6f3ce801278b47377fae3bae0215e2bbe3264e6bab683e994a85679eaf02d"
+                      "macos-universal": "87efaff2bc4e556623ee24e16be6f80628b1b703d7430742625ebebd3966b3dc",
+                      "windows-x64": "451518a3563d928e7fbf491755e873c986a2dc2e7fa48d4eb86331b0ddaeebb4",
+                      "windows-arm64": "555f7a4a283a275d169d387689896d66bb946a94f9d33650be9b7257a78a604f"
                   },
                   "debugSymbols": {
-                      "windows-x64": "f81d47820065c6b7a3b711fc9e3ff0f0d43472fcba213e939e49c95317303447",
-                      "windows-arm64": "391cb3a2751144e6c0996d73bbb179105666e073487f859c2a29e2a39f3b81f0"
+                      "windows-x64": "302426ed051990b2fcf80b939e27bf171b9433023d280e7cc98fd8bf3ce24813",
+                      "windows-arm64": "36a63f8c82989b67b876f8790a9e052688a0317535529e4008501b54bf03c635"
                   }
               },
               "cef": {


### PR DESCRIPTION
Bumps obs-deps to [`2025-08-23sl4`](https://github.com/streamlabs/obs-deps/releases/tag/2025-08-23sl4) (streamlabs/obs-deps#10).

## Why

**CVE-2026-8461 ("PixelSmash")** — heap out-of-bounds write in FFmpeg's MagicYUV decoder, CVSS 8.8. A crafted `slice_height` overflows onto an `AVBuffer` whose `free` function pointer is invoked at frame cleanup. Reachable from any AVI/MKV/MOV input. JFrog lists OBS Studio among confirmed-affected projects.

Confirmed against the shipped product before this work started — `avcodec-61.dll` reported `n7.1.1` and contained both `magicyuv` and `mace6`. Reachable via `shared/media-playback/media-playback/decode.c:165`, which calls `avcodec_find_decoder` with no allowlist: media sources, stinger transitions, `.overlay` theme bundles, and the Highlighter's `ffprobe`/`ffmpeg` passes over user video.

## What changed in the deps

- **FFmpeg 7.1.1 -> 7.1.5.** Upstream backported the fix to `release/7.1`, so 7.1.5 carries it while keeping the `avcodec-61` ABI — no source changes needed here.
- **`magicyuv`, `mace3`, `mace6` decoders disabled.** Unused by OBS. Also closes **CVE-2026-66039** (MACE6 integer overflow), fixed only on FFmpeg master — not in 7.1.x, not in 8.1.2 — so removing the surface is the only way to close it today.
- **Software HEVC decoder disabled on Windows**, restoring policy that held from late 2022 and was silently lost at `2024-05-08sl2` when Windows moved to the native PowerShell build script.
- **`hevc_cuvid` deliberately kept.** It is pure NVDEC and the only standalone HEVC decoder; every other hardware route is a hwaccel that selects `hevc_decoder` and dies with it. Without it, NVIDIA hosts lose HEVC playback entirely.
- **Two obsolete cuvid patches removed.** The crash they guarded against was fixed upstream in `07bcedc23` (FFmpeg 5.1), one release after the 5.0.1 we were building when it was hit.
- **CI guards added** in obs-deps asserting `hevc`/`magicyuv`/`mace*` are absent and `hevc_cuvid` is present, on every build. The HEVC policy had silently regressed four times before this.

## Behaviour change

**HEVC decode now depends on the GPU vendor:**

| Platform | HEVC decode |
|---|---|
| Windows + NVIDIA | works, via NVDEC (`hevc_cuvid`) |
| Windows + AMD / Intel | **none** |
| macOS | **none** (no standalone VideoToolbox HEVC decoder; unchanged since 2023) |

There is no user-facing message when decode is unavailable — the source loads and reports correct dimensions, then renders nothing. Worth knowing for QA: a failure on a non-NVIDIA box is the intended state, not a bug.

Hardware HEVC **encoding** is unaffected. The encoders users select (`obs_nvenc_hevc_tex`, `obs_qsv11_hevc`) come from obs-nvenc and obs-qsv11, which call the vendor SDKs directly — `obs-nvenc` has no avcodec dependency at all.

## Verification

- All nine hashes cross-checked programmatically against the release `CHECKSUMS.txt`.
- The published `windows-deps-2025-08-23sl4-x64.zip` was downloaded and exercised directly on an RTX 3070: `n7.1.5`, software `hevc` absent, `hevc_cuvid` present, and 8-bit HEVC, 10-bit HEVC, HEVC/MKV and HEVC/MOV all decode. `magicyuv.avi` correctly refused; H.264 control unaffected.
- obs-deps release run green, with the guard reporting `absent: hevc, magicyuv, mace3, mace6 | present: hevc_cuvid`.

## Still to do

- [ ] Smoke test a build from these deps: record, playback, stinger transition
- [ ] Confirm HEVC media sources play on NVIDIA and fail gracefully on AMD/Intel

🤖 Generated with [Claude Code](https://claude.com/claude-code)