### PR TITLE
win-capture: do not count DELETE on a volume root against the path

### DIFF
--- a/shared/obs-hook-config/hook-dir-security.h
+++ b/shared/obs-hook-config/hook-dir-security.h
@@ -42,6 +42,18 @@
  * every drive root grants exactly that to Authenticated Users. */
 #define HOOK_ANCESTOR_WRITE_ACCESS (FILE_DELETE_CHILD | DELETE | WRITE_DAC | WRITE_OWNER | GENERIC_ALL)
 
+/* A volume root is the one ancestor DELETE says nothing about: it cannot be
+ * renamed or unlinked, and holding it there confers nothing over what is inside.
+ * Replacing a directory below the root needs FILE_DELETE_CHILD on the root, or
+ * DELETE on that directory itself, and both are still checked.
+ *
+ * Counting it rejected real machines. The default root ACE
+ * (A;OICIIO;GRGWGX+DELETE;;;AU) is inherit-only and carries DELETE, so anything
+ * that materialises it onto the root - icacls /reset, a permissions repair tool,
+ * an imaging step - leaves DELETE granted to Authenticated Users and harmless,
+ * and every path on the machine failing. */
+#define HOOK_ROOT_WRITE_ACCESS (FILE_DELETE_CHILD | WRITE_DAC | WRITE_OWNER | GENERIC_ALL)
+
 static inline bool hook_enable_privilege(const wchar_t *name)
 {
 	TOKEN_PRIVILEGES privileges = {0};
@@ -273,7 +285,7 @@ static inline void hook_path_trust(const wchar_t *path, struct hook_trust *trust
 
 		if (separator == buffer + 2 && buffer[1] == L':') {
 			separator[1] = 0; /* the root keeps its separator */
-			trust->ancestors = hook_object_trust(buffer, HOOK_ANCESTOR_WRITE_ACCESS, trust->ancestor_why,
+			trust->ancestors = hook_object_trust(buffer, HOOK_ROOT_WRITE_ACCESS, trust->ancestor_why,
 							     _countof(trust->ancestor_why));
 			if (!trust->ancestors)
 				StringCchCopyW(trust->ancestor, _countof(trust->ancestor), buffer);


### PR DESCRIPTION
## What

Stops counting `DELETE` on a volume root against the path being checked. Every other ancestor keeps the mask it had, and the root keeps everything except `DELETE`.

```c
#define HOOK_ROOT_WRITE_ACCESS (FILE_DELETE_CHILD | WRITE_DAC | WRITE_OWNER | GENERIC_ALL)
```

One line of behaviour, in the root branch of `hook_path_trust()`.

Pairs with streamlabs/a-files-updater#145, which is the same rule in the copy that lives there. The two are kept in step by hand.

## Why

The evidence came from the updater side, where this rule has its other copy and where a refusal raises a Sentry event rather than only a log line. A report from updater 0.2.45:

```
The hook directory is reached through C:\, which grants S-1-5-11
write access 0x00010000, out of 0x001301BF
```

`S-1-5-11` is Authenticated Users, and `0x001301BF` is exactly the default root entry `(A;OICIIO;GRGWGX+DELETE;;;AU)` with its generic bits mapped and its inherit-only flag gone — what `icacls /reset`, a permissions repair tool, or an imaging step leaves behind. The only bit of it that intersects `HOOK_ANCESTOR_WRITE_ACCESS` is `DELETE`.

`DELETE` on a volume root is inert. A root cannot be renamed or unlinked. Swapping a directory below it needs `FILE_DELETE_CHILD` on the root — **not** in `0x001301BF` — or `DELETE` on that directory itself, which is its own object and still checked. So the machine was refused for a right that grants nothing, and with the root failing, every path on it fails.

`WRITE_DAC` and `WRITE_OWNER` stay: either one lets the holder grant themselves `FILE_DELETE_CHILD`. `FILE_DELETE_CHILD` and `GENERIC_ALL` stay for the obvious reason. Only bare `DELETE` goes, and only on the root.

## Effect here

Smaller than on the updater side. Since #762 an untrusted ancestor is advisory — logged, never acted on — so this does not change what the plugin does with the shared hook. It stops a misleading line being written about a machine that is fine, and it keeps this copy of the rule matching the updater's, which the header asks for.

## Testing

- `win-capture` x64 RelWithDebInfo: builds clean, 0 warnings with `/WX`. clang-format 19.1.5 clean.
- The reported grant was run through both masks in a scratch harness compiled against the real header:
  ```
  reported C:\ grant 0x001301BF (Authenticated Users)
    FILE_DELETE_CHILD granted : NO
    vs ancestor mask          : 0x00010000 -> REFUSED
    vs root mask              : 0x00000000 -> accepted
  ```
- The 13-path chain harness used through this series was re-run against the header before and after: **identical verdicts on all 13**, so nothing that was refused on a default machine is now allowed. The change is only reachable through a root whose ACL has been rewritten.
- Not reproduced end to end: that needs a machine whose drive root carries the materialised entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
