### PR TITLE
win-capture: say which path component failed the hook trust check, and act only on the directory

### DIFF
--- a/plugins/win-capture/game-capture-file-init.c
+++ b/plugins/win-capture/game-capture-file-init.c
@@ -14,6 +14,46 @@
 /* ------------------------------------------------------------------------- */
 /* helper funcs                                                              */
 
+/* Converted rather than logged through %ls, which goes via the CRT locale and
+ * drops the rest of the line at the first character outside it - a user profile
+ * name is exactly where these paths carry one. */
+static void hook_warn_path(const char *lead, const wchar_t *path)
+{
+	char *path_utf8 = NULL;
+
+	os_wcs_to_utf8_ptr(path, 0, &path_utf8);
+	hook_warn("%s: %s", lead, path_utf8 ? path_utf8 : "?");
+	bfree(path_utf8);
+}
+
+/* Names whichever half of the chain failed, and what was wrong with it. */
+static void hook_warn_trust(const char *lead, const wchar_t *path, const struct hook_trust *trust)
+{
+	char *path_utf8 = NULL;
+	char *why_utf8 = NULL;
+
+	if (trust->object && trust->ancestors)
+		return;
+
+	os_wcs_to_utf8_ptr(path, 0, &path_utf8);
+
+	if (!trust->object) {
+		os_wcs_to_utf8_ptr(trust->object_why, 0, &why_utf8);
+		hook_warn("%s: %s %s", lead, path_utf8 ? path_utf8 : "?", why_utf8 ? why_utf8 : "?");
+	} else {
+		char *ancestor_utf8 = NULL;
+
+		os_wcs_to_utf8_ptr(trust->ancestor, 0, &ancestor_utf8);
+		os_wcs_to_utf8_ptr(trust->ancestor_why, 0, &why_utf8);
+		hook_warn("%s: %s is reached through %s, which %s", lead, path_utf8 ? path_utf8 : "?",
+			  ancestor_utf8 ? ancestor_utf8 : "?", why_utf8 ? why_utf8 : "?");
+		bfree(ancestor_utf8);
+	}
+
+	bfree(path_utf8);
+	bfree(why_utf8);
+}
+
 static bool has_elevation_internal()
 {
 	SID_IDENTIFIER_AUTHORITY sia = SECURITY_NT_AUTHORITY;
@@ -105,11 +145,19 @@ char *get_hook_path(bool b64)
 	/* The whole chain, re-checked rather than relying on what module load
 	 * decided: this is the value we are about to inject into another
 	 * process, and startup was a long time ago. */
-	if (((b64 && programdata64_hook_exists) || (!b64 && programdata32_hook_exists)) &&
-	    hook_path_chain_is_trusted(path)) {
-		char *path_utf8 = NULL;
-		os_wcs_to_utf8_ptr(path, 0, &path_utf8);
-		return path_utf8;
+	if ((b64 && programdata64_hook_exists) || (!b64 && programdata32_hook_exists)) {
+		struct hook_trust trust;
+
+		hook_path_trust(path, &trust);
+
+		if (trust.object) {
+			char *path_utf8 = NULL;
+			os_wcs_to_utf8_ptr(path, 0, &path_utf8);
+			return path_utf8;
+		}
+
+		/* startup accepted it, so something changed since then */
+		hook_warn_trust("falling back to the hook in the install directory", path, &trust);
 	}
 
 	return obs_module_file(b64 ? "graphics-hook64.dll" : "graphics-hook32.dll");
@@ -167,7 +215,10 @@ static bool install_hook_file(const wchar_t *src, const wchar_t *dst)
  *
  * Unsafe is the directory's problem: untrusted, or holding files we cannot
  * vouch for, or gone. The loader hands that directory to every vulkan process
- * on the machine, elevated ones included, so the entry has to go. */
+ * on the machine, elevated ones included, so the entry has to go.
+ *
+ * The path above the directory is neither. It is logged where it is found and
+ * acted on nowhere - see hook_path_trust. */
 enum hook_shared_state {
 	HOOK_SHARED_OK,
 	HOOK_SHARED_UNUSABLE,
@@ -206,11 +257,26 @@ static enum hook_shared_state update_hook_file(bool b64)
 
 		/* We are about to publish these bytes machine-wide, elevated. If
 		 * our own copy sits somewhere a standard user can rewrite, there
-		 * is nothing here worth publishing. */
-		if (!hook_path_chain_is_trusted(src) || !hook_path_is_trusted(src_json)) {
-			hook_warn("the hook in the install directory is modifiable by non-administrators, "
-				  "not publishing it");
+		 * is nothing here worth publishing. The directory holding it, not
+		 * the path to it - a user who can rename a parent of
+		 * %ProgramFiles% can replace the application itself, so refusing
+		 * over one would cost capture and deny them nothing. */
+		struct hook_trust src_trust;
+
+		hook_path_trust(src, &src_trust);
+
+		if (!src_trust.object) {
+			hook_warn_trust("not publishing the hook in the install directory", src, &src_trust);
 			/* our copy, not the shared one - it may be sound */
+			return HOOK_SHARED_UNUSABLE;
+		}
+		if (!src_trust.ancestors)
+			hook_warn_trust("publishing the hook in the install directory despite its path", src,
+					&src_trust);
+		if (!hook_path_is_trusted(src_json)) {
+			hook_warn_path("not publishing the hook in the install directory, its manifest is "
+				       "modifiable by non-administrators",
+				       src_json);
 			return HOOK_SHARED_UNUSABLE;
 		}
 
@@ -218,11 +284,29 @@ static enum hook_shared_state update_hook_file(bool b64)
 		 * only means something if standard users could not have written
 		 * these files. Hardening propagates to children, so afterwards
 		 * the answer would always be yes. */
-		bool dir_was_trusted = dir_exists(dir) && hook_path_chain_is_trusted(dir);
+		struct hook_trust dir_trust;
+		bool dir_present = dir_exists(dir);
+
+		/* also for a path with nothing at it, where it reports that
+		 * there was no security descriptor to read */
+		hook_path_trust(dir, &dir_trust);
+
+		/* The directory itself, not the path to it. An untrusted
+		 * ancestor is not something an elevated writer can repair and
+		 * says nothing about who wrote what is inside, so replacing the
+		 * directory over it would destroy an administrator's hooks for
+		 * nothing. It still stops the shared copy being used, below. */
+		bool dir_was_trusted = dir_present && dir_trust.object;
 		bool was_trusted = dir_was_trusted && hook_path_is_trusted(dst) && hook_path_is_trusted(dst_json);
 
 		if (!dir_was_trusted) {
 			DWORD attributes = GetFileAttributesW(dir);
+
+			if (attributes != INVALID_FILE_ATTRIBUTES && !dir_present)
+				hook_warn_path("replacing the shared hook directory path, which is not a directory",
+					       dir);
+			else if (attributes != INVALID_FILE_ATTRIBUTES)
+				hook_warn_trust("replacing the shared hook directory", dir, &dir_trust);
 
 			if (attributes != INVALID_FILE_ATTRIBUTES && !hook_dir_quarantine(dir)) {
 				hook_warn("failed to move the untrusted hook directory aside: %lu", GetLastError());
@@ -258,8 +342,26 @@ static enum hook_shared_state update_hook_file(bool b64)
 		return HOOK_SHARED_UNSAFE;
 	}
 
-	if (!hook_path_chain_is_trusted(dir) || !hook_path_is_trusted(dst) || !hook_path_is_trusted(dst_json)) {
-		hook_warn("the hook directory or its files are modifiable by non-administrators, ignoring them");
+	struct hook_trust shared_trust;
+
+	hook_path_trust(dir, &shared_trust);
+
+	/* The directory, not the path to it. Withdrawing the layer over an
+	 * ancestor takes vulkan capture away from everything on the machine,
+	 * permanently and invisibly, for a condition no elevated writer can
+	 * repair and that a standard user with that reach does not need. */
+	if (!shared_trust.object) {
+		hook_warn_trust("ignoring the shared hook directory", dir, &shared_trust);
+		return HOOK_SHARED_UNSAFE;
+	}
+	if (!shared_trust.ancestors)
+		hook_warn_trust("using the shared hook directory despite its path", dir, &shared_trust);
+	if (!hook_path_is_trusted(dst)) {
+		hook_warn_path("ignoring the shared hook, it is modifiable by non-administrators", dst);
+		return HOOK_SHARED_UNSAFE;
+	}
+	if (!hook_path_is_trusted(dst_json)) {
+		hook_warn_path("ignoring the shared hook, its manifest is modifiable by non-administrators", dst_json);
 		return HOOK_SHARED_UNSAFE;
 	}
 

--- a/plugins/win-capture/game-capture-file-init.c
+++ b/plugins/win-capture/game-capture-file-init.c
@@ -16,41 +16,62 @@
 
 /* Converted rather than logged through %ls, which goes via the CRT locale and
  * drops the rest of the line at the first character outside it - a user profile
- * name is exactly where these paths carry one. */
-static void hook_warn_path(const char *lead, const wchar_t *path)
+ * name is exactly where these paths carry one. why is optional. */
+static void hook_warn_wide(const char *lead, const wchar_t *path, const wchar_t *why)
 {
 	char *path_utf8 = NULL;
+	char *why_utf8 = NULL;
 
 	os_wcs_to_utf8_ptr(path, 0, &path_utf8);
-	hook_warn("%s: %s", lead, path_utf8 ? path_utf8 : "?");
+	if (why)
+		os_wcs_to_utf8_ptr(why, 0, &why_utf8);
+
+	if (why_utf8)
+		hook_warn("%s: %s %s", lead, path_utf8 ? path_utf8 : "?", why_utf8);
+	else
+		hook_warn("%s: %s", lead, path_utf8 ? path_utf8 : "?");
+
 	bfree(path_utf8);
+	bfree(why_utf8);
+}
+
+/* hook_path_is_trusted, but it says why it refused. The refusal is not always a
+ * write grant - an unreadable descriptor or a reparse point lands here too - so
+ * a caller that phrases it as one is guessing. */
+static bool hook_file_is_trusted(const char *lead, const wchar_t *path)
+{
+	wchar_t why[HOOK_TRUST_REASON_MAX];
+
+	if (hook_object_trust(path, HOOK_WRITE_ACCESS, why, _countof(why)))
+		return true;
+
+	hook_warn_wide(lead, path, why);
+	return false;
 }
 
 /* Names whichever half of the chain failed, and what was wrong with it. */
 static void hook_warn_trust(const char *lead, const wchar_t *path, const struct hook_trust *trust)
 {
 	char *path_utf8 = NULL;
+	char *ancestor_utf8 = NULL;
 	char *why_utf8 = NULL;
 
-	if (trust->object && trust->ancestors)
+	if (!trust->object) {
+		hook_warn_wide(lead, path, trust->object_why);
+		return;
+	}
+	if (trust->ancestors)
 		return;
 
 	os_wcs_to_utf8_ptr(path, 0, &path_utf8);
+	os_wcs_to_utf8_ptr(trust->ancestor, 0, &ancestor_utf8);
+	os_wcs_to_utf8_ptr(trust->ancestor_why, 0, &why_utf8);
 
-	if (!trust->object) {
-		os_wcs_to_utf8_ptr(trust->object_why, 0, &why_utf8);
-		hook_warn("%s: %s %s", lead, path_utf8 ? path_utf8 : "?", why_utf8 ? why_utf8 : "?");
-	} else {
-		char *ancestor_utf8 = NULL;
-
-		os_wcs_to_utf8_ptr(trust->ancestor, 0, &ancestor_utf8);
-		os_wcs_to_utf8_ptr(trust->ancestor_why, 0, &why_utf8);
-		hook_warn("%s: %s is reached through %s, which %s", lead, path_utf8 ? path_utf8 : "?",
-			  ancestor_utf8 ? ancestor_utf8 : "?", why_utf8 ? why_utf8 : "?");
-		bfree(ancestor_utf8);
-	}
+	hook_warn("%s: %s is reached through %s, which %s", lead, path_utf8 ? path_utf8 : "?",
+		  ancestor_utf8 ? ancestor_utf8 : "?", why_utf8 ? why_utf8 : "?");
 
 	bfree(path_utf8);
+	bfree(ancestor_utf8);
 	bfree(why_utf8);
 }
 
@@ -273,12 +294,8 @@ static enum hook_shared_state update_hook_file(bool b64)
 		if (!src_trust.ancestors)
 			hook_warn_trust("publishing the hook in the install directory despite its path", src,
 					&src_trust);
-		if (!hook_path_is_trusted(src_json)) {
-			hook_warn_path("not publishing the hook in the install directory, its manifest is "
-				       "modifiable by non-administrators",
-				       src_json);
+		if (!hook_file_is_trusted("not publishing the hook in the install directory", src_json))
 			return HOOK_SHARED_UNUSABLE;
-		}
 
 		/* Read before we touch anything: the version arbitration below
 		 * only means something if standard users could not have written
@@ -303,8 +320,8 @@ static enum hook_shared_state update_hook_file(bool b64)
 			DWORD attributes = GetFileAttributesW(dir);
 
 			if (attributes != INVALID_FILE_ATTRIBUTES && !dir_present)
-				hook_warn_path("replacing the shared hook directory path, which is not a directory",
-					       dir);
+				hook_warn_wide("replacing the shared hook directory path, which is not a directory",
+					       dir, NULL);
 			else if (attributes != INVALID_FILE_ATTRIBUTES)
 				hook_warn_trust("replacing the shared hook directory", dir, &dir_trust);
 
@@ -356,14 +373,10 @@ static enum hook_shared_state update_hook_file(bool b64)
 	}
 	if (!shared_trust.ancestors)
 		hook_warn_trust("using the shared hook directory despite its path", dir, &shared_trust);
-	if (!hook_path_is_trusted(dst)) {
-		hook_warn_path("ignoring the shared hook, it is modifiable by non-administrators", dst);
+	if (!hook_file_is_trusted("ignoring the shared hook", dst))
 		return HOOK_SHARED_UNSAFE;
-	}
-	if (!hook_path_is_trusted(dst_json)) {
-		hook_warn_path("ignoring the shared hook, its manifest is modifiable by non-administrators", dst_json);
+	if (!hook_file_is_trusted("ignoring the shared hook", dst_json))
 		return HOOK_SHARED_UNSAFE;
-	}
 
 	/* Past this point the shared directory has passed the trust check, so
 	 * nothing below rejects it - it is administrator owned and whatever is

--- a/shared/obs-hook-config/hook-dir-security.h
+++ b/shared/obs-hook-config/hook-dir-security.h
@@ -18,6 +18,7 @@
 #include <windows.h>
 #include <aclapi.h>
 #include <sddl.h>
+#include <stdarg.h>
 #include <stdbool.h>
 #include <strsafe.h>
 
@@ -93,45 +94,99 @@ static inline bool hook_is_reparse_point(const wchar_t *path)
 	return attributes != INVALID_FILE_ATTRIBUTES && (attributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0;
 }
 
-/* Owned by an administrative account, with nobody else holding write_mask. */
-static inline bool hook_object_is_trusted(const wchar_t *path, DWORD write_mask)
+#define HOOK_TRUST_REASON_MAX 160
+#define HOOK_SID_TEXT_MAX 96
+
+/* Reasons are phrased to read after the path: "<path> is owned by
+ * S-1-5-21-...". Working that out from a bare bool cost a round trip through a
+ * crash report once, so every refusal below says which object and why. */
+static inline void hook_trust_why(wchar_t *why, size_t count, const wchar_t *format, ...)
+{
+	va_list args;
+
+	if (!why || count == 0)
+		return;
+
+	va_start(args, format);
+	StringCchVPrintfW(why, count, format, args);
+	va_end(args);
+}
+
+static inline void hook_sid_text(PSID sid, wchar_t *text, size_t count)
+{
+	wchar_t *converted = NULL;
+
+	if (sid && IsValidSid(sid) && ConvertSidToStringSidW(sid, &converted)) {
+		StringCchCopyW(text, count, converted);
+		LocalFree(converted);
+		return;
+	}
+
+	StringCchCopyW(text, count, L"an unreadable SID");
+}
+
+/* Owned by an administrative account, with nobody else holding write_mask.
+ * why is optional, and written only when this returns false. */
+static inline bool hook_object_trust(const wchar_t *path, DWORD write_mask, wchar_t *why, size_t why_count)
 {
 	PSECURITY_DESCRIPTOR sd = NULL;
 	PSID owner = NULL;
 	PACL dacl = NULL;
+	wchar_t sid_text[HOOK_SID_TEXT_MAX];
 	bool trusted = false;
+	DWORD result;
 
 	/* every other check here follows the link */
-	if (hook_is_reparse_point(path))
+	if (hook_is_reparse_point(path)) {
+		hook_trust_why(why, why_count, L"is a reparse point");
 		return false;
+	}
 
-	if (GetNamedSecurityInfoW(path, SE_FILE_OBJECT, OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION, &owner,
-				  NULL, &dacl, NULL, &sd) != ERROR_SUCCESS) {
+	result = GetNamedSecurityInfoW(path, SE_FILE_OBJECT, OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
+				       &owner, NULL, &dacl, NULL, &sd);
+	if (result != ERROR_SUCCESS) {
+		hook_trust_why(why, why_count, L"has no readable security descriptor: %lu", result);
 		return false;
 	}
 
 	/* the owner can always rewrite the DACL, and a NULL DACL grants
 	 * everything to everyone */
-	if (!hook_sid_is_trusted(owner) || !dacl)
+	if (!hook_sid_is_trusted(owner)) {
+		hook_sid_text(owner, sid_text, _countof(sid_text));
+		hook_trust_why(why, why_count, L"is owned by %s", sid_text);
 		goto done;
+	}
+	if (!dacl) {
+		hook_trust_why(why, why_count, L"has no DACL, which grants everything to everyone");
+		goto done;
+	}
 
 	for (WORD i = 0; i < dacl->AceCount; i++) {
 		ACCESS_ALLOWED_ACE *ace = NULL;
 
-		if (!GetAce(dacl, i, (void **)&ace))
+		if (!GetAce(dacl, i, (void **)&ace)) {
+			hook_trust_why(why, why_count, L"has an unreadable ACE at index %u", (unsigned)i);
 			goto done;
+		}
 		if (ace->Header.AceType == ACCESS_DENIED_ACE_TYPE)
 			continue;
-		if (ace->Header.AceType != ACCESS_ALLOWED_ACE_TYPE)
+		if (ace->Header.AceType != ACCESS_ALLOWED_ACE_TYPE) {
+			hook_trust_why(why, why_count, L"has an ACE at index %u of unhandled type %u", (unsigned)i,
+				       (unsigned)ace->Header.AceType);
 			goto done;
+		}
 		/* inherit-only, such as the CREATOR OWNER entry %ProgramData% and
 		 * %ProgramFiles% both carry, grants nothing on this object */
 		if (ace->Header.AceFlags & INHERIT_ONLY_ACE)
 			continue;
 		if ((ace->Mask & write_mask) == 0)
 			continue;
-		if (!hook_sid_is_trusted((PSID)&ace->SidStart))
+		if (!hook_sid_is_trusted((PSID)&ace->SidStart)) {
+			hook_sid_text((PSID)&ace->SidStart, sid_text, _countof(sid_text));
+			hook_trust_why(why, why_count, L"grants %s write access 0x%08lX, out of 0x%08lX", sid_text,
+				       (unsigned long)(ace->Mask & write_mask), (unsigned long)ace->Mask);
 			goto done;
+		}
 	}
 
 	trusted = true;
@@ -141,21 +196,46 @@ done:
 	return trusted;
 }
 
+static inline bool hook_object_is_trusted(const wchar_t *path, DWORD write_mask)
+{
+	return hook_object_trust(path, write_mask, NULL, 0);
+}
+
 static inline bool hook_path_is_trusted(const wchar_t *path)
 {
 	return hook_object_is_trusted(path, HOOK_WRITE_ACCESS);
 }
 
-/* The object plus every directory above it. Locking down a file means nothing
- * if a standard user can rename one of its parents and present a different
- * tree under the same path. */
-static inline bool hook_path_chain_is_trusted(const wchar_t *path)
+/* The object and the path to it, answered separately, because only the object
+ * is acted on. It is the one that says who wrote what is there, and the one an
+ * elevated writer can repair.
+ *
+ * An untrusted ancestor is reported and nothing else. A standard user who can
+ * rename a parent of %ProgramData% or of the install directory already owns the
+ * machine by routes that have nothing to do with us - the application the user
+ * launches sits under one of those parents - so refusing to capture over it
+ * costs them vulkan capture and denies an attacker nothing. Callers log which
+ * component failed and carry on. */
+struct hook_trust {
+	bool object;
+	bool ancestors;
+	wchar_t object_why[HOOK_TRUST_REASON_MAX];
+	wchar_t ancestor[MAX_PATH]; /* the component ancestor_why describes */
+	wchar_t ancestor_why[HOOK_TRUST_REASON_MAX];
+};
+
+static inline void hook_path_trust(const wchar_t *path, struct hook_trust *trust)
 {
 	wchar_t buffer[MAX_PATH];
 	size_t length = wcslen(path);
 
-	if (length == 0 || length >= MAX_PATH)
-		return false;
+	memset(trust, 0, sizeof(*trust));
+
+	if (length == 0 || length >= MAX_PATH) {
+		hook_trust_why(trust->object_why, _countof(trust->object_why),
+			       L"is %u characters, which is not a path this can examine", (unsigned)length);
+		return;
+	}
 
 	memcpy(buffer, path, (length + 1) * sizeof(wchar_t));
 
@@ -173,27 +253,41 @@ static inline bool hook_path_chain_is_trusted(const wchar_t *path)
 	if (buffer[length - 1] == L'\\' && !(length == 3 && buffer[1] == L':'))
 		buffer[length - 1] = 0;
 
-	if (!hook_object_is_trusted(buffer, HOOK_WRITE_ACCESS))
-		return false;
+	trust->object = hook_object_trust(buffer, HOOK_WRITE_ACCESS, trust->object_why, _countof(trust->object_why));
 
 	for (;;) {
 		wchar_t *separator = wcsrchr(buffer, L'\\');
 
 		/* not a drive-letter path, so not one we can reason about */
-		if (!separator)
-			return false;
+		if (!separator) {
+			StringCchCopyW(trust->ancestor, _countof(trust->ancestor), buffer);
+			hook_trust_why(trust->ancestor_why, _countof(trust->ancestor_why),
+				       L"is not under a drive letter, so the path to it cannot be checked");
+			return;
+		}
 
 		if (separator == buffer + 2 && buffer[1] == L':') {
 			separator[1] = 0; /* the root keeps its separator */
-			return hook_object_is_trusted(buffer, HOOK_ANCESTOR_WRITE_ACCESS);
+			trust->ancestors = hook_object_trust(buffer, HOOK_ANCESTOR_WRITE_ACCESS, trust->ancestor_why,
+							     _countof(trust->ancestor_why));
+			if (!trust->ancestors)
+				StringCchCopyW(trust->ancestor, _countof(trust->ancestor), buffer);
+			return;
 		}
 
 		*separator = 0;
 
-		if (!hook_object_is_trusted(buffer, HOOK_ANCESTOR_WRITE_ACCESS))
-			return false;
+		if (!hook_object_trust(buffer, HOOK_ANCESTOR_WRITE_ACCESS, trust->ancestor_why,
+				       _countof(trust->ancestor_why))) {
+			StringCchCopyW(trust->ancestor, _countof(trust->ancestor), buffer);
+			return;
+		}
 	}
 }
+
+/* No chain predicate on purpose. One that folded the ancestors back into a
+ * single bool is what led callers to quarantine a directory, and to decline the
+ * shared hook, over a drive root they could neither vouch for nor repair. */
 
 /* Moves an untrusted hook path aside rather than repairing it in place: an ACL
  * change does not revoke handles opened before it, so the creator could rename


### PR DESCRIPTION
## What

Two changes to the graphics hook trust check, both prompted by the first field report of the updater half of #756 failing.

1. Every trust refusal now says **which** path component was refused and **why**.
2. An untrusted **ancestor** is reported and acted on nowhere. Only the object — the shared hook directory, the payload directory, the files — decides anything.

Pairs with streamlabs/a-files-updater#144, which makes the same two changes there. `hook-dir-security.h` and its copy in the updater are kept in step by hand.

## Why

The report was from the updater, but the cause sits in the rules both sides share. `hook_path_chain_is_trusted()` answers for the object and every directory above it, up to and including the drive root, and returns one bool. On the reporting machine that bool was false, and the log could not say whether the hook directory, `%ProgramData%` or `C:\` had been refused, or on what. Working it out took a machine-local reimplementation of the rules, and the answer is still inference: the two failing checks share exactly one object, `C:\`.

That is fix 1. Fix 2 is what the same investigation turned up here: `dir_was_trusted` at the quarantine, `was_trusted` for the files, and the final gate were all the whole chain, so an ancestor we can neither vouch for nor repair was driving decisions that are only about the directory.

## What it does now

`hook_object_trust()` takes an optional reason buffer; `hook_path_trust()` fills a `struct hook_trust` with the object and the ancestors answered separately, the failing ancestor named, and a reason for each — the owning SID, the granting SID with the rights it holds and the full mask, a reparse point, or the error that stopped the descriptor being read.

Paths are converted with `os_wcs_to_utf8_ptr()` rather than logged through `%ls`. `%ls` in a narrow `printf` converts via the CRT locale and drops the rest of the line at the first character outside it, and a user profile name is exactly where these paths carry one — which would lose the diagnostic for the users hardest to reach remotely.

Behaviour, for an untrusted ancestor only:

| | before | after |
|---|---|---|
| shared hook directory | quarantined and recreated | left alone |
| hooks in it | treated as untrusted, reinstalled | trust judged on their own ACLs |
| install-directory payload | not published | published |
| result | `HOOK_SHARED_UNSAFE` | proceeds; logged |
| implicit vulkan layer | withdrawn | left registered |
| `get_hook_path()` | silent fallback to the install directory | uses the shared hook; a fallback now says why |

Nothing changes when the **object** is untrusted. Same quarantine, same descriptor, same `HOOK_SHARED_UNSAFE`, same layer withdrawal.

`hook_path_chain_is_trusted()` is gone rather than left unused. Folding the two answers back into a single bool is what produced the behaviour above, and leaving the predicate in a shared header is how it comes back.

## The relaxation, stated plainly

The layer is the part worth arguing about, and the argument is what settled it.

`disable_vulkan_layer()` removes the **HKCU** entry unconditionally and the **HKLM** one only when elevated. The app normally is not elevated. So withdrawing over an ancestor removed the per-user entry — which grants no privilege a standard user does not already have, since they can register their own implicit layer in their own hive whenever they like — and left the machine-wide entry, which is the one that reaches elevated processes and the one a standard user cannot create. The cost and the benefit were the wrong way round for the common case.

Against that, the cost is real and permanent: vulkan capture gone for every OBS derived application on the machine, for a condition no elevated writer can repair. Game capture was never affected — `get_hook_path()` falls back to the hook in the install directory — so this was only ever vulkan titles, but it was all of them.

And a standard user who can rename a parent of `%ProgramData%` can rename a parent of `%ProgramFiles%` and replace the application that gets launched. Whatever we decline to do about the hook is not their limiting factor. The same reasoning is why the install-directory payload is held to its own directory now rather than to its whole path.

## Testing

- `win-capture` x64 RelWithDebInfo: builds clean, 0 warnings with `/WX`. Confirmed `TreatWarningAsError` and `WarningLevel` in the generated project first, then forced a full recompile of the translation unit rather than relying on an up-to-date target.
- clang-format 19.1.5 clean on both files. CI pins 19.1.1 — same major, not the same binary.
- **Equivalence, not assumed.** The header was compiled at `streamlabs` and at this revision into two harnesses and their answers diffed across 13 paths: identical on all of them. That covers the separator handling #756 added — a fully forward-slash path, a mixed one, and a trailing separator all still resolve the same way — so the trust computation is unchanged and only the policy differs. The harness also asserts the split agrees with the old combined answer on every path.
- Every reason branch was exercised against live ACLs in the same harness: the granting-ACE branch on `C:\ProgramData` (`grants S-1-5-32-545 write access 0x00000116` — `BUILTIN\Users`, which is why the ancestor mask is weaker than the object one), the owner branch, a reparse point via `C:\Documents and Settings`, a missing path, and a path with no drive letter. `C:\work\temp`'s ancestor failure was correctly attributed to `C:\work`.
- Probing `C:\` as an object reports `grants S-1-5-11 write access 0x00000004` — Authenticated Users with `FILE_APPEND_DATA`, the entry the weaker ancestor mask exists to tolerate. That is the mechanism behind the original report, and it is one inherit-only flag away from failing every path on a machine.
- Not run end to end: reproducing the reported condition needs a machine whose drive root ACL is non-default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
