### PR TITLE
fix: allow write sharing on nofollow recording opens

### DIFF
--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -1535,8 +1535,8 @@ static bool lock_safe_components(wchar_t *path, bool include_final, HANDLE **han
 	return true;
 }
 
-/* Matches what fopen("wb") granted. Safety comes from the reparse checks below, not from denying
- * writers: withholding FILE_SHARE_WRITE only breaks callers that legitimately share a file. */
+/* READ|WRITE is the CRT deny-none mode fopen("wb") used; DELETE is carried over from this API's
+ * original mask. Safety comes from the reparse checks below, not from denying writers. */
 #define WRITE_SHARE_MODE (FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
 
 FILE *os_fopen_write_nofollow(const char *path)

--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -1535,6 +1535,10 @@ static bool lock_safe_components(wchar_t *path, bool include_final, HANDLE **han
 	return true;
 }
 
+/* Matches what fopen("wb") granted. Safety comes from the reparse checks below, not from denying
+ * writers: withholding FILE_SHARE_WRITE only breaks callers that legitimately share a file. */
+#define WRITE_SHARE_MODE (FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+
 FILE *os_fopen_write_nofollow(const char *path)
 {
 	wchar_t *wide_path = NULL;
@@ -1565,7 +1569,7 @@ FILE *os_fopen_write_nofollow(const char *path)
 	for (size_t attempt = 0; attempt < 3; attempt++) {
 		DWORD error;
 
-		handle = CreateFileW(absolute, GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_DELETE, NULL, OPEN_EXISTING,
+		handle = CreateFileW(absolute, GENERIC_WRITE, WRITE_SHARE_MODE, NULL, OPEN_EXISTING,
 				     FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, NULL);
 		if (handle != INVALID_HANDLE_VALUE)
 			break;
@@ -1576,7 +1580,7 @@ FILE *os_fopen_write_nofollow(const char *path)
 			goto cleanup;
 		}
 
-		handle = CreateFileW(absolute, GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_DELETE, NULL, CREATE_NEW,
+		handle = CreateFileW(absolute, GENERIC_WRITE, WRITE_SHARE_MODE, NULL, CREATE_NEW,
 				     FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, NULL);
 		if (handle != INVALID_HANDLE_VALUE)
 			break;
@@ -1603,7 +1607,7 @@ FILE *os_fopen_write_nofollow(const char *path)
 			goto cleanup;
 		}
 		CloseHandle(handle);
-		handle = CreateFileW(absolute, GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_DELETE, NULL, OPEN_EXISTING,
+		handle = CreateFileW(absolute, GENERIC_WRITE, WRITE_SHARE_MODE, NULL, OPEN_EXISTING,
 				     FILE_ATTRIBUTE_NORMAL, NULL);
 		if (handle == INVALID_HANDLE_VALUE) {
 			set_errno_from_win32(GetLastError());

--- a/test/cmocka/test_os_path.c
+++ b/test/cmocka/test_os_path.c
@@ -152,6 +152,14 @@ static void os_fopen_write_nofollow_test(void **state)
 	assert_true(fwrite("data", 1, 4, normal) == 4);
 	assert_int_equal(fclose(normal), 0);
 
+	/* Dual output opens one recording path from two muxers; denying write sharing failed the second. */
+	FILE *first = os_fopen_write_nofollow(utf8_path);
+	assert_non_null(first);
+	FILE *second = os_fopen_write_nofollow(utf8_path);
+	assert_non_null(second);
+	assert_int_equal(fclose(second), 0);
+	assert_int_equal(fclose(first), 0);
+
 	assert_true(create_test_junction(junction_dir, target_dir));
 	assert_true(os_wcs_to_utf8(junction_child, 0, utf8_path, sizeof(utf8_path)) > 0);
 	assert_null(os_fopen_write_nofollow(utf8_path));


### PR DESCRIPTION
## Summary

Fixes a recording regression introduced by #758. `os_fopen_write_nofollow()` requested `GENERIC_WRITE` while granting only `FILE_SHARE_READ | FILE_SHARE_DELETE`. The `os_fopen(path, "wb")` it replaced used the CRT default of deny-none (`FILE_SHARE_READ | FILE_SHARE_WRITE`), so any second writer on the same file went from working to `ERROR_SHARING_VIOLATION`.

It surfaces from ffmpeg-mux as:

```
Couldn't open 'D:\a\...\osnData/2026-08-07 22-22-28.mp4', Permission denied
```

Dual output hits it every time: both muxers derive the same second-resolution filename, the first opens it, and the second dies before emitting a stopping signal — the test harness then reports `expected 'stop' to equal 'stopping'`. Once the muxer wedges, an orphan `obs-ffmpeg-mux` survives and every later suite fails to start OBS, so one root cause produced 27 failures in obs-studio-node CI ([run](https://github.com/streamlabs/obs-studio-node/actions/runs/31220300701/job/93012449630) on the v32.1.1sl3 bump).

The separate question of why two dual-output muxers derive the same filename is an obs-studio-node issue and is being tracked there.

## Why widening the share mask is safe

Denying write sharing was never the mechanism that made the open safe. That is `FILE_FLAG_OPEN_REPARSE_POINT` plus the name-surrogate check in `is_safe_path_handle()`, the volume/file-index comparison on the reparse retry, and the ancestor locks in `lock_safe_components()` — none of which change here. Those ancestor handles still hold `FILE_SHARE_READ` only, which is what blocks rename/reparse mutation while the final handle is being secured.

An attacker who can open the target file for writing can already write to it; the share mask on our handle does not gate that.

## Test plan

- [x] `libobs` builds clean (RelWithDebInfo, warnings-as-errors)
- [x] cmocka `test_os_path` passes, including the junction-rejection assertions (symlink assertions soft-skip without `SeCreateSymbolicLinkPrivilege`)
- [x] New regression assertion in `test_os_path.c`: two concurrent `os_fopen_write_nofollow()` handles on one path both succeed — fails before this change, passes after
- [x] Standalone harness against the built `obs.dll`, before → after:
      `file open by fopen("wb"): FAIL (errno=13)` → `OK`
      sequential / ancestor-locked / 4-thread concurrent cases unaffected (240/240 both ways)
- [ ] obs-studio-node CI green on a libobs bump that includes this
